### PR TITLE
Fix SemanticConstraint.GetAttrNumVal method

### DIFF
--- a/DocumentFormat.OpenXml/src/ofapi/Validation/SemanticValidation/SemanticConstraint/SemanticConstraint.cs
+++ b/DocumentFormat.OpenXml/src/ofapi/Validation/SemanticValidation/SemanticConstraint/SemanticConstraint.cs
@@ -204,18 +204,14 @@ namespace DocumentFormat.OpenXml.Internal.SemanticValidation
             HexBinaryValue hexBinaryValue = attributeValue as HexBinaryValue;
             if (hexBinaryValue != null)
             {
-                long val = -1;
-                bool result;
-
-                result = long.TryParse(hexBinaryValue.Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out val);
-                value = (double)val;
-
+                long val;
+                bool result = long.TryParse(hexBinaryValue.Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out val);
+                value = val;
                 return result;
             }
-            else
-            {
-                return double.TryParse(attributeValue.InnerText, out value);
-            }
+
+            return double.TryParse(attributeValue.InnerText, NumberStyles.AllowDecimalPoint,
+                CultureInfo.InvariantCulture, out value);
         }
 
         private static OpenXmlPart GetPartThroughPartPath(IEnumerable<IdPartPair> pairs, string[] path)


### PR DESCRIPTION
Attribute strings containing decimal numbers were not correctly converted to double for all cultures. This commit fixes that issue.

See #49 for details.

