### PR TITLE
Case sensitive path issue: BugRegression -> bugregression

### DIFF
--- a/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/GenerateList4LowLevelTest.cs
+++ b/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/GenerateList4LowLevelTest.cs
@@ -54,7 +54,7 @@ namespace DocumentFormat.OpenXml.Tests
         public void TestRootElementOfVmlDrawingPartIsLoadedAsUnknown()
         {
             this.MyTestInitialize(TestContext.GetCurrentMethod());
-            var file = CopyTestFiles(@"BugRegression", true, "537826.vmlpart.xlsx", f => f.IsSpreadsheetFile())
+            var file = CopyTestFiles(@"bugregression", true, "537826.vmlpart.xlsx", f => f.IsSpreadsheetFile())
                 .FirstOrDefault();
 
             using (var vmldoc = SpreadsheetDocument.Open(file.FullName, false))

--- a/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/OpenXmlCompositeElementTestClass.cs
+++ b/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/OpenXmlCompositeElementTestClass.cs
@@ -2543,7 +2543,7 @@ namespace DocumentFormat.OpenXml.Tests
         public void Bug680607_SaveOutWord14Beta2File()
         {
             this.MyTestInitialize(TestContext.GetCurrentMethod());
-            var testfile = CopyTestFiles("BugRegression", true, "680607.HelloO14.docx", f => f.IsWordprocessingFile())
+            var testfile = CopyTestFiles("bugregression", true, "680607.HelloO14.docx", f => f.IsWordprocessingFile())
                 .FirstOrDefault();
 
             using (var Package = testfile.OpenPackage(true))


### PR DESCRIPTION
The folder that the test files are in is called 'bugregression', but the tests refer to it as 'BugRegression'. This causes it to fail to find the files on Linux. 
