### PR TITLE
XName Properties for OpenXmlElement and OpenXmlAttribute

### DIFF
--- a/Open-XML-SDK.csproj
+++ b/Open-XML-SDK.csproj
@@ -41,6 +41,7 @@
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.XML" />
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Framework/OpenXmlAttribute.cs
+++ b/src/Framework/OpenXmlAttribute.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
+using System.Xml.Linq;
 
 namespace DocumentFormat.OpenXml
 {
@@ -113,6 +114,17 @@ namespace DocumentFormat.OpenXml
             get
             {
                 return new XmlQualifiedName(this._tagName, this._namespaceUri);
+            }
+        }
+
+        /// <summary>
+        /// Gets the qualified name of the current attribute.
+        /// </summary>
+        public XName XName
+        {
+            get
+            {
+                return XName.Get(this._tagName, this._namespaceUri);
             }
         }
 

--- a/src/Framework/OpenXmlElement.cs
+++ b/src/Framework/OpenXmlElement.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.IO;
 using System.Xml;
+using System.Xml.Linq;
 using System.Globalization;
 using System.Diagnostics;
 using DocumentFormat.OpenXml;
@@ -485,6 +486,17 @@ namespace DocumentFormat.OpenXml
             get
             {
                 return new XmlQualifiedName(this.LocalName, this.NamespaceUri);
+            }
+        }
+
+        /// <summary>
+        /// Gets the qualified name of the current element.
+        /// </summary>
+        public virtual XName XName
+        {
+            get
+            {
+                return XName.Get(this.LocalName, this.NamespaceUri);
             }
         }
         

--- a/src/Framework/OpenXmlPackage.cs
+++ b/src/Framework/OpenXmlPackage.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
-// Copyright 2014 Thomas Barnekow (cloning)
+// Copyright 2014 Thomas Barnekow (cloning, Flat OPC (with Eric White))
 using System;
 using System.Diagnostics;
 using System.Collections;
@@ -13,6 +13,8 @@ using System.Runtime.Serialization;
 using System.Globalization;
 using DocumentFormat.OpenXml;
 using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
 
 namespace DocumentFormat.OpenXml.Packaging
 {
@@ -1624,7 +1626,7 @@ namespace DocumentFormat.OpenXml.Packaging
             if (openSettings == null)
                 openSettings = OpenSettings;
 
-            // Save the contents of all parts and relationships that are contained 
+            // Save the contents of all parts and relationships that are contained
             // in the OpenXml package to make sure we clone a consistent state.
             // This will also invoke ThrowIfObjectDisposed(), so we don't need
             // to call it here.
@@ -1711,7 +1713,7 @@ namespace DocumentFormat.OpenXml.Packaging
             // Use this OpenXml package's OpenSettings if none are provided.
             // This is more in line with cloning than providing the default
             // OpenSettings, i.e., unless the caller explicitly specifies
-            // something, we'll later open the clone with this OpenXml 
+            // something, we'll later open the clone with this OpenXml
             // package's OpenSettings.
             if (openSettings == null)
                 openSettings = OpenSettings;
@@ -1823,6 +1825,239 @@ namespace DocumentFormat.OpenXml.Packaging
         #endregion Package-based cloning
 
         #endregion saving and cloning
+
+        #region Flat OPC
+
+        private static readonly XNamespace pkg = "http://schemas.microsoft.com/office/2006/xmlPackage";
+        private static readonly XNamespace rel = "http://schemas.openxmlformats.org/package/2006/relationships";
+
+        /// <summary>
+        /// Converts an OpenXml package in OPC format to string in Flat OPC format.
+        /// </summary>
+        /// <returns>The OpenXml package in Flat OPC format.</returns>
+        public string ToFlatOpcString()
+        {
+            return ToFlatOpcDocument().ToString();
+        }
+
+        /// <summary>
+        /// Converts an OpenXml package in OPC format to an <see cref="XDocument"/>
+        /// in Flat OPC format.
+        /// </summary>
+        /// <returns>The OpenXml package in Flat OPC format.</returns>
+        public abstract XDocument ToFlatOpcDocument();
+
+        /// <summary>
+        /// Converts an OpenXml package in OPC format to an <see cref="XDocument"/>
+        /// in Flat OPC format.
+        /// </summary>
+        /// <param name="instruction">The processing instruction.</param>
+        /// <returns>The OpenXml package in Flat OPC format.</returns>
+        protected XDocument ToFlatOpcDocument(XProcessingInstruction instruction)
+        {
+            // Save the contents of all parts and relationships that are contained
+            // in the OpenXml package to make sure we convert a consistent state.
+            // This will also invoke ThrowIfObjectDisposed(), so we don't need
+            // to call it here.
+            Save();
+
+            // Create an XML document with a standalone declaration, processing
+            // instruction (if not null), and a package root element with a
+            // namespace declaration and one child element for each part.
+            return new XDocument(
+                new XDeclaration("1.0", "UTF-8", "yes"),
+                instruction,
+                new XElement(
+                    pkg + "package",
+                    new XAttribute(XNamespace.Xmlns + "pkg", pkg.ToString()),
+                    Package.GetParts().Select(part => GetContentsAsXml(part))));
+        }
+
+        /// <summary>
+        /// Gets the <see cref="PackagePart"/>'s contents as an <see cref="XElement"/>.
+        /// </summary>
+        /// <param name="part">The package part.</param>
+        /// <returns>The corresponding <see cref="XElement"/>.</returns>
+        private static XElement GetContentsAsXml(PackagePart part)
+        {
+            if (part.ContentType.EndsWith("xml"))
+            {
+                using (Stream stream = part.GetStream())
+                using (StreamReader streamReader = new StreamReader(stream))
+                using (XmlReader xmlReader = XmlReader.Create(streamReader))
+                    return new XElement(pkg + "part",
+                        new XAttribute(pkg + "name", part.Uri),
+                        new XAttribute(pkg + "contentType", part.ContentType),
+                        new XElement(pkg + "xmlData", XElement.Load(xmlReader)));
+            }
+            else
+            {
+                using (Stream stream = part.GetStream())
+                using (BinaryReader binaryReader = new BinaryReader(stream))
+                {
+                    int len = (int)binaryReader.BaseStream.Length;
+                    byte[] byteArray = binaryReader.ReadBytes(len);
+
+                    // The following expression creates the base64String, then chunks
+                    // it to lines of 76 characters long.
+                    string base64String = System.Convert.ToBase64String(byteArray)
+                        .Select((c, i) => new { Character = c, Chunk = i / 76 })
+                        .GroupBy(c => c.Chunk)
+                        .Aggregate(
+                            new StringBuilder(),
+                            (s, i) =>
+                                s.Append(
+                                    i.Aggregate(
+                                        new StringBuilder(),
+                                        (seed, it) => seed.Append(it.Character),
+                                        sb => sb.ToString())).Append(Environment.NewLine),
+                            s => s.ToString());
+
+                    return new XElement(pkg + "part",
+                        new XAttribute(pkg + "name", part.Uri),
+                        new XAttribute(pkg + "contentType", part.ContentType),
+                        new XAttribute(pkg + "compression", "store"),
+                        new XElement(pkg + "binaryData", base64String));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Converts an <see cref="XDocument"/> in Flat OPC format to an OpenXml package
+        /// stored on a <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="document">The document in Flat OPC format.</param>
+        /// <param name="stream">The <see cref="Stream"/> on which to store the OpenXml package.</param>
+        /// <returns>The <see cref="Stream"/> containing the OpenXml package.</returns>
+        protected static Stream FromFlatOpcDocumentCore(XDocument document, Stream stream)
+        {
+            using (Package package = Package.Open(stream, FileMode.Create, FileAccess.ReadWrite))
+            {
+                FromFlatOpcDocumentCore(document, package);
+            }
+            return stream;
+        }
+
+        /// <summary>
+        /// Converts an <see cref="XDocument"/> in Flat OPC format to an OpenXml package
+        /// stored in a file.
+        /// </summary>
+        /// <param name="document">The document in Flat OPC format.</param>
+        /// <param name="path">The path and file name of the file in which to store the OpenXml package.</param>
+        /// <returns>The path and file name of the file containing the OpenXml package.</returns>
+        protected static string FromFlatOpcDocumentCore(XDocument document, string path)
+        {
+            using (Package package = Package.Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
+            {
+                FromFlatOpcDocumentCore(document, package);
+            }
+            return path;
+        }
+
+        /// <summary>
+        /// Converts an <see cref="XDocument"/> in Flat OPC format to an OpenXml package
+        /// stored in a <see cref="Package"/>.
+        /// </summary>
+        /// <param name="document">The document in Flat OPC format.</param>
+        /// <param name="package">The <see cref="Package"/> in which to store the OpenXml package.</param>
+        /// <returns>The <see cref="Package"/> containing the OpenXml package.</returns>
+        protected static Package FromFlatOpcDocumentCore(XDocument document, Package package)
+        {
+            // Add all parts (but not relationships).
+            foreach (var xmlPart in document.Root
+                .Elements()
+                .Where(p =>
+                    (string)p.Attribute(pkg + "contentType") !=
+                        "application/vnd.openxmlformats-package.relationships+xml"))
+            {
+                string name = (string)xmlPart.Attribute(pkg + "name");
+                string contentType = (string)xmlPart.Attribute(pkg + "contentType");
+                if (contentType.EndsWith("xml"))
+                {
+                    Uri uri = new Uri(name, UriKind.Relative);
+                    PackagePart part = package.CreatePart(uri, contentType, CompressionOption.SuperFast);
+                    using (Stream stream = part.GetStream(FileMode.Create))
+                    using (XmlWriter xmlWriter = XmlWriter.Create(stream))
+                        xmlPart.Element(pkg + "xmlData")
+                            .Elements()
+                            .First()
+                            .WriteTo(xmlWriter);
+                }
+                else
+                {
+                    Uri uri = new Uri(name, UriKind.Relative);
+                    PackagePart part = package.CreatePart(uri, contentType, CompressionOption.SuperFast);
+                    using (Stream stream = part.GetStream(FileMode.Create))
+                    using (BinaryWriter binaryWriter = new BinaryWriter(stream))
+                    {
+                        string base64StringInChunks = (string)xmlPart.Element(pkg + "binaryData");
+                        char[] base64CharArray = base64StringInChunks
+                            .Where(c => c != '\r' && c != '\n').ToArray();
+                        byte[] byteArray =
+                            System.Convert.FromBase64CharArray(
+                                base64CharArray, 0, base64CharArray.Length);
+                        binaryWriter.Write(byteArray);
+                    }
+                }
+            }
+
+            foreach (var xmlPart in document.Root.Elements())
+            {
+                string name = (string)xmlPart.Attribute(pkg + "name");
+                string contentType = (string)xmlPart.Attribute(pkg + "contentType");
+                if (contentType == "application/vnd.openxmlformats-package.relationships+xml")
+                {
+                    if (name == "/_rels/.rels")
+                    {
+                        // Add the package level relationships.
+                        foreach (XElement xmlRel in xmlPart.Descendants(rel + "Relationship"))
+                        {
+                            string id = (string)xmlRel.Attribute("Id");
+                            string type = (string)xmlRel.Attribute("Type");
+                            string target = (string)xmlRel.Attribute("Target");
+                            string targetMode = (string)xmlRel.Attribute("TargetMode");
+                            if (targetMode == "External")
+                                package.CreateRelationship(
+                                    new Uri(target, UriKind.Absolute),
+                                    TargetMode.External, type, id);
+                            else
+                                package.CreateRelationship(
+                                    new Uri(target, UriKind.Relative),
+                                    TargetMode.Internal, type, id);
+                        }
+                    }
+                    else
+                    {
+                        // Add part level relationships.
+                        string directory = name.Substring(0, name.IndexOf("/_rels"));
+                        string relsFilename = name.Substring(name.LastIndexOf('/'));
+                        string filename = relsFilename.Substring(0, relsFilename.IndexOf(".rels"));
+                        PackagePart fromPart = package.GetPart(new Uri(directory + filename, UriKind.Relative));
+                        foreach (XElement xmlRel in xmlPart.Descendants(rel + "Relationship"))
+                        {
+                            string id = (string)xmlRel.Attribute("Id");
+                            string type = (string)xmlRel.Attribute("Type");
+                            string target = (string)xmlRel.Attribute("Target");
+                            string targetMode = (string)xmlRel.Attribute("TargetMode");
+                            if (targetMode == "External")
+                                fromPart.CreateRelationship(
+                                    new Uri(target, UriKind.Absolute),
+                                    TargetMode.External, type, id);
+                            else
+                                fromPart.CreateRelationship(
+                                    new Uri(target, UriKind.Relative),
+                                    TargetMode.Internal, type, id);
+                        }
+                    }
+                }
+            }
+
+            // Save contents of all parts and relationships contained in package.
+            package.Flush();
+            return package;
+        }
+
+        #endregion Flat OPC
     }
 
     /// <summary>

--- a/src/ofapi/PackageDocument.cs
+++ b/src/ofapi/PackageDocument.cs
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright 2014 Thomas Barnekow (cloning)
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -705,6 +706,77 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             get { return GetSubPartOfType<WebExTaskpanesPart>(); }
         }
+
+        #region cloning
+
+        #region Stream-based cloning
+
+        /// <summary>
+        /// Creates a new OpenXmlPackage on the given stream.
+        /// </summary>
+        /// <param name="stream">The stream on which the concrete OpenXml package will be created.</param>
+        /// <returns>A new instance of OpenXmlPackage.</returns>
+        protected override OpenXmlPackage CreateClone(Stream stream)
+        {
+            return WordprocessingDocument.Create(stream, DocumentType, OpenSettings.AutoSave);
+        }
+
+        /// <summary>
+        /// Opens the cloned OpenXml package on the given stream.
+        /// </summary>
+        /// <param name="stream">The stream on which the cloned OpenXml package will be opened.</param>
+        /// <param name="isEditable">In ReadWrite mode. False for Read only mode.</param>
+        /// <param name="openSettings">The advanced settings for opening a document.</param>
+        /// <returns>A new instance of OpenXmlPackage.</returns>
+        protected override OpenXmlPackage OpenClone(Stream stream, bool isEditable, OpenSettings openSettings)
+        {
+            return WordprocessingDocument.Open(stream, isEditable, openSettings);
+        }
+
+        #endregion Stream-based cloning
+
+        #region File-based cloning
+
+        /// <summary>
+        /// Creates a new OpenXml package on the given file.
+        /// </summary>
+        /// <param name="path">The path and file name of the target OpenXml package.</param>
+        /// <returns>A new instance of OpenXmlPackage.</returns>
+        protected override OpenXmlPackage CreateClone(string path)
+        {
+            return WordprocessingDocument.Create(path, DocumentType, OpenSettings.AutoSave);
+        }
+
+        /// <summary>
+        /// Opens the cloned OpenXml package on the given file.
+        /// </summary>
+        /// <param name="path">The path and file name of the target OpenXml package.</param>
+        /// <param name="isEditable">In ReadWrite mode. False for Read only mode.</param>
+        /// <param name="openSettings">The advanced settings for opening a document.</param>
+        /// <returns>A new instance of OpenXmlPackage.</returns>
+        protected override OpenXmlPackage OpenClone(string path, bool isEditable, OpenSettings openSettings)
+        {
+            return WordprocessingDocument.Open(path, isEditable, openSettings);
+        }
+
+        #endregion File-based cloning
+
+        #region Package-based cloning
+
+        /// <summary>
+        /// Creates a new instance of OpenXmlPackage on the specified instance
+        /// of Package.
+        /// </summary>
+        /// <param name="package">The specified instance of Package.</param>
+        /// <returns>A new instance of OpenXmlPackage.</returns>
+        protected override OpenXmlPackage CreateClone(Package package)
+        {
+            return WordprocessingDocument.Create(package, DocumentType, OpenSettings.AutoSave);
+        }
+
+        #endregion Package-based cloning
+
+        #endregion cloning
     }
     
     /// <summary>
@@ -1400,6 +1472,77 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             get { return GetSubPartOfType<WebExTaskpanesPart>(); }
         }
+
+        #region cloning
+
+        #region Stream-based cloning
+
+        /// <summary>
+        /// Creates a new OpenXmlPackage on the given stream.
+        /// </summary>
+        /// <param name="stream">The stream on which the concrete OpenXml package will be created.</param>
+        /// <returns>A new instance of OpenXmlPackage.</returns>
+        protected override OpenXmlPackage CreateClone(Stream stream)
+        {
+            return SpreadsheetDocument.Create(stream, DocumentType, OpenSettings.AutoSave);
+        }
+
+        /// <summary>
+        /// Opens the cloned OpenXml package on the given stream.
+        /// </summary>
+        /// <param name="stream">The stream on which the cloned OpenXml package will be opened.</param>
+        /// <param name="isEditable">In ReadWrite mode. False for Read only mode.</param>
+        /// <param name="openSettings">The advanced settings for opening a document.</param>
+        /// <returns>A new instance of OpenXmlPackage.</returns>
+        protected override OpenXmlPackage OpenClone(Stream stream, bool isEditable, OpenSettings openSettings)
+        {
+            return SpreadsheetDocument.Open(stream, isEditable, openSettings);
+        }
+
+        #endregion Stream-based cloning
+
+        #region File-based cloning
+
+        /// <summary>
+        /// Creates a new OpenXml package on the given file.
+        /// </summary>
+        /// <param name="path">The path and file name of the target OpenXml package.</param>
+        /// <returns>A new instance of OpenXmlPackage.</returns>
+        protected override OpenXmlPackage CreateClone(string path)
+        {
+            return SpreadsheetDocument.Create(path, DocumentType, OpenSettings.AutoSave);
+        }
+
+        /// <summary>
+        /// Opens the cloned OpenXml package on the given file.
+        /// </summary>
+        /// <param name="path">The path and file name of the target OpenXml package.</param>
+        /// <param name="isEditable">In ReadWrite mode. False for Read only mode.</param>
+        /// <param name="openSettings">The advanced settings for opening a document.</param>
+        /// <returns>A new instance of OpenXmlPackage.</returns>
+        protected override OpenXmlPackage OpenClone(string path, bool isEditable, OpenSettings openSettings)
+        {
+            return SpreadsheetDocument.Open(path, isEditable, openSettings);
+        }
+
+        #endregion File-based cloning
+
+        #region Package-based cloning
+
+        /// <summary>
+        /// Creates a new instance of OpenXmlPackage on the specified instance
+        /// of Package.
+        /// </summary>
+        /// <param name="package">The specified instance of Package.</param>
+        /// <returns>A new instance of OpenXmlPackage.</returns>
+        protected override OpenXmlPackage CreateClone(Package package)
+        {
+            return SpreadsheetDocument.Create(package, DocumentType, OpenSettings.AutoSave);
+        }
+
+        #endregion Package-based cloning
+
+        #endregion cloning
     }
     
     /// <summary>
@@ -2103,5 +2246,76 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             get { return GetSubPartOfType<WebExTaskpanesPart>(); }
         }
+
+        #region cloning
+
+        #region Stream-based cloning
+
+        /// <summary>
+        /// Creates a new OpenXmlPackage on the given stream.
+        /// </summary>
+        /// <param name="stream">The stream on which the concrete OpenXml package will be created.</param>
+        /// <returns>A new instance of OpenXmlPackage.</returns>
+        protected override OpenXmlPackage CreateClone(Stream stream)
+        {
+            return PresentationDocument.Create(stream, DocumentType, OpenSettings.AutoSave);
+        }
+
+        /// <summary>
+        /// Opens the cloned OpenXml package on the given stream.
+        /// </summary>
+        /// <param name="stream">The stream on which the cloned OpenXml package will be opened.</param>
+        /// <param name="isEditable">In ReadWrite mode. False for Read only mode.</param>
+        /// <param name="openSettings">The advanced settings for opening a document.</param>
+        /// <returns>A new instance of OpenXmlPackage.</returns>
+        protected override OpenXmlPackage OpenClone(Stream stream, bool isEditable, OpenSettings openSettings)
+        {
+            return PresentationDocument.Open(stream, isEditable, openSettings);
+        }
+
+        #endregion Stream-based cloning
+
+        #region File-based cloning
+
+        /// <summary>
+        /// Creates a new OpenXml package on the given file.
+        /// </summary>
+        /// <param name="path">The path and file name of the target OpenXml package.</param>
+        /// <returns>A new instance of OpenXmlPackage.</returns>
+        protected override OpenXmlPackage CreateClone(string path)
+        {
+            return PresentationDocument.Create(path, DocumentType, OpenSettings.AutoSave);
+        }
+
+        /// <summary>
+        /// Opens the cloned OpenXml package on the given file.
+        /// </summary>
+        /// <param name="path">The path and file name of the target OpenXml package.</param>
+        /// <param name="isEditable">In ReadWrite mode. False for Read only mode.</param>
+        /// <param name="openSettings">The advanced settings for opening a document.</param>
+        /// <returns>A new instance of OpenXmlPackage.</returns>
+        protected override OpenXmlPackage OpenClone(string path, bool isEditable, OpenSettings openSettings)
+        {
+            return PresentationDocument.Open(path, isEditable, openSettings);
+        }
+
+        #endregion File-based cloning
+
+        #region Package-based cloning
+
+        /// <summary>
+        /// Creates a new instance of OpenXmlPackage on the specified instance
+        /// of Package.
+        /// </summary>
+        /// <param name="package">The specified instance of Package.</param>
+        /// <returns>A new instance of OpenXmlPackage.</returns>
+        protected override OpenXmlPackage CreateClone(Package package)
+        {
+            return PresentationDocument.Create(package, DocumentType, OpenSettings.AutoSave);
+        }
+
+        #endregion Package-based cloning
+
+        #endregion cloning
     }
 }

--- a/src/ofapi/PackageDocument.cs
+++ b/src/ofapi/PackageDocument.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
-// Copyright 2014 Thomas Barnekow (cloning)
+// Copyright 2014 Thomas Barnekow (cloning, Flat OPC)
 using System;
 using System.Collections.Generic;
 using System.Text;
 using System.IO;
 using System.IO.Packaging;
 using System.Collections.Specialized;
+using System.Xml.Linq;
 
 namespace DocumentFormat.OpenXml.Packaging
 {
@@ -777,6 +778,152 @@ namespace DocumentFormat.OpenXml.Packaging
         #endregion Package-based cloning
 
         #endregion cloning
+
+        #region Flat OPC
+
+        /// <summary>
+        /// Converts an OpenXml package in OPC format to an <see cref="XDocument"/>
+        /// in Flat OPC format.
+        /// </summary>
+        /// <returns>The OpenXml package in Flat OPC format.</returns>
+        public override XDocument ToFlatOpcDocument()
+        {
+            return ToFlatOpcDocument(new XProcessingInstruction("mso-application", "progid=\"Word.Document\""));
+        }
+
+        /// <summary>
+        /// Creates a new editable instance of WordprocessingDocument from an <see cref="XDocument"/>
+        /// in Flat OPC format, opened on a <see cref="MemoryStream"/>.
+        /// </summary>
+        /// <param name="document">The document in Flat OPC format.</param>
+        /// <returns>A new instance of WordprocessingDocument.</returns>
+        public static WordprocessingDocument FromFlatOpcDocument(XDocument document)
+        {
+            return FromFlatOpcDocument(document, new MemoryStream(), true);
+        }
+
+        /// <summary>
+        /// Creates a new instance of WordprocessingDocument from an <see cref="XDocument"/>
+        /// in Flat OPC format.
+        /// </summary>
+        /// <param name="document">The document in Flat OPC format.</param>
+        /// <param name="stream">The <see cref="Stream"/> on which the WordprocessingDocument will be created.</param>
+        /// <param name="isEditable">In ReadWrite mode. False for Read only mode.</param>
+        /// <returns>A new instance of WordprocessingDocument.</returns>
+        public static WordprocessingDocument FromFlatOpcDocument(XDocument document, Stream stream, bool isEditable)
+        {
+            if (document == null)
+                throw new ArgumentNullException("document");
+            if (stream == null)
+                throw new ArgumentNullException("stream");
+
+            return WordprocessingDocument.Open(FromFlatOpcDocumentCore(document, stream), isEditable);
+        }
+
+        /// <summary>
+        /// Creates a new instance of WordprocessingDocument from an <see cref="XDocument"/>
+        /// in Flat OPC format.
+        /// </summary>
+        /// <param name="document">The document in Flat OPC format.</param>
+        /// <param name="path">The path and file name of the target WordprocessingDocument.</param>
+        /// <param name="isEditable">In ReadWrite mode. False for Read only mode.</param>
+        /// <returns>A new instance of WordprocessingDocument.</returns>
+        public static WordprocessingDocument FromFlatOpcDocument(XDocument document, string path, bool isEditable)
+        {
+            if (document == null)
+                throw new ArgumentNullException("document");
+            if (path == null)
+                throw new ArgumentNullException("path");
+
+            return WordprocessingDocument.Open(FromFlatOpcDocumentCore(document, path), isEditable);
+        }
+
+        /// <summary>
+        /// Creates a new instance of WordprocessingDocument from an <see cref="XDocument"/>
+        /// in Flat OPC format.
+        /// </summary>
+        /// <param name="document">The document in Flat OPC format.</param>
+        /// <param name="package">The <see cref="Package"/> of the target WordprocessingDocument.</param>
+        /// <returns>A new instance of WordprocessingDocument.</returns>
+        public static WordprocessingDocument FromFlatOpcDocument(XDocument document, Package package)
+        {
+            if (document == null)
+                throw new ArgumentNullException("document");
+            if (package == null)
+                throw new ArgumentNullException("package");
+
+            return WordprocessingDocument.Open(FromFlatOpcDocumentCore(document, package));
+        }
+
+        /// <summary>
+        /// Creates a new instance of WordprocessingDocument from a string
+        /// in Flat OPC format on a <see cref="MemoryStream"/> with expandable
+        /// capacity.
+        /// </summary>
+        /// <param name="text">The string in Flat OPC format.</param>
+        /// <returns>A new instance of WordprocessingDocument.</returns>
+        public static WordprocessingDocument FromFlatOpcString(string text)
+        {
+            if (text == null)
+                throw new ArgumentNullException("text");
+
+            return FromFlatOpcDocument(XDocument.Parse(text), new MemoryStream(), true);
+        }
+
+        /// <summary>
+        /// Creates a new instance of WordprocessingDocument from a string
+        /// in Flat OPC format on a
+        /// </summary>
+        /// <param name="text">The string in Flat OPC format.</param>
+        /// <param name="stream">The <see cref="Stream"/> on which the WordprocessingDocument will be created.</param>
+        /// <param name="isEditable">In ReadWrite mode. False for Read only mode.</param>
+        /// <returns>A new instance of WordprocessingDocument.</returns>
+        public static WordprocessingDocument FromFlatOpcString(string text, Stream stream, bool isEditable)
+        {
+            if (text == null)
+                throw new ArgumentNullException("text");
+            if (stream == null)
+                throw new ArgumentNullException("stream");
+
+            return FromFlatOpcDocument(XDocument.Parse(text), stream, isEditable);
+        }
+
+        /// <summary>
+        /// Creates a new instance of WordprocessingDocument from a string
+        /// in Flat OPC format.
+        /// </summary>
+        /// <param name="text">The string in Flat OPC format.</param>
+        /// <param name="path">The path and file name of the target WordprocessingDocument.</param>
+        /// <param name="isEditable">In ReadWrite mode. False for Read only mode.</param>
+        /// <returns>A new instance of WordprocessingDocument.</returns>
+        public static WordprocessingDocument FromFlatOpcString(string text, string path, bool isEditable)
+        {
+            if (text == null)
+                throw new ArgumentNullException("text");
+            if (path == null)
+                throw new ArgumentNullException("path");
+
+            return FromFlatOpcDocument(XDocument.Parse(text), path, isEditable);
+        }
+
+        /// <summary>
+        /// Creates a new instance of WordprocessingDocument from a string
+        /// in Flat OPC format.
+        /// </summary>
+        /// <param name="text">The string in Flat OPC format.</param>
+        /// <param name="package">The <see cref="Package"/> of the target WordprocessingDocument.</param>
+        /// <returns>A new instance of WordprocessingDocument.</returns>
+        public static WordprocessingDocument FromFlatOpcString(string text, Package package)
+        {
+            if (text == null)
+                throw new ArgumentNullException("text");
+            if (package == null)
+                throw new ArgumentNullException("package");
+
+            return FromFlatOpcDocument(XDocument.Parse(text), package);
+        }
+
+        #endregion Flat OPC
     }
     
     /// <summary>
@@ -1543,6 +1690,152 @@ namespace DocumentFormat.OpenXml.Packaging
         #endregion Package-based cloning
 
         #endregion cloning
+
+        #region Flat OPC
+
+        /// <summary>
+        /// Converts an OpenXml package in OPC format to an <see cref="XDocument"/>
+        /// in Flat OPC format.
+        /// </summary>
+        /// <returns>The OpenXml package in Flat OPC format.</returns>
+        public override XDocument ToFlatOpcDocument()
+        {
+            return ToFlatOpcDocument(null);
+        }
+
+        /// <summary>
+        /// Creates a new editable instance of SpreadsheetDocument from an <see cref="XDocument"/>
+        /// in Flat OPC format, opened on a <see cref="MemoryStream"/>.
+        /// </summary>
+        /// <param name="document">The document in Flat OPC format.</param>
+        /// <returns>A new instance of SpreadsheetDocument.</returns>
+        public static SpreadsheetDocument FromFlatOpcDocument(XDocument document)
+        {
+            return FromFlatOpcDocument(document, new MemoryStream(), true);
+        }
+
+        /// <summary>
+        /// Creates a new instance of SpreadsheetDocument from a workbook
+        /// in Flat OPC format.
+        /// </summary>
+        /// <param name="document">The workbook in Flat OPC format.</param>
+        /// <param name="stream">The stream on which the SpreadsheetDocument will be created.</param>
+        /// <param name="isEditable">In ReadWrite mode. False for Read only mode.</param>
+        /// <returns>A new instance of SpreadsheetDocument.</returns>
+        public static SpreadsheetDocument FromFlatOpcDocument(XDocument document, Stream stream, bool isEditable)
+        {
+            if (document == null)
+                throw new ArgumentNullException("document");
+            if (stream == null)
+                throw new ArgumentNullException("stream");
+
+            return SpreadsheetDocument.Open(FromFlatOpcDocumentCore(document, stream), true);
+        }
+
+        /// <summary>
+        /// Creates a new instance of SpreadsheetDocument from a workbook
+        /// in Flat OPC format.
+        /// </summary>
+        /// <param name="document">The workbook in Flat OPC format.</param>
+        /// <param name="path">The path and file name of the target SpreadsheetDocument.</param>
+        /// <param name="isEditable">In ReadWrite mode. False for Read only mode.</param>
+        /// <returns>A new instance of SpreadsheetDocument.</returns>
+        public static SpreadsheetDocument FromFlatOpcDocument(XDocument document, string path, bool isEditable)
+        {
+            if (document == null)
+                throw new ArgumentNullException("document");
+            if (path == null)
+                throw new ArgumentNullException("path");
+
+            return SpreadsheetDocument.Open(FromFlatOpcDocumentCore(document, path), isEditable);
+        }
+
+        /// <summary>
+        /// Creates a new instance of SpreadsheetDocument from a workbook
+        /// in Flat OPC format on the specified instance of Package.
+        /// </summary>
+        /// <param name="document">The workbook in Flat OPC format.</param>
+        /// <param name="package">The specified instance of Package.</param>
+        /// <returns>A new instance of SpreadsheetDocument.</returns>
+        public static SpreadsheetDocument FromFlatOpcDocument(XDocument document, Package package)
+        {
+            if (document == null)
+                throw new ArgumentNullException("document");
+            if (package == null)
+                throw new ArgumentNullException("package");
+
+            return SpreadsheetDocument.Open(FromFlatOpcDocumentCore(document, package));
+        }
+
+        /// <summary>
+        /// Creates a new instance of SpreadsheetDocument from a string
+        /// in Flat OPC format on a <see cref="MemoryStream"/> with expandable
+        /// capacity.
+        /// </summary>
+        /// <param name="text">The string in Flat OPC format.</param>
+        /// <returns>A new instance of SpreadsheetDocument.</returns>
+        public static SpreadsheetDocument FromFlatOpcString(string text)
+        {
+            if (text == null)
+                throw new ArgumentNullException("text");
+
+            return FromFlatOpcDocument(XDocument.Parse(text), new MemoryStream(), true);
+        }
+
+        /// <summary>
+        /// Creates a new instance of SpreadsheetDocument from a string
+        /// in Flat OPC format on a
+        /// </summary>
+        /// <param name="text">The string in Flat OPC format.</param>
+        /// <param name="stream">The <see cref="Stream"/> on which the SpreadsheetDocument will be created.</param>
+        /// <param name="isEditable">In ReadWrite mode. False for Read only mode.</param>
+        /// <returns>A new instance of SpreadsheetDocument.</returns>
+        public static SpreadsheetDocument FromFlatOpcString(string text, Stream stream, bool isEditable)
+        {
+            if (text == null)
+                throw new ArgumentNullException("text");
+            if (stream == null)
+                throw new ArgumentNullException("stream");
+
+            return FromFlatOpcDocument(XDocument.Parse(text), stream, isEditable);
+        }
+
+        /// <summary>
+        /// Creates a new instance of SpreadsheetDocument from a string
+        /// in Flat OPC format.
+        /// </summary>
+        /// <param name="text">The string in Flat OPC format.</param>
+        /// <param name="path">The path and file name of the target SpreadsheetDocument.</param>
+        /// <param name="isEditable">In ReadWrite mode. False for Read only mode.</param>
+        /// <returns>A new instance of SpreadsheetDocument.</returns>
+        public static SpreadsheetDocument FromFlatOpcString(string text, string path, bool isEditable)
+        {
+            if (text == null)
+                throw new ArgumentNullException("text");
+            if (path == null)
+                throw new ArgumentNullException("path");
+
+            return FromFlatOpcDocument(XDocument.Parse(text), path, isEditable);
+        }
+
+        /// <summary>
+        /// Creates a new instance of SpreadsheetDocument from a string
+        /// in Flat OPC format.
+        /// </summary>
+        /// <param name="text">The string in Flat OPC format.</param>
+        /// <param name="package">The <see cref="Package"/> of the target SpreadsheetDocument.</param>
+        /// <returns>A new instance of SpreadsheetDocument.</returns>
+        public static SpreadsheetDocument FromFlatOpcString(string text, Package package)
+        {
+            if (text == null)
+                throw new ArgumentNullException("text");
+            if (package == null)
+                throw new ArgumentNullException("package");
+
+            return FromFlatOpcDocument(XDocument.Parse(text), package);
+        }
+
+        #endregion Flat OPC
     }
     
     /// <summary>
@@ -2317,5 +2610,151 @@ namespace DocumentFormat.OpenXml.Packaging
         #endregion Package-based cloning
 
         #endregion cloning
+
+        #region Flat OPC
+
+        /// <summary>
+        /// Converts an OpenXml package in OPC format to an <see cref="XDocument"/>
+        /// in Flat OPC format.
+        /// </summary>
+        /// <returns>The OpenXml package in Flat OPC format.</returns>
+        public override XDocument ToFlatOpcDocument()
+        {
+            return ToFlatOpcDocument(new XProcessingInstruction("mso-application", "progid=\"PowerPoint.Show\""));
+        }
+
+        /// <summary>
+        /// Creates a new editable instance of PresentationDocument from an <see cref="XDocument"/>
+        /// in Flat OPC format, opened on a <see cref="MemoryStream"/>.
+        /// </summary>
+        /// <param name="document">The document in Flat OPC format.</param>
+        /// <returns>A new instance of PresentationDocument.</returns>
+        public static PresentationDocument FromFlatOpcDocument(XDocument document)
+        {
+            return FromFlatOpcDocument(document, new MemoryStream(), true);
+        }
+
+        /// <summary>
+        /// Creates a new instance of PresentationDocument from a presentation
+        /// in Flat OPC format.
+        /// </summary>
+        /// <param name="document">The presentation in Flat OPC format.</param>
+        /// <param name="stream">The stream on which the PresentationDocument will be created.</param>
+        /// <param name="isEditable">In ReadWrite mode. False for Read only mode.</param>
+        /// <returns>A new instance of PresentationDocument.</returns>
+        public static PresentationDocument FromFlatOpcDocument(XDocument document, Stream stream, bool isEditable)
+        {
+            if (document == null)
+                throw new ArgumentNullException("document");
+            if (stream == null)
+                throw new ArgumentNullException("stream");
+
+            return PresentationDocument.Open(FromFlatOpcDocumentCore(document, stream), isEditable);
+        }
+
+        /// <summary>
+        /// Creates a new instance of PresentationDocument from a presentation
+        /// in Flat OPC format.
+        /// </summary>
+        /// <param name="document">The presentation in Flat OPC format.</param>
+        /// <param name="path">The path and file name of the target PresentationDocument.</param>
+        /// <param name="isEditable">In ReadWrite mode. False for Read only mode.</param>
+        /// <returns>A new instance of PresentationDocument.</returns>
+        public static PresentationDocument FromFlatOpcDocument(XDocument document, string path, bool isEditable)
+        {
+            if (document == null)
+                throw new ArgumentNullException("document");
+            if (path == null)
+                throw new ArgumentNullException("path");
+
+            return PresentationDocument.Open(FromFlatOpcDocumentCore(document, path), isEditable);
+        }
+
+        /// <summary>
+        /// Creates a new instance of PresentationDocument from a presentation
+        /// in Flat OPC format on the specified instance of Package.
+        /// </summary>
+        /// <param name="document">The presentation in Flat OPC format.</param>
+        /// <param name="package">The specified instance of Package.</param>
+        /// <returns>A new instance of PresentationDocument.</returns>
+        public static PresentationDocument FromFlatOpcDocument(XDocument document, Package package)
+        {
+            if (document == null)
+                throw new ArgumentNullException("document");
+            if (package == null)
+                throw new ArgumentNullException("package");
+
+            return PresentationDocument.Open(FromFlatOpcDocumentCore(document, package));
+        }
+
+        /// <summary>
+        /// Creates a new instance of PresentationDocument from a string
+        /// in Flat OPC format on a <see cref="MemoryStream"/> with expandable
+        /// capacity.
+        /// </summary>
+        /// <param name="text">The string in Flat OPC format.</param>
+        /// <returns>A new instance of PresentationDocument.</returns>
+        public static PresentationDocument FromFlatOpcString(string text)
+        {
+            if (text == null)
+                throw new ArgumentNullException("text");
+
+            return FromFlatOpcDocument(XDocument.Parse(text), new MemoryStream(), true);
+        }
+
+        /// <summary>
+        /// Creates a new instance of PresentationDocument from a string
+        /// in Flat OPC format on a
+        /// </summary>
+        /// <param name="text">The string in Flat OPC format.</param>
+        /// <param name="stream">The <see cref="Stream"/> on which the PresentationDocument will be created.</param>
+        /// <param name="isEditable">In ReadWrite mode. False for Read only mode.</param>
+        /// <returns>A new instance of PresentationDocument.</returns>
+        public static PresentationDocument FromFlatOpcString(string text, Stream stream, bool isEditable)
+        {
+            if (text == null)
+                throw new ArgumentNullException("text");
+            if (stream == null)
+                throw new ArgumentNullException("stream");
+
+            return FromFlatOpcDocument(XDocument.Parse(text), stream, isEditable);
+        }
+
+        /// <summary>
+        /// Creates a new instance of PresentationDocument from a string
+        /// in Flat OPC format.
+        /// </summary>
+        /// <param name="text">The string in Flat OPC format.</param>
+        /// <param name="path">The path and file name of the target PresentationDocument.</param>
+        /// <param name="isEditable">In ReadWrite mode. False for Read only mode.</param>
+        /// <returns>A new instance of PresentationDocument.</returns>
+        public static PresentationDocument FromFlatOpcString(string text, string path, bool isEditable)
+        {
+            if (text == null)
+                throw new ArgumentNullException("text");
+            if (path == null)
+                throw new ArgumentNullException("path");
+
+            return FromFlatOpcDocument(XDocument.Parse(text), path, isEditable);
+        }
+
+        /// <summary>
+        /// Creates a new instance of PresentationDocument from a string
+        /// in Flat OPC format.
+        /// </summary>
+        /// <param name="text">The string in Flat OPC format.</param>
+        /// <param name="package">The <see cref="Package"/> of the target PresentationDocument.</param>
+        /// <returns>A new instance of PresentationDocument.</returns>
+        public static PresentationDocument FromFlatOpcString(string text, Package package)
+        {
+            if (text == null)
+                throw new ArgumentNullException("text");
+            if (package == null)
+                throw new ArgumentNullException("package");
+
+            return FromFlatOpcDocument(XDocument.Parse(text), package);
+        }
+
+        #endregion Flat OPC
     }
 }

--- a/src/ofapi/PackageDocument.cs
+++ b/src/ofapi/PackageDocument.cs
@@ -246,6 +246,82 @@ namespace DocumentFormat.OpenXml.Packaging
         }
 
         /// <summary>
+        /// Creates an editable WordprocessingDocument from a template, opened on
+        /// a MemoryStream with expandable capacity. The template will be attached
+        /// to the WordprocessingDocument.
+        /// </summary>
+        /// <remarks>
+        /// Attaching the template has been chosen as the default behavior because
+        /// this is also what happens when a document is created from a template
+        /// (other than Normal.dotm) using Microsoft Word.
+        /// </remarks>
+        /// <param name="path">The path and file name of the template.</param>
+        /// <returns>The new WordprocessingDocument based on and linked to the template.</returns>
+        public static WordprocessingDocument CreateFromTemplate(string path)
+        {
+            return CreateFromTemplate(path, true);
+        }
+
+        /// <summary>
+        /// Creates an editable WordprocessingDocument from a template, opened on
+        /// a MemoryStream with expandable capacity.
+        /// </summary>
+        /// <remarks>
+        /// This method is provided to offer the choice to not attach the template.
+        /// When templates are attached in Microsoft Word, for example, the absolute
+        /// path will be used in the relationship. These absolute paths are most
+        /// often user-specific, however, so once documents are shared with other
+        /// users, the relationship gets "broken" anyhow.
+        /// </remarks>
+        /// <param name="path">The path and file name of the template.</param>
+        /// <param name="isTemplateAttached">True, if the template should be attached to the document.</param>
+        /// <returns>The new WordprocessingDocument based on and linked to the template.</returns>
+        public static WordprocessingDocument CreateFromTemplate(string path, bool isTemplateAttached)
+        {
+            if (path == null)
+                throw new ArgumentNullException("path");
+
+            // Check extensions as the template must have a valid Word Open XML extension.
+            string extension = Path.GetExtension(path);
+            if (extension != ".docx" && extension != ".docm" && extension != ".dotx" && extension != ".dotm")
+                throw new ArgumentException("Illegal template file: " + path, "path");
+
+            using (WordprocessingDocument template = WordprocessingDocument.Open(path, false))
+            {
+                // We've opened the template in read-only mode to let multiple processes
+                // open it without running into problems.
+                WordprocessingDocument document = (WordprocessingDocument)template.Clone();
+
+                // If the template is a document rather than a template, we are done.
+                if (extension == ".docx" || extension == ".docm")
+                    return document;
+
+                // Otherwise, we'll have to do some more work.
+                // Firstly, we'll change the document type from Template to Document.
+                document.ChangeDocumentType(WordprocessingDocumentType.Document);
+
+                // Secondly, we'll attach the template to our new document if so desired.
+                if (isTemplateAttached)
+                {
+                    // Create a relative or absolute external relationship to the template.
+                    // TODO: Check whether relative URIs are universally supported. They work in Office 2010.
+                    MainDocumentPart mainDocumentPart = document.MainDocumentPart;
+                    DocumentSettingsPart documentSettingsPart = mainDocumentPart.DocumentSettingsPart;
+                    ExternalRelationship relationship = documentSettingsPart.AddExternalRelationship(
+                        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/attachedTemplate",
+                        new Uri(path, UriKind.RelativeOrAbsolute));
+                    documentSettingsPart.Settings.Append(
+                        new DocumentFormat.OpenXml.Wordprocessing.AttachedTemplate() { Id = relationship.Id });
+                }
+
+                // We are done, so save and return.
+                // TODO: Check whether it would be safe to return without saving.
+                document.Save();
+                return document;
+            }
+        }
+
+        /// <summary>
         /// Creates a new instance of the WordprocessingDocument class from the specified file.
         /// </summary>
         /// <param name="path">The path and file name of the target WordprocessingDocument.</param>
@@ -380,7 +456,7 @@ namespace DocumentFormat.OpenXml.Packaging
         }
 
         /// <summary>
-        /// Changes the document type. 
+        /// Changes the document type.
         /// </summary>
         /// <param name="newType">The new type of the document.</param>
         /// <remarks>The MainDocumentPart will be changed.</remarks>
@@ -925,7 +1001,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
         #endregion Flat OPC
     }
-    
+
     /// <summary>
     /// Defines SpreadsheetDocument - an OpenXmlPackage represents a Spreadsheet document.
     /// </summary>
@@ -1164,6 +1240,43 @@ namespace DocumentFormat.OpenXml.Packaging
         }
 
         /// <summary>
+        /// Creates an editable SpreadsheetDocument from a template, opened on
+        /// a MemoryStream with expandable capacity.
+        /// </summary>
+        /// <param name="path">The path and file name of the template.</param>
+        /// <returns>The new SpreadsheetDocument based on and linked to the template.</returns>
+        public static SpreadsheetDocument CreateFromTemplate(string path)
+        {
+            if (path == null)
+                throw new ArgumentNullException("path");
+
+            // Check extensions as the template must have a valid Word Open XML extension.
+            string extension = Path.GetExtension(path);
+            if (extension != ".xlsx" && extension != ".xlsm" && extension != ".xltx" && extension != ".xltm")
+                throw new ArgumentException("Illegal template file: " + path, "path");
+
+            using (SpreadsheetDocument template = SpreadsheetDocument.Open(path, false))
+            {
+                // We've opened the template in read-only mode to let multiple processes or
+                // threads open it without running into problems.
+                SpreadsheetDocument document = (SpreadsheetDocument)template.Clone();
+
+                // If the template is a document rather than a template, we are done.
+                if (extension == ".xlsx" || extension == ".xlsm")
+                    return document;
+
+                // Otherwise, we'll have to do some more work.
+                // Firstly, we'll change the document type from Template to Document.
+                document.ChangeDocumentType(SpreadsheetDocumentType.Workbook);
+
+                // We are done, so save and return.
+                // TODO: Check whether it would be safe to return without saving.
+                document.Save();
+                return document;
+            }
+        }
+
+        /// <summary>
         /// Creates a new instance of the SpreadsheetDocument class from the specified file.
         /// </summary>
         /// <param name="path">The path and file name of the target SpreadsheetDocument.</param>
@@ -1294,7 +1407,7 @@ namespace DocumentFormat.OpenXml.Packaging
         }
 
         /// <summary>
-        /// Changes the document type. 
+        /// Changes the document type.
         /// </summary>
         /// <param name="newType">The new type of the document.</param>
         /// <remarks>The WorkbookPart will be changed.</remarks>
@@ -1837,7 +1950,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
         #endregion Flat OPC
     }
-    
+
     /// <summary>
     /// Defines PresentationDocument - an OpenXmlPackage represents a Presentation document
     /// </summary>
@@ -2072,6 +2185,41 @@ namespace DocumentFormat.OpenXml.Packaging
             return doc;
         }
 
+        /// <summary>
+        /// Creates an editable PresentationDocument from a template, opened on
+        /// a MemoryStream with expandable capacity.
+        /// </summary>
+        /// <param name="path">The path and file name of the template.</param>
+        /// <returns>The new PresentationDocument based on the template.</returns>
+        public static PresentationDocument CreateFromTemplate(string path)
+        {
+            if (path == null)
+                throw new ArgumentNullException("path");
+
+            // Check extensions as the template must have a valid Word Open XML extension.
+            string extension = Path.GetExtension(path);
+            if (extension != ".pptx" && extension != ".pptm" && extension != ".potx" && extension != ".potm")
+                throw new ArgumentException("Illegal template file: " + path, "path");
+
+            using (PresentationDocument template = PresentationDocument.Open(path, false))
+            {
+                // We've opened the template in read-only mode to let multiple processes or
+                // threads open it without running into problems.
+                PresentationDocument document = (PresentationDocument)template.Clone();
+
+                // If the template is a document rather than a template, we are done.
+                if (extension == ".xlsx" || extension == ".xlsm")
+                    return document;
+
+                // Otherwise, we'll have to do some more work.
+                document.ChangeDocumentType(PresentationDocumentType.Presentation);
+
+                // We are done, so save and return.
+                // TODO: Check whether it would be safe to return without saving.
+                document.Save();
+                return document;
+            }
+        }
 
         /// <summary>
         /// Creates a new instance of the PresentationDocument class from the specified file.
@@ -2207,7 +2355,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
 
         /// <summary>
-        /// Changes the document type. 
+        /// Changes the document type.
         /// </summary>
         /// <param name="newType">The new type of the document.</param>
         /// <remarks>The PresentationPart will be changed.</remarks>

--- a/src/ofapi/Properties/AssemblyInfo.cs
+++ b/src/ofapi/Properties/AssemblyInfo.cs
@@ -36,8 +36,8 @@ using System.Security;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("2.5.5864.780")]
-[assembly: AssemblyFileVersion("2.5.5864.780")]
+[assembly: AssemblyVersion("2.5.5864.840")]
+[assembly: AssemblyFileVersion("2.5.5864.840")]
 
 [assembly: NeutralResourcesLanguageAttribute("en-US")]
 [assembly: AllowPartiallyTrustedCallers]

--- a/src/ofapi/Properties/AssemblyInfo.cs
+++ b/src/ofapi/Properties/AssemblyInfo.cs
@@ -36,8 +36,8 @@ using System.Security;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("2.5.5716.1020")]
-[assembly: AssemblyFileVersion("2.5.5716.1020")]
+[assembly: AssemblyVersion("2.5.5864.780")]
+[assembly: AssemblyFileVersion("2.5.5864.780")]
 
 [assembly: NeutralResourcesLanguageAttribute("en-US")]
 [assembly: AllowPartiallyTrustedCallers]

--- a/src/ofapi/Properties/AssemblyInfo.cs
+++ b/src/ofapi/Properties/AssemblyInfo.cs
@@ -36,8 +36,8 @@ using System.Security;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("2.5.5864.840")]
-[assembly: AssemblyFileVersion("2.5.5864.840")]
+[assembly: AssemblyVersion("2.5.5864.900")]
+[assembly: AssemblyFileVersion("2.5.5864.900")]
 
 [assembly: NeutralResourcesLanguageAttribute("en-US")]
 [assembly: AllowPartiallyTrustedCallers]

--- a/src/ofapi/Properties/AssemblyInfo.cs
+++ b/src/ofapi/Properties/AssemblyInfo.cs
@@ -36,8 +36,8 @@ using System.Security;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("2.5.5864.900")]
-[assembly: AssemblyFileVersion("2.5.5864.900")]
+[assembly: AssemblyVersion("2.5.5864.960")]
+[assembly: AssemblyFileVersion("2.5.5864.960")]
 
 [assembly: NeutralResourcesLanguageAttribute("en-US")]
 [assembly: AllowPartiallyTrustedCallers]


### PR DESCRIPTION
This pull request (which replaces the feat/xname pull request) contains an additional commit on top of the "Document Extensions" pull request, adding an `XName` property to both `OpenXmlElement` and `OpenXmlAttribute`. This supports integration with projects using Linq for XML.