### PR TITLE
Code cleanup - introducing the 'nameof' operator instead of string values

### DIFF
--- a/DocumentFormat.OpenXml/src/Framework/DataPartReferenceRelationship.cs
+++ b/DocumentFormat.OpenXml/src/Framework/DataPartReferenceRelationship.cs
@@ -107,7 +107,7 @@ namespace DocumentFormat.OpenXml.Packaging
                     break;
 
                 default:
-                    throw new ArgumentOutOfRangeException("relationshipType");
+                    throw new ArgumentOutOfRangeException(nameof(relationshipType));
             }
             dataPartReferenceRelationship.Container = containter;
             return dataPartReferenceRelationship;

--- a/DocumentFormat.OpenXml/src/Framework/MediaDataPart.cs
+++ b/DocumentFormat.OpenXml/src/Framework/MediaDataPart.cs
@@ -152,7 +152,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (sourceStream == null)
             {
-                throw new ArgumentNullException("sourceStream");
+                throw new ArgumentNullException(nameof(sourceStream));
             }
 
             using (Stream targetStream = this.GetStream(FileMode.Create))
@@ -554,7 +554,7 @@ namespace DocumentFormat.OpenXml.Packaging
                     return "video/vc1";
 
                 default:
-                    throw new ArgumentOutOfRangeException("mediaDataPartType");
+                    throw new ArgumentOutOfRangeException(nameof(mediaDataPartType));
             }
         }
 

--- a/DocumentFormat.OpenXml/src/Framework/NamespaceIdMap.cs
+++ b/DocumentFormat.OpenXml/src/Framework/NamespaceIdMap.cs
@@ -414,7 +414,7 @@ namespace DocumentFormat.OpenXml
         {
             if (strictNamespace == null)
             {
-                throw new ArgumentNullException("strictNamespace");
+                throw new ArgumentNullException(nameof(strictNamespace));
             }
 
             return _namespaceTranslationDic.TryGetValue(strictNamespace, out transitionalNamespace);
@@ -430,7 +430,7 @@ namespace DocumentFormat.OpenXml
         {
             if (strictRelationship == null)
             {
-                throw new ArgumentNullException("strictRelationship");
+                throw new ArgumentNullException(nameof(strictRelationship));
             }
 
             return _relationshipTranslationDic.TryGetValue(strictRelationship, out transitionalRelationship);
@@ -478,7 +478,7 @@ namespace DocumentFormat.OpenXml
         {
             if (namespaceUri == null)
             {
-                throw new ArgumentNullException("namespaceUri");
+                throw new ArgumentNullException(nameof(namespaceUri));
             }
 
             int index = Array.IndexOf(_namespaceList, namespaceUri);
@@ -507,7 +507,7 @@ namespace DocumentFormat.OpenXml
         {
             if (namespaceUri == null)
             {
-                throw new ArgumentNullException("namespaceUri");
+                throw new ArgumentNullException(nameof(namespaceUri));
             }
 
             int index = Array.IndexOf(_namespaceList, namespaceUri);
@@ -552,7 +552,7 @@ namespace DocumentFormat.OpenXml
         {
             if (prefix == null)
             {
-                throw new ArgumentNullException("prefix");
+                throw new ArgumentNullException(nameof(prefix));
             }
 
             int index = Array.IndexOf(_namespacePrefixList, prefix);

--- a/DocumentFormat.OpenXml/src/Framework/OpenXmlAttribute.cs
+++ b/DocumentFormat.OpenXml/src/Framework/OpenXmlAttribute.cs
@@ -33,7 +33,7 @@ namespace DocumentFormat.OpenXml
         {
             if (String.IsNullOrEmpty(qualifiedName))
             {
-                throw new ArgumentNullException("qualifiedName");
+                throw new ArgumentNullException(nameof(qualifiedName));
             }
 
             this._namespaceUri = namespaceUri;
@@ -53,7 +53,7 @@ namespace DocumentFormat.OpenXml
         {
             if (String.IsNullOrEmpty(localName))
             {
-                throw new ArgumentNullException("localName");
+                throw new ArgumentNullException(nameof(localName));
             }
 
             this._namespaceUri = namespaceUri;

--- a/DocumentFormat.OpenXml/src/Framework/OpenXmlBasePart.cs
+++ b/DocumentFormat.OpenXml/src/Framework/OpenXmlBasePart.cs
@@ -51,12 +51,12 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (uriTarget == null)
             {
-                throw new ArgumentNullException("uriTarget");
+                throw new ArgumentNullException(nameof(uriTarget));
             }
 
             if (id == null)
             {
-                throw new ArgumentNullException("id");
+                throw new ArgumentNullException(nameof(id));
             }
 
             if (openXmlPackage == null && parent == null)
@@ -66,7 +66,7 @@ namespace DocumentFormat.OpenXml.Packaging
             else if (parent != null && openXmlPackage != null &&
                  parent.OpenXmlPackage != openXmlPackage)
             {
-                throw new ArgumentOutOfRangeException("parent");
+                throw new ArgumentOutOfRangeException(nameof(parent));
             }
             else if (parent != null && openXmlPackage == null)
             {
@@ -121,7 +121,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (contentType == null)
             {
-                throw new ArgumentNullException("contentType");
+                throw new ArgumentNullException(nameof(contentType));
             }
 
             PartConstraintRule partConstraintRule;
@@ -148,7 +148,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
                 return child;
             }
-            throw new ArgumentOutOfRangeException("relationshipType");
+            throw new ArgumentOutOfRangeException(nameof(relationshipType));
         }
 
         // get app specific TargetPath if exists
@@ -193,7 +193,7 @@ namespace DocumentFormat.OpenXml.Packaging
             else if (parent != null && openXmlPackage != null &&
                  parent.OpenXmlPackage != openXmlPackage)
             {
-                throw new ArgumentOutOfRangeException("parent");
+                throw new ArgumentOutOfRangeException(nameof(parent));
             }
             else if (parent != null && openXmlPackage == null)
             {
@@ -262,7 +262,7 @@ namespace DocumentFormat.OpenXml.Packaging
             else if (parent != null && openXmlPackage != null &&
                  parent.OpenXmlPackage != openXmlPackage)
             {
-                throw new ArgumentOutOfRangeException("parent");
+                throw new ArgumentOutOfRangeException(nameof(parent));
             }
             else if (parent != null && openXmlPackage == null)
             {
@@ -407,7 +407,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (sourceStream == null)
             {
-                throw new ArgumentNullException("sourceStream");
+                throw new ArgumentNullException(nameof(sourceStream));
             }
 
             using (Stream targetStream = this.GetStream(FileMode.Create))
@@ -449,7 +449,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (schemas == null)
             {
-                throw new ArgumentNullException("schemas");
+                throw new ArgumentNullException(nameof(schemas));
             }
 
             XmlReaderSettings xmlReaderSettings = new XmlReaderSettings();
@@ -491,7 +491,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (schemaFile == null)
             {
-                throw new ArgumentNullException("schemaFile");
+                throw new ArgumentNullException(nameof(schemaFile));
             }
 
             XmlSchemaSet schemas = new XmlSchemaSet();
@@ -580,7 +580,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (reachableParts == null)
             {
-                throw new ArgumentNullException("reachableParts");
+                throw new ArgumentNullException(nameof(reachableParts));
             }
 
             reachableParts.Add(this, false);
@@ -860,7 +860,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (sourceStream == null)
             {
-                throw new ArgumentNullException("sourceStream");
+                throw new ArgumentNullException(nameof(sourceStream));
             }
             
             using (BinaryReader sourceReader = new BinaryReader(sourceStream))

--- a/DocumentFormat.OpenXml/src/Framework/OpenXmlCompositeElement.cs
+++ b/DocumentFormat.OpenXml/src/Framework/OpenXmlCompositeElement.cs
@@ -69,7 +69,7 @@ namespace DocumentFormat.OpenXml
         {
             if (childrenElements == null)
             {
-                throw new ArgumentNullException("childrenElements");
+                throw new ArgumentNullException(nameof(childrenElements));
             }
 
             foreach (OpenXmlElement child in childrenElements)
@@ -88,7 +88,7 @@ namespace DocumentFormat.OpenXml
         {
             if (childrenElements == null)
             {
-                throw new ArgumentNullException("childrenElements");
+                throw new ArgumentNullException(nameof(childrenElements));
             }
 
             foreach (OpenXmlElement child in childrenElements)
@@ -106,7 +106,7 @@ namespace DocumentFormat.OpenXml
         {
             if (childrenElements == null)
             {
-                throw new ArgumentNullException("childrenElements");
+                throw new ArgumentNullException(nameof(childrenElements));
             }
 
             foreach (OpenXmlElement child in childrenElements)
@@ -251,7 +251,7 @@ namespace DocumentFormat.OpenXml
         {
             if (newChild == null)
             {
-                // throw new ArgumentNullException("newChild");
+                // throw new ArgumentNullException(nameof(newChild));
                 return null;
             }
 
@@ -297,7 +297,7 @@ namespace DocumentFormat.OpenXml
         {
             if (newChild == null)
             {
-                // throw new ArgumentNullException("newChild");
+                // throw new ArgumentNullException(nameof(newChild));
                 return null;
             }
 
@@ -356,7 +356,7 @@ namespace DocumentFormat.OpenXml
         {
             if (newChild == null)
             {
-                // throw new ArgumentNullException("newChild");
+                // throw new ArgumentNullException(nameof(newChild));
                 return null;
             }
 
@@ -415,7 +415,7 @@ namespace DocumentFormat.OpenXml
         {
             if (newChild == null)
             {
-                // throw new ArgumentNullException("newChild");
+                // throw new ArgumentNullException(nameof(newChild));
                 return null;
             }
 
@@ -426,7 +426,7 @@ namespace DocumentFormat.OpenXml
 
             if (index < 0 || index > this.ChildElements.Count)
             {
-                throw new ArgumentOutOfRangeException("index");
+                throw new ArgumentOutOfRangeException(nameof(index));
             }
             else if ( index == 0 )
             {
@@ -453,7 +453,7 @@ namespace DocumentFormat.OpenXml
         {
             if (newChild == null)
             {
-                //throw new ArgumentNullException("newChild");
+                //throw new ArgumentNullException(nameof(newChild));
                 return null;
             }
 
@@ -475,7 +475,7 @@ namespace DocumentFormat.OpenXml
         {
             if (oldChild == null)
             {
-                // throw new ArgumentNullException("oldChild");
+                // throw new ArgumentNullException(nameof(oldChild));
                 return null;
             }
 
@@ -559,13 +559,13 @@ namespace DocumentFormat.OpenXml
         {
             if (oldChild == null)
             {
-                //throw new ArgumentNullException("oldChild");
+                //throw new ArgumentNullException(nameof(oldChild));
                 return null;
             }
 
             if (newChild == null)
             {
-                throw new ArgumentNullException("newChild");
+                throw new ArgumentNullException(nameof(newChild));
             }
 
             if (oldChild.Parent != this)

--- a/DocumentFormat.OpenXml/src/Framework/OpenXmlElement.cs
+++ b/DocumentFormat.OpenXml/src/Framework/OpenXmlElement.cs
@@ -638,7 +638,7 @@ namespace DocumentFormat.OpenXml
         {
             if (localName == null)
             {
-                throw new ArgumentNullException("localName");
+                throw new ArgumentNullException(nameof(localName));
             }
 
             if (namespaceUri == null)
@@ -721,7 +721,7 @@ namespace DocumentFormat.OpenXml
         {
             if (attributes == null)
             {
-                throw new ArgumentNullException("attributes");
+                throw new ArgumentNullException(nameof(attributes));
             }
 
             if (this.HasAttributes)
@@ -832,7 +832,7 @@ namespace DocumentFormat.OpenXml
         {
             if (localName == null)
             {
-                throw new ArgumentNullException("localName");
+                throw new ArgumentNullException(nameof(localName));
             }
 
             if (namespaceUri == null)
@@ -897,7 +897,7 @@ namespace DocumentFormat.OpenXml
         {
             if (openXmlAttributes == null)
             {
-                throw new ArgumentNullException("openXmlAttributes");
+                throw new ArgumentNullException(nameof(openXmlAttributes));
             }
 
             foreach (OpenXmlAttribute attribute in openXmlAttributes)
@@ -937,11 +937,11 @@ namespace DocumentFormat.OpenXml
         {
             if (string.IsNullOrEmpty(prefix))
             {
-                throw new ArgumentNullException("prefix");
+                throw new ArgumentNullException(nameof(prefix));
             }
             if (string.IsNullOrEmpty(uri))
             {
-                throw new ArgumentNullException("uri");
+                throw new ArgumentNullException(nameof(uri));
             }
             MakeSureParsed();
             if (NamespaceDeclField == null)
@@ -967,7 +967,7 @@ namespace DocumentFormat.OpenXml
         {
             if (string.IsNullOrEmpty(prefix))
             {
-                throw new ArgumentNullException("prefix");
+                throw new ArgumentNullException(nameof(prefix));
             }
             MakeSureParsed();
             if (NamespaceDeclField != null)
@@ -1256,7 +1256,7 @@ namespace DocumentFormat.OpenXml
         {
             if (xmlWriter == null)
             {
-                throw new ArgumentNullException("xmlWriter");
+                throw new ArgumentNullException(nameof(xmlWriter));
             }
 
             if (this.XmlParsed)
@@ -1293,7 +1293,7 @@ namespace DocumentFormat.OpenXml
         {
             if (newChildren == null)
             {
-                throw new ArgumentNullException("newChildren");
+                throw new ArgumentNullException(nameof(newChildren));
             }
 
             foreach (OpenXmlElement child in newChildren)
@@ -1362,7 +1362,7 @@ namespace DocumentFormat.OpenXml
         {
             if (newElement == null)
             {
-                throw new ArgumentNullException("newElement");
+                throw new ArgumentNullException(nameof(newElement));
                 // TODO: should we just return null? InsertBefore / InsertAfter do not throw on null newChild.
                 // return null;
             }
@@ -1385,7 +1385,7 @@ namespace DocumentFormat.OpenXml
         {
             if (newElement == null)
             {
-                throw new ArgumentNullException("newElement");
+                throw new ArgumentNullException(nameof(newElement));
                 // TODO: should we just return null? InsertBefore / InsertAfter do not throw on null newChild.
                 // return null;
             }
@@ -1492,7 +1492,7 @@ namespace DocumentFormat.OpenXml
         {
             if (element == null)
             {
-                throw new ArgumentNullException("element");
+                throw new ArgumentNullException(nameof(element));
             }
 
             return (GetOrder(this, element) == ElementOrder.After);
@@ -1507,7 +1507,7 @@ namespace DocumentFormat.OpenXml
         {
             if (element == null)
             {
-                throw new ArgumentNullException("element");
+                throw new ArgumentNullException(nameof(element));
             }
 
             return (GetOrder(this, element) == ElementOrder.Before);
@@ -2326,7 +2326,7 @@ namespace DocumentFormat.OpenXml
         {
             if (annotation == null)
             {
-                throw new ArgumentNullException("annotation");
+                throw new ArgumentNullException(nameof(annotation));
             }
             if (this._annotations == null)
             {
@@ -2401,7 +2401,7 @@ namespace DocumentFormat.OpenXml
         {
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
 
             if (this._annotations != null)
@@ -2478,7 +2478,7 @@ namespace DocumentFormat.OpenXml
         {
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
 
             if (this._annotations != null)
@@ -2568,7 +2568,7 @@ namespace DocumentFormat.OpenXml
         {
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
             if (this._annotations != null)
             {
@@ -3117,7 +3117,7 @@ namespace DocumentFormat.OpenXml
         {
             if (prefix == null)
             {
-                throw new ArgumentNullException("prefix");
+                throw new ArgumentNullException(nameof(prefix));
             }
 
             // first, lookup whether the prefix is defined on itself and any ancestor elements.
@@ -3145,7 +3145,7 @@ namespace DocumentFormat.OpenXml
         {
             if (string.IsNullOrEmpty(namespaceUri))
             {
-                throw new ArgumentNullException("namespaceUri");
+                throw new ArgumentNullException(nameof(namespaceUri));
             }
 
             var node = this;

--- a/DocumentFormat.OpenXml/src/Framework/OpenXmlElementList.cs
+++ b/DocumentFormat.OpenXml/src/Framework/OpenXmlElementList.cs
@@ -147,7 +147,7 @@ namespace DocumentFormat.OpenXml
                 
             }            
             // return null;
-            throw new ArgumentOutOfRangeException("index");
+            throw new ArgumentOutOfRangeException(nameof(index));
         }
 
         public override int Count
@@ -190,7 +190,7 @@ namespace DocumentFormat.OpenXml
         
         public override OpenXmlElement GetItem(int index)
         {
-            throw new ArgumentOutOfRangeException("index");
+            throw new ArgumentOutOfRangeException(nameof(index));
         }
 
         public override int Count

--- a/DocumentFormat.OpenXml/src/Framework/OpenXmlNonElementNode.cs
+++ b/DocumentFormat.OpenXml/src/Framework/OpenXmlNonElementNode.cs
@@ -48,7 +48,7 @@ namespace DocumentFormat.OpenXml
                 case XmlNodeType.EntityReference:
                 case XmlNodeType.Notation: // not allowed when DtdProcessing = DtdProcessing.Prohibit
                 case XmlNodeType.None:
-                    throw new ArgumentOutOfRangeException("nodeType");
+                    throw new ArgumentOutOfRangeException(nameof(nodeType));
             }
 
             this.XmlNodeType = nodeType;
@@ -65,7 +65,7 @@ namespace DocumentFormat.OpenXml
         {
             if ( String.IsNullOrEmpty( outerXml ) )
             {
-                throw new ArgumentNullException("outerXml");
+                throw new ArgumentNullException(nameof(outerXml));
             }
             
             // check the out XML match the nodeType
@@ -284,7 +284,7 @@ namespace DocumentFormat.OpenXml
         {
             if (xmlWriter == null)
             {
-                throw new ArgumentNullException("xmlWriter");
+                throw new ArgumentNullException(nameof(xmlWriter));
             }
 
             // write out the raw xml

--- a/DocumentFormat.OpenXml/src/Framework/OpenXmlPackage.cs
+++ b/DocumentFormat.OpenXml/src/Framework/OpenXmlPackage.cs
@@ -158,7 +158,7 @@ namespace DocumentFormat.OpenXml.Packaging
             this.BasePackage = package;
             if (this.BasePackage == null)
             {
-                throw new ArgumentNullException("BasePackage");
+                throw new ArgumentNullException(nameof(BasePackage));
             }
 
             this.BasePackageRelationshipCollection = this.BasePackage.GetRelationships();
@@ -189,7 +189,7 @@ namespace DocumentFormat.OpenXml.Packaging
             this.BasePackagePart = packagePart;
             if (this.BasePackagePart == null)
             {
-                throw new ArgumentNullException("BasePackagePart");
+                throw new ArgumentNullException(nameof(BasePackagePart));
             }
 
             this.BasePackageRelationshipCollection = this.BasePackagePart.GetRelationships();
@@ -274,7 +274,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (package == null)
             {
-                throw new ArgumentNullException("package");
+                throw new ArgumentNullException(nameof(package));
             }
 
             if (package.FileOpenAccess == FileAccess.Write)
@@ -300,7 +300,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (package == null)
             {
-                throw new ArgumentNullException("package");
+                throw new ArgumentNullException(nameof(package));
             }
 
             //if (package.FileOpenAccess != FileAccess.Write)
@@ -323,7 +323,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (stream == null)
             {
-                throw new ArgumentNullException("stream");
+                throw new ArgumentNullException(nameof(stream));
             }
 
             if (readWriteMode)
@@ -349,7 +349,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (stream == null)
             {
-                throw new ArgumentNullException("stream");
+                throw new ArgumentNullException(nameof(stream));
             }
 
             if (!stream.CanWrite)
@@ -373,7 +373,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (path == null)
             {
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException(nameof(path));
             }
 
             if (readWriteMode)
@@ -398,7 +398,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (path == null)
             {
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException(nameof(path));
             }
 
             this._accessMode = FileAccess.ReadWrite;
@@ -586,7 +586,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (part == null)
             {
-                throw new ArgumentNullException("part");
+                throw new ArgumentNullException(nameof(part));
             }
 
             if (part.RelationshipType == this.MainPartRelationshipType &&
@@ -642,7 +642,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (contentType == null)
             {
-                throw new ArgumentNullException("contentType");
+                throw new ArgumentNullException(nameof(contentType));
             }
 
             MediaDataPart mediaDataPart = new MediaDataPart();
@@ -668,12 +668,12 @@ namespace DocumentFormat.OpenXml.Packaging
             
             if (contentType == null)
             {
-                throw new ArgumentNullException("contentType");
+                throw new ArgumentNullException(nameof(contentType));
             }
 
             if (extension == null)
             {
-                throw new ArgumentNullException("extension");
+                throw new ArgumentNullException(nameof(extension));
             }
 
             MediaDataPart mediaDataPart = new MediaDataPart();
@@ -715,7 +715,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (dataPart == null)
             {
-                throw new ArgumentNullException("dataPart");
+                throw new ArgumentNullException(nameof(dataPart));
             }
 
             if (dataPart.OpenXmlPackage != this)
@@ -1257,7 +1257,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (contentType == null)
             {
-                throw new ArgumentNullException("contentType");
+                throw new ArgumentNullException(nameof(contentType));
             }
 
             PartConstraintRule partConstraintRule;
@@ -1284,7 +1284,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
                 return child;
             }
-            throw new ArgumentOutOfRangeException("relationshipType");
+            throw new ArgumentOutOfRangeException(nameof(relationshipType));
         }
 
         internal sealed override OpenXmlPackage InternalOpenXmlPackage
@@ -1304,7 +1304,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (reachableParts == null)
             {
-                throw new ArgumentNullException("reachableParts");
+                throw new ArgumentNullException(nameof(reachableParts));
             }
 
             foreach (OpenXmlPart part in this.ChildrenParts.Values)
@@ -1622,7 +1622,7 @@ namespace DocumentFormat.OpenXml.Packaging
         public OpenXmlPackage Clone(Stream stream, bool isEditable, OpenSettings openSettings)
         {
             if (stream == null)
-                throw new ArgumentNullException("stream");
+                throw new ArgumentNullException(nameof(stream));
 
             // Use this OpenXml package's OpenSettings if none are provided.
             // This is more in line with cloning than providing the default
@@ -1717,7 +1717,7 @@ namespace DocumentFormat.OpenXml.Packaging
         public OpenXmlPackage Clone(string path, bool isEditable, OpenSettings openSettings)
         {
             if (path == null)
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException(nameof(path));
 
             // Use this OpenXml package's OpenSettings if none are provided.
             // This is more in line with cloning than providing the default
@@ -1788,7 +1788,7 @@ namespace DocumentFormat.OpenXml.Packaging
         public OpenXmlPackage Clone(Package package, OpenSettings openSettings)
         {
             if (package == null)
-                throw new ArgumentNullException("package");
+                throw new ArgumentNullException(nameof(package));
 
             // Use this OpenXml package's OpenSettings if none are provided.
             // This is more in line with cloning than providing the default

--- a/DocumentFormat.OpenXml/src/Framework/OpenXmlPartRootElement.cs
+++ b/DocumentFormat.OpenXml/src/Framework/OpenXmlPartRootElement.cs
@@ -51,7 +51,7 @@ namespace DocumentFormat.OpenXml
         {
             if (openXmlPart == null)
             {
-                throw new ArgumentNullException("openXmlPart");
+                throw new ArgumentNullException(nameof(openXmlPart));
             }
 
             this._elementContext = new OpenXmlElementContext();
@@ -201,7 +201,7 @@ namespace DocumentFormat.OpenXml
         {
             if (openXmlPart == null)
             {
-                throw new ArgumentNullException("openXmlPart");
+                throw new ArgumentNullException(nameof(openXmlPart));
             }
 
             XmlWriterSettings settings = new XmlWriterSettings();
@@ -321,7 +321,7 @@ namespace DocumentFormat.OpenXml
         {
             if (xmlWriter == null)
             {
-                throw new ArgumentNullException("xmlWriter");
+                throw new ArgumentNullException(nameof(xmlWriter));
             }
 
             if (this.XmlParsed)

--- a/DocumentFormat.OpenXml/src/Framework/OpenXmlReader.cs
+++ b/DocumentFormat.OpenXml/src/Framework/OpenXmlReader.cs
@@ -79,7 +79,7 @@ namespace DocumentFormat.OpenXml
         {
             if (baseReader == null)
             {
-                throw new ArgumentNullException("baseReader");
+                throw new ArgumentNullException(nameof(baseReader));
             }
 
             this._strictTranslation = strictTranslation;
@@ -915,7 +915,7 @@ namespace DocumentFormat.OpenXml
         {
             if (openXmlPart == null)
             {
-                throw new ArgumentNullException("openXmlPart");
+                throw new ArgumentNullException(nameof(openXmlPart));
             }
             Stream partStream = openXmlPart.GetStream(FileMode.Open);
             // set MaxCharactersInDocument to limit the part size on loading DOM.
@@ -933,7 +933,7 @@ namespace DocumentFormat.OpenXml
         {
             if (openXmlPart == null)
             {
-                throw new ArgumentNullException("openXmlPart");
+                throw new ArgumentNullException(nameof(openXmlPart));
             }
             // set MaxCharactersInDocument to limit the part size on loading DOM.
             this._elementContext.XmlReaderSettings.MaxCharactersInDocument = openXmlPart.MaxCharactersInPart;
@@ -949,7 +949,7 @@ namespace DocumentFormat.OpenXml
         {
             if (partStream == null)
             {
-                throw new ArgumentNullException("partStream");
+                throw new ArgumentNullException(nameof(partStream));
             }
 
             // we don't know the MaxCharactersInPart if only a stream is passed in.
@@ -966,7 +966,7 @@ namespace DocumentFormat.OpenXml
         {
             if (partStream == null)
             {
-                throw new ArgumentNullException("partStream");
+                throw new ArgumentNullException(nameof(partStream));
             }
             // we don't know the MaxCharactersInPart if only a stream is passed in.
             this.Init(partStream, /*closeInput*/false);
@@ -1906,7 +1906,7 @@ namespace DocumentFormat.OpenXml
         {
             if (openXmlElement == null)
             {
-                throw new ArgumentNullException("openXmlElement");
+                throw new ArgumentNullException(nameof(openXmlElement));
             }
 
             this.Init(openXmlElement);
@@ -1922,7 +1922,7 @@ namespace DocumentFormat.OpenXml
         {
             if (openXmlElement == null)
             {
-                throw new ArgumentNullException("openXmlElement");
+                throw new ArgumentNullException(nameof(openXmlElement));
             }
 
             this.Init(openXmlElement);

--- a/DocumentFormat.OpenXml/src/Framework/OpenXmlSimpleType.cs
+++ b/DocumentFormat.OpenXml/src/Framework/OpenXmlSimpleType.cs
@@ -36,7 +36,7 @@ namespace DocumentFormat.OpenXml
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
 
             this.TextValue = source.TextValue;
@@ -216,7 +216,7 @@ namespace DocumentFormat.OpenXml
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
 
             this.InnerText = source.InnerText;
@@ -338,7 +338,7 @@ namespace DocumentFormat.OpenXml
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
         }
 
@@ -484,7 +484,7 @@ namespace DocumentFormat.OpenXml
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
         }
          
@@ -642,7 +642,7 @@ namespace DocumentFormat.OpenXml
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
         }
 
@@ -795,7 +795,7 @@ namespace DocumentFormat.OpenXml
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
         }
 
@@ -947,7 +947,7 @@ namespace DocumentFormat.OpenXml
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
         }
 
@@ -1118,7 +1118,7 @@ namespace DocumentFormat.OpenXml
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
         }
 
@@ -1278,7 +1278,7 @@ namespace DocumentFormat.OpenXml
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
         }
 
@@ -1434,7 +1434,7 @@ namespace DocumentFormat.OpenXml
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
         }
 
@@ -1586,7 +1586,7 @@ namespace DocumentFormat.OpenXml
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
         }
 
@@ -1736,7 +1736,7 @@ namespace DocumentFormat.OpenXml
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
         }
 
@@ -1889,7 +1889,7 @@ namespace DocumentFormat.OpenXml
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
         }
 
@@ -2048,7 +2048,7 @@ namespace DocumentFormat.OpenXml
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
         }
 
@@ -2223,7 +2223,7 @@ namespace DocumentFormat.OpenXml
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
         }
 
@@ -2404,7 +2404,7 @@ namespace DocumentFormat.OpenXml
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
         }
 
@@ -2564,7 +2564,7 @@ namespace DocumentFormat.OpenXml
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
         }
 
@@ -2671,7 +2671,7 @@ namespace DocumentFormat.OpenXml
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
         }
 
@@ -2781,7 +2781,7 @@ namespace DocumentFormat.OpenXml
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
         }
 
@@ -2882,7 +2882,7 @@ namespace DocumentFormat.OpenXml
         {
             if (list == null)
             {
-                throw new ArgumentNullException("list");
+                throw new ArgumentNullException(nameof(list));
             }
 
             this._list =  new ObservableCollection<T>();
@@ -2903,7 +2903,7 @@ namespace DocumentFormat.OpenXml
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
         }
 
@@ -3139,7 +3139,7 @@ namespace DocumentFormat.OpenXml
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
             this._enumValue = source._enumValue;
         }
@@ -3622,7 +3622,7 @@ namespace DocumentFormat.OpenXml
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
 
             Initialize();
@@ -3813,7 +3813,7 @@ namespace DocumentFormat.OpenXml
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
             Initialize();
             _impl.InnerText = source.InnerText;
@@ -4009,7 +4009,7 @@ namespace DocumentFormat.OpenXml
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
             Initialize();
             _impl.InnerText = source.InnerText;
@@ -4130,7 +4130,7 @@ namespace DocumentFormat.OpenXml
         {
             if (xmlAttribute == null)
             {
-                throw new ArgumentNullException("xmlAttribute");
+                throw new ArgumentNullException(nameof(xmlAttribute));
             }
 
             return ToBoolean(xmlAttribute);

--- a/DocumentFormat.OpenXml/src/Framework/OpenXmlUnknownElement.cs
+++ b/DocumentFormat.OpenXml/src/Framework/OpenXmlUnknownElement.cs
@@ -48,7 +48,7 @@ namespace DocumentFormat.OpenXml
         {
             if (name == null)
             {
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
             }
 
             OpenXmlElement.SplitName(name, out this._prefix, out this._tagName);
@@ -67,7 +67,7 @@ namespace DocumentFormat.OpenXml
         {
             if (qualifiedName == null)
             {
-                throw new ArgumentNullException("qualifiedName");
+                throw new ArgumentNullException(nameof(qualifiedName));
             }
 
             OpenXmlElement.SplitName(qualifiedName, out this._prefix, out this._tagName);
@@ -88,7 +88,7 @@ namespace DocumentFormat.OpenXml
         {
             if (localName == null)
             {
-                throw new ArgumentNullException("localName");
+                throw new ArgumentNullException(nameof(localName));
             }
 
             if (prefix == null)
@@ -116,7 +116,7 @@ namespace DocumentFormat.OpenXml
         {
             if (String.IsNullOrEmpty(outerXml))
             {
-                throw new ArgumentNullException("outerXml");
+                throw new ArgumentNullException(nameof(outerXml));
             }
 
             TextReader stringReader = new StringReader(outerXml);
@@ -286,7 +286,7 @@ namespace DocumentFormat.OpenXml
         {
             if (xmlWriter == null)
             {
-                throw new ArgumentNullException("xmlWriter");
+                throw new ArgumentNullException(nameof(xmlWriter));
             }
 
             if (this.XmlParsed)

--- a/DocumentFormat.OpenXml/src/Framework/OpenXmlWriter.cs
+++ b/DocumentFormat.OpenXml/src/Framework/OpenXmlWriter.cs
@@ -229,12 +229,12 @@ namespace DocumentFormat.OpenXml
         {
             if (openXmlPart == null)
             {
-                throw new ArgumentNullException("openXmlPart");
+                throw new ArgumentNullException(nameof(openXmlPart));
             }
 
             if (encoding == null)
             {
-                throw new ArgumentNullException("encoding");
+                throw new ArgumentNullException(nameof(encoding));
             }
 
             Stream partStream = openXmlPart.GetStream(FileMode.Create);
@@ -259,12 +259,12 @@ namespace DocumentFormat.OpenXml
         {
             if (partStream == null)
             {
-                throw new ArgumentNullException("partStream");
+                throw new ArgumentNullException(nameof(partStream));
             }
 
             if (encoding == null)
             {
-                throw new ArgumentNullException("encoding");
+                throw new ArgumentNullException(nameof(encoding));
             }
 
             this.Init(partStream, /*closeOutput*/false, encoding);
@@ -323,18 +323,18 @@ namespace DocumentFormat.OpenXml
         {
             if (elementReader == null)
             {
-                throw new ArgumentNullException("elementReader");
+                throw new ArgumentNullException(nameof(elementReader));
             }
 
             if (elementReader.IsEndElement)
             {
-                throw new ArgumentOutOfRangeException("elementReader");
+                throw new ArgumentOutOfRangeException(nameof(elementReader));
             }
 
             if (elementReader.IsMiscNode)
             {
                 // OpenXmlMiscNode should be written by WriteElement( );
-                throw new ArgumentOutOfRangeException("elementReader");
+                throw new ArgumentOutOfRangeException(nameof(elementReader));
             }
 
             this.ThrowIfObjectDisposed();
@@ -376,12 +376,12 @@ namespace DocumentFormat.OpenXml
         {
             if (elementObject == null)
             {
-                throw new ArgumentNullException("elementObject");
+                throw new ArgumentNullException(nameof(elementObject));
             }
 
             if (elementObject is OpenXmlMiscNode)
             {
-                throw new ArgumentOutOfRangeException("elementObject");
+                throw new ArgumentOutOfRangeException(nameof(elementObject));
             }
 
             this.ThrowIfObjectDisposed();
@@ -427,12 +427,12 @@ namespace DocumentFormat.OpenXml
         {
             if (elementObject == null)
             {
-                throw new ArgumentNullException("elementObject");
+                throw new ArgumentNullException(nameof(elementObject));
             }
 
             if (elementObject is OpenXmlMiscNode)
             {
-                throw new ArgumentOutOfRangeException("elementObject");
+                throw new ArgumentOutOfRangeException(nameof(elementObject));
             }
 
             this.ThrowIfObjectDisposed();
@@ -506,7 +506,7 @@ namespace DocumentFormat.OpenXml
         {
             if (elementObject == null)
             {
-                throw new ArgumentNullException("elementObject");
+                throw new ArgumentNullException(nameof(elementObject));
             }
 
             this.ThrowIfObjectDisposed();

--- a/DocumentFormat.OpenXml/src/Framework/PartContainer.cs
+++ b/DocumentFormat.OpenXml/src/Framework/PartContainer.cs
@@ -90,7 +90,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (referenceRelationship == null)
             {
-                throw new ArgumentNullException("referenceRelationship");
+                throw new ArgumentNullException(nameof(referenceRelationship));
             }
 
             if (referenceRelationship.Id == null || referenceRelationship.Container != this)
@@ -122,7 +122,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (id == null)
             {
-                throw new ArgumentNullException("id");
+                throw new ArgumentNullException(nameof(id));
             }
 
             foreach (var referenceRelationship in this.ReferenceRelationshipList)
@@ -152,7 +152,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (id == null)
             {
-                throw new ArgumentNullException("id");
+                throw new ArgumentNullException(nameof(id));
             }
 
             foreach (var referenceRelatinship in this.ReferenceRelationshipList)
@@ -197,12 +197,12 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (relationshipType == null)
             {
-                throw new ArgumentNullException("relationshipType");
+                throw new ArgumentNullException(nameof(relationshipType));
             }
 
             if (externalUri == null)
             {
-                throw new ArgumentNullException("externalUri");
+                throw new ArgumentNullException(nameof(externalUri));
             }
 
             if (relationshipType == HyperlinkRelationship.RelationshipTypeConst)
@@ -234,17 +234,17 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (relationshipType == null)
             {
-                throw new ArgumentNullException("relationshipType");
+                throw new ArgumentNullException(nameof(relationshipType));
             }
 
             if (externalUri == null)
             {
-                throw new ArgumentNullException("externalUri");
+                throw new ArgumentNullException(nameof(externalUri));
             }
 
             if (id == null)
             {
-                throw new ArgumentNullException("id");
+                throw new ArgumentNullException(nameof(id));
             }
 
             if (relationshipType == HyperlinkRelationship.RelationshipTypeConst)
@@ -272,7 +272,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (externalRelationship == null)
             {
-                throw new ArgumentNullException("externalRelationship");
+                throw new ArgumentNullException(nameof(externalRelationship));
             }
 
             if (externalRelationship.Id == null || externalRelationship.Container != this)
@@ -302,7 +302,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (id == null)
             {
-                throw new ArgumentNullException("id");
+                throw new ArgumentNullException(nameof(id));
             }
 
             foreach (var externalRelationship in this.ReferenceRelationshipList.OfType<ExternalRelationship>())
@@ -330,7 +330,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (id == null)
             {
-                throw new ArgumentNullException("id");
+                throw new ArgumentNullException(nameof(id));
             }
 
             foreach (var externalRelationship in this.ReferenceRelationshipList.OfType<ExternalRelationship>())
@@ -373,7 +373,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (hyperlinkUri == null)
             {
-                throw new ArgumentNullException("hyperlinkUri");
+                throw new ArgumentNullException(nameof(hyperlinkUri));
             }
 
             TargetMode targetMode = isExternal ? TargetMode.External : TargetMode.Internal;
@@ -399,12 +399,12 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (hyperlinkUri == null)
             {
-                throw new ArgumentNullException("hyperlinkUri");
+                throw new ArgumentNullException(nameof(hyperlinkUri));
             }
 
             if (id == null)
             {
-                throw new ArgumentNullException("id");
+                throw new ArgumentNullException(nameof(id));
             }
 
             PackageRelationship relationship = this.CreateRelationship(hyperlinkUri, TargetMode.External, HyperlinkRelationship.RelationshipTypeConst, id);
@@ -445,7 +445,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (mediaDataPart == null)
             {
-                throw new ArgumentNullException("mediaDataPart");
+                throw new ArgumentNullException(nameof(mediaDataPart));
             }
 
             if (mediaDataPart.OpenXmlPackage != this.InternalOpenXmlPackage)
@@ -477,12 +477,12 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (mediaDataPart == null)
             {
-                throw new ArgumentNullException("mediaDataPart");
+                throw new ArgumentNullException(nameof(mediaDataPart));
             }
 
             if (id == null)
             {
-                throw new ArgumentNullException("id");
+                throw new ArgumentNullException(nameof(id));
             }
 
             if (mediaDataPart.OpenXmlPackage != this.InternalOpenXmlPackage)
@@ -509,7 +509,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (dataPartReferenceRelationship == null)
             {
-                throw new ArgumentNullException("dataPartReferenceRelationship");
+                throw new ArgumentNullException(nameof(dataPartReferenceRelationship));
             }
 
             var mediaDataPart = dataPartReferenceRelationship.DataPart;
@@ -551,7 +551,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (id == null)
             {
-                throw new ArgumentNullException("id");
+                throw new ArgumentNullException(nameof(id));
             }
 
             OpenXmlPart part = null;
@@ -563,7 +563,7 @@ namespace DocumentFormat.OpenXml.Packaging
             else
             {
                 // return null;
-                throw new ArgumentOutOfRangeException("id");
+                throw new ArgumentOutOfRangeException(nameof(id));
             }
         }
 
@@ -580,7 +580,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (part == null)
             {
-                throw new ArgumentNullException("part");
+                throw new ArgumentNullException(nameof(part));
             }
 
             if (this.PartDictionary.ContainsValue(part))
@@ -594,7 +594,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 }
             }
 
-            throw new ArgumentOutOfRangeException("part");
+            throw new ArgumentOutOfRangeException(nameof(part));
         }
 
         /// <summary>
@@ -612,12 +612,12 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (part == null)
             {
-                throw new ArgumentNullException("part");
+                throw new ArgumentNullException(nameof(part));
             }
 
             if (newRelationshipId == null)
             {
-                throw new ArgumentNullException("newRelationshipId");
+                throw new ArgumentNullException(nameof(newRelationshipId));
             }
 
             string oldId = null;
@@ -646,7 +646,7 @@ namespace DocumentFormat.OpenXml.Packaging
             if (oldId == null)
             {
                 // the part is not a sub part.
-                throw new ArgumentOutOfRangeException("part");
+                throw new ArgumentOutOfRangeException(nameof(part));
             }
 
             // Add a new relationship, and then remove the old relationship
@@ -691,7 +691,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (id == null)
             {
-                throw new ArgumentNullException("id");
+                throw new ArgumentNullException(nameof(id));
             }
             return (T)AddPartFrom(part, id);
         }
@@ -709,7 +709,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (targetPart == null)
             {
-                throw new ArgumentNullException("targetPart");
+                throw new ArgumentNullException(nameof(targetPart));
             }
             if (!IsInSamePackage(targetPart))
             {
@@ -737,11 +737,11 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (targetPart == null)
             {
-                throw new ArgumentNullException("targetPart");
+                throw new ArgumentNullException(nameof(targetPart));
             }
             if (id == null)
             {
-                throw new ArgumentNullException("id");
+                throw new ArgumentNullException(nameof(id));
             }
             if (!IsInSamePackage(targetPart))
             {
@@ -794,7 +794,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (contentType == null)
             {
-                throw new ArgumentNullException("contentType");
+                throw new ArgumentNullException(nameof(contentType));
             }
 
             return this.AddNewPartInternal<T>(contentType, id);
@@ -826,17 +826,17 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (relationshipType == null)
             {
-                throw new ArgumentNullException("relationshipType");
+                throw new ArgumentNullException(nameof(relationshipType));
             }
 
             if (contentType == null)
             {
-                throw new ArgumentNullException("contentType");
+                throw new ArgumentNullException(nameof(contentType));
             }
 
             if (targetExt == null)
             {
-                throw new ArgumentNullException("targetExt");
+                throw new ArgumentNullException(nameof(targetExt));
             }
 
             ExtendedPart child = new ExtendedPart(relationshipType);
@@ -863,7 +863,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (id == null)
             {
-                throw new ArgumentNullException("id");
+                throw new ArgumentNullException(nameof(id));
             }
 
             return DeletePartCore(id);
@@ -881,7 +881,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             //if (part == null)
             //{
-            //    throw new ArgumentNullException("part");
+            //    throw new ArgumentNullException(nameof(part));
             //}
             if (part == null)
             {
@@ -910,7 +910,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (partsToBeDeleted == null)
             {
-                throw new ArgumentNullException("partsToBeDeleted");
+                throw new ArgumentNullException(nameof(partsToBeDeleted));
             }
 
             StringCollection relationshipIds = new StringCollection();
@@ -962,7 +962,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (annotation == null)
             {
-                throw new ArgumentNullException("annotation");
+                throw new ArgumentNullException(nameof(annotation));
             }
             if (this._annotations == null)
             {
@@ -1037,7 +1037,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
 
             if (this._annotations != null)
@@ -1114,7 +1114,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
 
             if (this._annotations != null)
@@ -1204,7 +1204,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
             if (this._annotations != null)
             {
@@ -1285,7 +1285,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (partCollection == null)
             {
-                throw new ArgumentNullException("partCollection");
+                throw new ArgumentNullException(nameof(partCollection));
             }
 
             partCollection.Clear();
@@ -1428,7 +1428,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (contentType == null)
             {
-                throw new ArgumentNullException("contentType");
+                throw new ArgumentNullException(nameof(contentType));
             }
 
             if (contentType == string.Empty)
@@ -1452,7 +1452,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 // Invalid part (same relationship type, but wrong (is different to be expected )content type 
                 if (partConstraintRule.PartContentType != null && contentType != partConstraintRule.PartContentType)
                 {
-                    throw new ArgumentOutOfRangeException("newPart");
+                    throw new ArgumentOutOfRangeException(nameof(newPart));
                 }
 
                 newPart.CreateInternal(this.InternalOpenXmlPackage, this.ThisOpenXmlPart, contentType, null);
@@ -1476,7 +1476,7 @@ namespace DocumentFormat.OpenXml.Packaging
             //}
             else
             {
-                throw new ArgumentOutOfRangeException("newPart");
+                throw new ArgumentOutOfRangeException(nameof(newPart));
             }
         }
 
@@ -1495,7 +1495,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (subPart == null)
             {
-                throw new ArgumentNullException("subPart");
+                throw new ArgumentNullException(nameof(subPart));
             }
 
             if (subPart.OpenXmlPackage == this.InternalOpenXmlPackage)
@@ -1526,7 +1526,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 }
                 else
                 {
-                    //throw new ArgumentOutOfRangeException("subPart");                    
+                    //throw new ArgumentOutOfRangeException(nameof(subPart));                    
                     throw new InvalidOperationException(ExceptionMessages.AddedPartIsNotAllowed);
                 }
             }
@@ -1534,7 +1534,7 @@ namespace DocumentFormat.OpenXml.Packaging
             {
                 if (partConstraintRule.PartContentType != null && subPart.ContentType != partConstraintRule.PartContentType)
                 {
-                    //throw new ArgumentOutOfRangeException("subPart");                    
+                    //throw new ArgumentOutOfRangeException(nameof(subPart));                    
                     throw new InvalidOperationException(ExceptionMessages.AddedPartIsNotAllowed);
                 }
 
@@ -1569,7 +1569,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (part == null)
             {
-                throw new ArgumentNullException("part");
+                throw new ArgumentNullException(nameof(part));
             }
 
             // only one part has the same relationshipType allowed
@@ -1597,7 +1597,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (part == null)
             {
-                throw new ArgumentNullException("part");
+                throw new ArgumentNullException(nameof(part));
             }
 
             // check if part is shared
@@ -1637,7 +1637,7 @@ namespace DocumentFormat.OpenXml.Packaging
             {
                 if (rId == null)
                 {
-                    throw new ArgumentNullException("rId");
+                    throw new ArgumentNullException(nameof(rId));
                 }
             }
 
@@ -1947,7 +1947,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (relationshipType == null)
             {
-                throw new ArgumentNullException("relationshipType");
+                throw new ArgumentNullException(nameof(relationshipType));
             }
 
             // there should be only one part of this type
@@ -1979,12 +1979,12 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (part == null)
             {
-                throw new ArgumentNullException("part");
+                throw new ArgumentNullException(nameof(part));
             }
 
             if (part.OpenXmlPackage != this.InternalOpenXmlPackage)
             {
-                throw new ArgumentOutOfRangeException("part");
+                throw new ArgumentOutOfRangeException(nameof(part));
             }
 
             return this.PartDictionary.ContainsValue(part);
@@ -2001,7 +2001,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (relationshipType == null)
             {
-                throw new ArgumentNullException("relationshipType");
+                throw new ArgumentNullException(nameof(relationshipType));
             }
 
             OpenXmlPart part = null;
@@ -2400,7 +2400,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (relationshipType == null)
             {
-                throw new ArgumentNullException("relationshipType");
+                throw new ArgumentNullException(nameof(relationshipType));
             }
 
             OpenXmlPart openXmlPart = null;
@@ -2441,7 +2441,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (relationshipType == null)
             {
-                throw new ArgumentNullException("relationshipType");
+                throw new ArgumentNullException(nameof(relationshipType));
             }
             switch (relationshipType)
             {

--- a/DocumentFormat.OpenXml/src/Framework/PartExtensionProvider.cs
+++ b/DocumentFormat.OpenXml/src/Framework/PartExtensionProvider.cs
@@ -74,12 +74,12 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (contentType == null)
             {
-                throw new ArgumentNullException("contentType");
+                throw new ArgumentNullException(nameof(contentType));
             }
 
             if (partExtension == null)
             {
-                throw new ArgumentNullException("partExtension");
+                throw new ArgumentNullException(nameof(partExtension));
             }
 
             string existedPartExtension = null;

--- a/DocumentFormat.OpenXml/src/Framework/UnknownPart.cs
+++ b/DocumentFormat.OpenXml/src/Framework/UnknownPart.cs
@@ -119,7 +119,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (subPart == null)
             {
-                throw new ArgumentNullException("subPart");
+                throw new ArgumentNullException(nameof(subPart));
             }
 
             if (subPart.OpenXmlPackage == this.InternalOpenXmlPackage)
@@ -156,7 +156,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (contentType == null)
             {
-                throw new ArgumentNullException("contentType");
+                throw new ArgumentNullException(nameof(contentType));
             }
 
             if (contentType == string.Empty)

--- a/DocumentFormat.OpenXml/src/Framework/XmlDOMTextWriter.cs
+++ b/DocumentFormat.OpenXml/src/Framework/XmlDOMTextWriter.cs
@@ -29,7 +29,7 @@ namespace DocumentFormat.OpenXml
         {
             if (String.IsNullOrEmpty(localName))
             {
-                throw new ArgumentNullException("localName");
+                throw new ArgumentNullException(nameof(localName));
             }
 
             if (prefix == null)
@@ -50,7 +50,7 @@ namespace DocumentFormat.OpenXml
         {
             if (String.IsNullOrEmpty(localName))
             {
-                throw new ArgumentNullException("localName");
+                throw new ArgumentNullException(nameof(localName));
             }
 
             if (prefix == null)

--- a/DocumentFormat.OpenXml/src/ofapi/BinaryTypeEnums.cs
+++ b/DocumentFormat.OpenXml/src/ofapi/BinaryTypeEnums.cs
@@ -126,7 +126,7 @@ namespace DocumentFormat.OpenXml.Packaging
                     return "image/x-wmf";
 
                 default:
-                    throw new ArgumentOutOfRangeException("imageType");
+                    throw new ArgumentOutOfRangeException(nameof(imageType));
             }
         }
 
@@ -208,7 +208,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 case MailMergeRecipientDataPartType.MsWordMailMergeRecipientData:
                     return "application/vnd.ms-word.mailMergeRecipientData+xml";
                 default:
-                    throw new ArgumentOutOfRangeException("mailMergeRecipientDataPartType");
+                    throw new ArgumentOutOfRangeException(nameof(mailMergeRecipientDataPartType));
             }
         }
 
@@ -257,7 +257,7 @@ namespace DocumentFormat.OpenXml.Packaging
                     return "application/vnd.openxmlformats-officedocument.obfuscatedFont";
 
                 default:
-                    throw new ArgumentOutOfRangeException("fontType");
+                    throw new ArgumentOutOfRangeException(nameof(fontType));
             }
         }
 
@@ -313,7 +313,7 @@ namespace DocumentFormat.OpenXml.Packaging
                     return "application/xml";
 
                 default:
-                    throw new ArgumentOutOfRangeException("partType");
+                    throw new ArgumentOutOfRangeException(nameof(partType));
             }
         }
 
@@ -374,7 +374,7 @@ namespace DocumentFormat.OpenXml.Packaging
                     return "image/x-wmf";
 
                 default:
-                    throw new ArgumentOutOfRangeException("imageType");
+                    throw new ArgumentOutOfRangeException(nameof(imageType));
             }
         }
 
@@ -430,7 +430,7 @@ namespace DocumentFormat.OpenXml.Packaging
                     return "application/vnd.ms-office.activeX";
 
                 default:
-                    throw new ArgumentOutOfRangeException("controlType");
+                    throw new ArgumentOutOfRangeException(nameof(controlType));
             }
         }
 
@@ -475,7 +475,7 @@ namespace DocumentFormat.OpenXml.Packaging
                     return "application/vnd.ms-office.activeX";
 
                 default:
-                    throw new ArgumentOutOfRangeException("controlType");
+                    throw new ArgumentOutOfRangeException(nameof(controlType));
             }
         }
 
@@ -607,7 +607,7 @@ namespace DocumentFormat.OpenXml.Packaging
                     return "text/html";
 
                 default:
-                    throw new ArgumentOutOfRangeException("partType");
+                    throw new ArgumentOutOfRangeException(nameof(partType));
             }
         }
 
@@ -707,7 +707,7 @@ namespace DocumentFormat.OpenXml.Packaging
                     return "application/inkml+xml";
 
                 default:
-                    throw new ArgumentOutOfRangeException("partType");
+                    throw new ArgumentOutOfRangeException(nameof(partType));
             }
         }
 

--- a/DocumentFormat.OpenXml/src/ofapi/ExtensionMethods.cs
+++ b/DocumentFormat.OpenXml/src/ofapi/ExtensionMethods.cs
@@ -25,7 +25,7 @@ namespace DocumentFormat.OpenXml
         {
             if (element == null)
             {
-                throw new ArgumentNullException("element");
+                throw new ArgumentNullException(nameof(element));
             }
 
             if (element.Parent == null)
@@ -83,7 +83,7 @@ namespace DocumentFormat.OpenXml
         {
             if (element == null)
             {
-                throw new ArgumentNullException("element");
+                throw new ArgumentNullException(nameof(element));
             }
 
             OpenXmlPartRootElement partRootElement = element.GetPartRootElement();

--- a/DocumentFormat.OpenXml/src/ofapi/HelperPartialClass.cs
+++ b/DocumentFormat.OpenXml/src/ofapi/HelperPartialClass.cs
@@ -57,7 +57,7 @@ namespace DocumentFormat.OpenXml.Packaging
             set
             {
                 if (value == null)
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException(nameof(value));
                 SetDomTree(value);
             }
         }
@@ -113,7 +113,7 @@ namespace DocumentFormat.OpenXml.Packaging
             set
             {
                 if (value == null)
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException(nameof(value));
                 SetDomTree(value);
             }
         }

--- a/DocumentFormat.OpenXml/src/ofapi/PackageDocument.cs
+++ b/DocumentFormat.OpenXml/src/ofapi/PackageDocument.cs
@@ -193,7 +193,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (string.IsNullOrEmpty(path))
             {
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException(nameof(path));
             }
             WordprocessingDocument doc = new WordprocessingDocument();
             doc.DocumentType = type;
@@ -279,7 +279,7 @@ namespace DocumentFormat.OpenXml.Packaging
         public static WordprocessingDocument CreateFromTemplate(string path, bool isTemplateAttached)
         {
             if (path == null)
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException(nameof(path));
 
             // Check extensions as the template must have a valid Word Open XML extension.
             string extension = Path.GetExtension(path);
@@ -511,7 +511,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (relationshipType == null)
             {
-                throw new ArgumentNullException("relationshipType");
+                throw new ArgumentNullException(nameof(relationshipType));
             }
             switch (relationshipType)
             {
@@ -546,7 +546,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 case WebExTaskpanesPart.RelationshipTypeConstant:
                     return new WebExTaskpanesPart();
             }
-            throw new ArgumentOutOfRangeException("relationshipType");
+            throw new ArgumentOutOfRangeException(nameof(relationshipType));
         }
 
         /// <summary>
@@ -565,7 +565,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (contentType == null)
             {
-                throw new ArgumentNullException("contentType");
+                throw new ArgumentNullException(nameof(contentType));
             }
 
             if (typeof(MainDocumentPart).IsAssignableFrom(typeof(T)) && contentType != WordprocessingDocument.MainPartContentTypes[this._documentType])
@@ -889,9 +889,9 @@ namespace DocumentFormat.OpenXml.Packaging
         public static WordprocessingDocument FromFlatOpcDocument(XDocument document, Stream stream, bool isEditable)
         {
             if (document == null)
-                throw new ArgumentNullException("document");
+                throw new ArgumentNullException(nameof(document));
             if (stream == null)
-                throw new ArgumentNullException("stream");
+                throw new ArgumentNullException(nameof(stream));
 
             return WordprocessingDocument.Open(FromFlatOpcDocumentCore(document, stream), isEditable);
         }
@@ -907,9 +907,9 @@ namespace DocumentFormat.OpenXml.Packaging
         public static WordprocessingDocument FromFlatOpcDocument(XDocument document, string path, bool isEditable)
         {
             if (document == null)
-                throw new ArgumentNullException("document");
+                throw new ArgumentNullException(nameof(document));
             if (path == null)
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException(nameof(path));
 
             return WordprocessingDocument.Open(FromFlatOpcDocumentCore(document, path), isEditable);
         }
@@ -924,9 +924,9 @@ namespace DocumentFormat.OpenXml.Packaging
         public static WordprocessingDocument FromFlatOpcDocument(XDocument document, Package package)
         {
             if (document == null)
-                throw new ArgumentNullException("document");
+                throw new ArgumentNullException(nameof(document));
             if (package == null)
-                throw new ArgumentNullException("package");
+                throw new ArgumentNullException(nameof(package));
 
             return WordprocessingDocument.Open(FromFlatOpcDocumentCore(document, package));
         }
@@ -941,7 +941,7 @@ namespace DocumentFormat.OpenXml.Packaging
         public static WordprocessingDocument FromFlatOpcString(string text)
         {
             if (text == null)
-                throw new ArgumentNullException("text");
+                throw new ArgumentNullException(nameof(text));
 
             return FromFlatOpcDocument(XDocument.Parse(text), new MemoryStream(), true);
         }
@@ -957,9 +957,9 @@ namespace DocumentFormat.OpenXml.Packaging
         public static WordprocessingDocument FromFlatOpcString(string text, Stream stream, bool isEditable)
         {
             if (text == null)
-                throw new ArgumentNullException("text");
+                throw new ArgumentNullException(nameof(text));
             if (stream == null)
-                throw new ArgumentNullException("stream");
+                throw new ArgumentNullException(nameof(stream));
 
             return FromFlatOpcDocument(XDocument.Parse(text), stream, isEditable);
         }
@@ -975,9 +975,9 @@ namespace DocumentFormat.OpenXml.Packaging
         public static WordprocessingDocument FromFlatOpcString(string text, string path, bool isEditable)
         {
             if (text == null)
-                throw new ArgumentNullException("text");
+                throw new ArgumentNullException(nameof(text));
             if (path == null)
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException(nameof(path));
 
             return FromFlatOpcDocument(XDocument.Parse(text), path, isEditable);
         }
@@ -992,9 +992,9 @@ namespace DocumentFormat.OpenXml.Packaging
         public static WordprocessingDocument FromFlatOpcString(string text, Package package)
         {
             if (text == null)
-                throw new ArgumentNullException("text");
+                throw new ArgumentNullException(nameof(text));
             if (package == null)
-                throw new ArgumentNullException("package");
+                throw new ArgumentNullException(nameof(package));
 
             return FromFlatOpcDocument(XDocument.Parse(text), package);
         }
@@ -1186,7 +1186,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (string.IsNullOrEmpty(path))
             {
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException(nameof(path));
             }
             SpreadsheetDocument doc = new SpreadsheetDocument();
             doc.DocumentType = type;
@@ -1248,7 +1248,7 @@ namespace DocumentFormat.OpenXml.Packaging
         public static SpreadsheetDocument CreateFromTemplate(string path)
         {
             if (path == null)
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException(nameof(path));
 
             // Check extensions as the template must have a valid Word Open XML extension.
             string extension = Path.GetExtension(path);
@@ -1462,7 +1462,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (relationshipType == null)
             {
-                throw new ArgumentNullException("relationshipType");
+                throw new ArgumentNullException(nameof(relationshipType));
             }
             switch (relationshipType)
             {
@@ -1496,7 +1496,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 case WebExTaskpanesPart.RelationshipTypeConstant:
                     return new WebExTaskpanesPart();
             }
-            throw new ArgumentOutOfRangeException("relationshipType");
+            throw new ArgumentOutOfRangeException(nameof(relationshipType));
         }
 
         /// <summary>
@@ -1515,7 +1515,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (contentType == null)
             {
-                throw new ArgumentNullException("contentType");
+                throw new ArgumentNullException(nameof(contentType));
             }
 
             if (typeof(WorkbookPart).IsAssignableFrom(typeof(T)) && contentType != SpreadsheetDocument.MainPartContentTypes[this._documentType])
@@ -1838,9 +1838,9 @@ namespace DocumentFormat.OpenXml.Packaging
         public static SpreadsheetDocument FromFlatOpcDocument(XDocument document, Stream stream, bool isEditable)
         {
             if (document == null)
-                throw new ArgumentNullException("document");
+                throw new ArgumentNullException(nameof(document));
             if (stream == null)
-                throw new ArgumentNullException("stream");
+                throw new ArgumentNullException(nameof(stream));
 
             return SpreadsheetDocument.Open(FromFlatOpcDocumentCore(document, stream), true);
         }
@@ -1856,9 +1856,9 @@ namespace DocumentFormat.OpenXml.Packaging
         public static SpreadsheetDocument FromFlatOpcDocument(XDocument document, string path, bool isEditable)
         {
             if (document == null)
-                throw new ArgumentNullException("document");
+                throw new ArgumentNullException(nameof(document));
             if (path == null)
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException(nameof(path));
 
             return SpreadsheetDocument.Open(FromFlatOpcDocumentCore(document, path), isEditable);
         }
@@ -1873,9 +1873,9 @@ namespace DocumentFormat.OpenXml.Packaging
         public static SpreadsheetDocument FromFlatOpcDocument(XDocument document, Package package)
         {
             if (document == null)
-                throw new ArgumentNullException("document");
+                throw new ArgumentNullException(nameof(document));
             if (package == null)
-                throw new ArgumentNullException("package");
+                throw new ArgumentNullException(nameof(package));
 
             return SpreadsheetDocument.Open(FromFlatOpcDocumentCore(document, package));
         }
@@ -1890,7 +1890,7 @@ namespace DocumentFormat.OpenXml.Packaging
         public static SpreadsheetDocument FromFlatOpcString(string text)
         {
             if (text == null)
-                throw new ArgumentNullException("text");
+                throw new ArgumentNullException(nameof(text));
 
             return FromFlatOpcDocument(XDocument.Parse(text), new MemoryStream(), true);
         }
@@ -1906,9 +1906,9 @@ namespace DocumentFormat.OpenXml.Packaging
         public static SpreadsheetDocument FromFlatOpcString(string text, Stream stream, bool isEditable)
         {
             if (text == null)
-                throw new ArgumentNullException("text");
+                throw new ArgumentNullException(nameof(text));
             if (stream == null)
-                throw new ArgumentNullException("stream");
+                throw new ArgumentNullException(nameof(stream));
 
             return FromFlatOpcDocument(XDocument.Parse(text), stream, isEditable);
         }
@@ -1924,9 +1924,9 @@ namespace DocumentFormat.OpenXml.Packaging
         public static SpreadsheetDocument FromFlatOpcString(string text, string path, bool isEditable)
         {
             if (text == null)
-                throw new ArgumentNullException("text");
+                throw new ArgumentNullException(nameof(text));
             if (path == null)
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException(nameof(path));
 
             return FromFlatOpcDocument(XDocument.Parse(text), path, isEditable);
         }
@@ -1941,9 +1941,9 @@ namespace DocumentFormat.OpenXml.Packaging
         public static SpreadsheetDocument FromFlatOpcString(string text, Package package)
         {
             if (text == null)
-                throw new ArgumentNullException("text");
+                throw new ArgumentNullException(nameof(text));
             if (package == null)
-                throw new ArgumentNullException("package");
+                throw new ArgumentNullException(nameof(package));
 
             return FromFlatOpcDocument(XDocument.Parse(text), package);
         }
@@ -2194,7 +2194,7 @@ namespace DocumentFormat.OpenXml.Packaging
         public static PresentationDocument CreateFromTemplate(string path)
         {
             if (path == null)
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException(nameof(path));
 
             // Check extensions as the template must have a valid Word Open XML extension.
             string extension = Path.GetExtension(path);
@@ -2410,7 +2410,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (relationshipType == null)
             {
-                throw new ArgumentNullException("relationshipType");
+                throw new ArgumentNullException(nameof(relationshipType));
             }
             switch (relationshipType)
             {
@@ -2444,7 +2444,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 case WebExTaskpanesPart.RelationshipTypeConstant:
                     return new WebExTaskpanesPart();
             }
-            throw new ArgumentOutOfRangeException("relationshipType");
+            throw new ArgumentOutOfRangeException(nameof(relationshipType));
         }
 
 
@@ -2543,7 +2543,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             if (contentType == null)
             {
-                throw new ArgumentNullException("contentType");
+                throw new ArgumentNullException(nameof(contentType));
             }
 
             if (typeof(PresentationPart).IsAssignableFrom(typeof(T)) && contentType != PresentationDocument.MainPartContentTypes[this._documentType])
@@ -2793,9 +2793,9 @@ namespace DocumentFormat.OpenXml.Packaging
         public static PresentationDocument FromFlatOpcDocument(XDocument document, Stream stream, bool isEditable)
         {
             if (document == null)
-                throw new ArgumentNullException("document");
+                throw new ArgumentNullException(nameof(document));
             if (stream == null)
-                throw new ArgumentNullException("stream");
+                throw new ArgumentNullException(nameof(stream));
 
             return PresentationDocument.Open(FromFlatOpcDocumentCore(document, stream), isEditable);
         }
@@ -2811,9 +2811,9 @@ namespace DocumentFormat.OpenXml.Packaging
         public static PresentationDocument FromFlatOpcDocument(XDocument document, string path, bool isEditable)
         {
             if (document == null)
-                throw new ArgumentNullException("document");
+                throw new ArgumentNullException(nameof(document));
             if (path == null)
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException(nameof(path));
 
             return PresentationDocument.Open(FromFlatOpcDocumentCore(document, path), isEditable);
         }
@@ -2828,9 +2828,9 @@ namespace DocumentFormat.OpenXml.Packaging
         public static PresentationDocument FromFlatOpcDocument(XDocument document, Package package)
         {
             if (document == null)
-                throw new ArgumentNullException("document");
+                throw new ArgumentNullException(nameof(document));
             if (package == null)
-                throw new ArgumentNullException("package");
+                throw new ArgumentNullException(nameof(package));
 
             return PresentationDocument.Open(FromFlatOpcDocumentCore(document, package));
         }
@@ -2845,7 +2845,7 @@ namespace DocumentFormat.OpenXml.Packaging
         public static PresentationDocument FromFlatOpcString(string text)
         {
             if (text == null)
-                throw new ArgumentNullException("text");
+                throw new ArgumentNullException(nameof(text));
 
             return FromFlatOpcDocument(XDocument.Parse(text), new MemoryStream(), true);
         }
@@ -2861,9 +2861,9 @@ namespace DocumentFormat.OpenXml.Packaging
         public static PresentationDocument FromFlatOpcString(string text, Stream stream, bool isEditable)
         {
             if (text == null)
-                throw new ArgumentNullException("text");
+                throw new ArgumentNullException(nameof(text));
             if (stream == null)
-                throw new ArgumentNullException("stream");
+                throw new ArgumentNullException(nameof(stream));
 
             return FromFlatOpcDocument(XDocument.Parse(text), stream, isEditable);
         }
@@ -2879,9 +2879,9 @@ namespace DocumentFormat.OpenXml.Packaging
         public static PresentationDocument FromFlatOpcString(string text, string path, bool isEditable)
         {
             if (text == null)
-                throw new ArgumentNullException("text");
+                throw new ArgumentNullException(nameof(text));
             if (path == null)
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException(nameof(path));
 
             return FromFlatOpcDocument(XDocument.Parse(text), path, isEditable);
         }
@@ -2896,9 +2896,9 @@ namespace DocumentFormat.OpenXml.Packaging
         public static PresentationDocument FromFlatOpcString(string text, Package package)
         {
             if (text == null)
-                throw new ArgumentNullException("text");
+                throw new ArgumentNullException(nameof(text));
             if (package == null)
-                throw new ArgumentNullException("package");
+                throw new ArgumentNullException(nameof(package));
 
             return FromFlatOpcDocument(XDocument.Parse(text), package);
         }

--- a/DocumentFormat.OpenXml/src/ofapi/SchemaInfoAttribute.cs
+++ b/DocumentFormat.OpenXml/src/ofapi/SchemaInfoAttribute.cs
@@ -26,7 +26,7 @@ namespace DocumentFormat.OpenXml
         {
             if (string.IsNullOrEmpty(tag))
             {
-                throw new ArgumentNullException("tag");
+                throw new ArgumentNullException(nameof(tag));
             }
 
             _nsId = nsId;

--- a/DocumentFormat.OpenXml/src/ofapi/Sources1.cs
+++ b/DocumentFormat.OpenXml/src/ofapi/Sources1.cs
@@ -505,7 +505,7 @@ namespace DocumentFormat.OpenXml.Packaging
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException(nameof(value));
                 }
                 if (this.MailMergeRecipients != null)
                 {
@@ -530,7 +530,7 @@ namespace DocumentFormat.OpenXml.Packaging
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException(nameof(value));
                 }
                 if (this.Recipients != null)
                 {

--- a/DocumentFormat.OpenXml/src/ofapi/Validation/OpenXmlValidator.cs
+++ b/DocumentFormat.OpenXml/src/ofapi/Validation/OpenXmlValidator.cs
@@ -214,7 +214,7 @@ namespace DocumentFormat.OpenXml.Validation
             {
                 if (value < 0)
                 {
-                    throw new ArgumentOutOfRangeException("value");
+                    throw new ArgumentOutOfRangeException(nameof(value));
                 }
 
                 this._settings.MaxNumberOfErrors = value;
@@ -235,7 +235,7 @@ namespace DocumentFormat.OpenXml.Validation
         {
             if (openXmlPackage == null)
             {
-                throw new ArgumentNullException("openXmlPackage");
+                throw new ArgumentNullException(nameof(openXmlPackage));
             }
 
             if (openXmlPackage.OpenSettings.MarkupCompatibilityProcessSettings.ProcessMode != MarkupCompatibilityProcessMode.NoProcess &&
@@ -285,7 +285,7 @@ namespace DocumentFormat.OpenXml.Validation
         {
             if (openXmlPart == null)
             {
-                throw new ArgumentNullException("openXmlPart");
+                throw new ArgumentNullException(nameof(openXmlPart));
             }
 
             var openXmlPackage = openXmlPart.OpenXmlPackage;
@@ -373,7 +373,7 @@ namespace DocumentFormat.OpenXml.Validation
         {
             if (openXmlElement == null)
             {
-                throw new ArgumentNullException("openXmlElement");
+                throw new ArgumentNullException(nameof(openXmlElement));
             }
 
             if (openXmlElement is OpenXmlUnknownElement)

--- a/DocumentFormat.OpenXml/src/ofapi/Validation/SchemaValidation/BinDataTypes.cs
+++ b/DocumentFormat.OpenXml/src/ofapi/Validation/SchemaValidation/BinDataTypes.cs
@@ -538,7 +538,7 @@ namespace DocumentFormat.OpenXml.Internal.SchemaValidation
         {
             if (index >= SdbData.MaxSdbIndex)
             {
-                throw new ArgumentOutOfRangeException("index");
+                throw new ArgumentOutOfRangeException(nameof(index));
             }
              
             this.ParticleIndex = (SdbIndex)index;

--- a/DocumentFormat.OpenXml/src/ofapi/Validation/SchemaValidation/SimpleTypes.cs
+++ b/DocumentFormat.OpenXml/src/ofapi/Validation/SchemaValidation/SimpleTypes.cs
@@ -227,10 +227,10 @@ namespace DocumentFormat.OpenXml.Internal.SchemaValidation
                 //return "OnOffValue":
 
                 default:
-                    throw new ArgumentOutOfRangeException("xsdType");
+                    throw new ArgumentOutOfRangeException(nameof(xsdType));
             }
 
-            throw new ArgumentOutOfRangeException("xsdType");;
+            throw new ArgumentOutOfRangeException(nameof(xsdType));;
         }
     }
 

--- a/DocumentFormat.OpenXml/src/ofapi/Validation/XmlPath.cs
+++ b/DocumentFormat.OpenXml/src/ofapi/Validation/XmlPath.cs
@@ -64,7 +64,7 @@ namespace DocumentFormat.OpenXml
             if (element == null)
             {
                 return null;
-                // throw new ArgumentNullException("element");
+                // throw new ArgumentNullException(nameof(element));
             }
 
             XmlPath xmlPath = new XmlPath();


### PR DESCRIPTION
- The changes were done in DocumentFormat.OpenXml project
- Simple replacement for basic scenarios like throwing an exception
- No logic code change
