### PR TITLE
Missing Files in Package - More Detailed Error

### DIFF
--- a/src/Framework/OpenXmlBasePart.cs
+++ b/src/Framework/OpenXmlBasePart.cs
@@ -81,6 +81,11 @@ namespace DocumentFormat.OpenXml.Packaging
             this._uri = uriTarget;
 
             // TODO: should we delay load?
+            if (!this.OpenXmlPackage.Package.PartExists(uriTarget))
+            {
+                throw new OpenXmlPackageException(string.Format("The part with URI target {0} does not exist in the package.", uriTarget));
+            }
+
             PackagePart metroPart = this.OpenXmlPackage.Package.GetPart(uriTarget);
 
             if (this.IsContentTypeFixed &&


### PR DESCRIPTION
When a package isn't found in the document, a generic "Specified part does not exist in the package." error is produced.  This doesn't guide the developer in which out of the many possible files in the package is
missing.

In my case, I had this problem from a file I didn't generate, so I was lost as to how to resolve the issue.  Looking on stackoverflow, these post were useful (http://stackoverflow.com/questions/11212374/specified-part-does-not-exist-in-the-package  http://www.telkoth.net/blog/?p=30), but the error message was quite vague.