### PR TITLE
Update XmlDOMTextWriter to derive from XmlWriter

### DIFF
--- a/DocumentFormat.OpenXml/src/Framework/OpenXmlCompositeElement.cs
+++ b/DocumentFormat.OpenXml/src/Framework/OpenXmlCompositeElement.cs
@@ -203,7 +203,7 @@ namespace DocumentFormat.OpenXml
                     // because XmlReader can not be created on InnerXml ( InnerXml may have several root elements ).
 
                     StringWriter w = new StringWriter(CultureInfo.InvariantCulture);
-                    XmlTextWriter writer2 = new XmlDOMTextWriter(w);
+                    XmlWriter writer2 = new XmlDOMTextWriter(w);
                     try
                     {
                         writer2.WriteStartElement(this.Prefix, this.LocalName, this.NamespaceUri);

--- a/DocumentFormat.OpenXml/src/Framework/OpenXmlCompositeElement.cs
+++ b/DocumentFormat.OpenXml/src/Framework/OpenXmlCompositeElement.cs
@@ -202,36 +202,33 @@ namespace DocumentFormat.OpenXml
                     // create an outer XML by wrapping the InnerXml with this element.
                     // because XmlReader can not be created on InnerXml ( InnerXml may have several root elements ).
 
-                    StringWriter w = new StringWriter(CultureInfo.InvariantCulture);
-                    XmlWriter writer2 = new XmlDOMTextWriter(w);
-                    try
+                    using (StringWriter w = new StringWriter(CultureInfo.InvariantCulture))
                     {
-                        writer2.WriteStartElement(this.Prefix, this.LocalName, this.NamespaceUri);
-                        writer2.WriteRaw(value);
-                        writer2.WriteEndElement();
-                    }
-                    finally
-                    {
-                        writer2.Close();
-                    }
+                        using (XmlWriter writer2 = new XmlDOMTextWriter(w))
+                        {
+                            writer2.WriteStartElement(this.Prefix, this.LocalName, this.NamespaceUri);
+                            writer2.WriteRaw(value);
+                            writer2.WriteEndElement();
+                        }
 
-                    // create a temp element to parse the xml.
-                    OpenXmlElement newElement = this.CloneNode(false);
-                    newElement.OuterXml = w.ToString();
+                        // create a temp element to parse the xml.
+                        OpenXmlElement newElement = this.CloneNode(false);
+                        newElement.OuterXml = w.ToString();
 
-                    OpenXmlElement child = newElement.FirstChild;
-                    OpenXmlElement next = null;
+                        OpenXmlElement child = newElement.FirstChild;
+                        OpenXmlElement next = null;
 
-                    // then move all children to this element.
-                    while (child != null)
-                    {
-                        next = child.NextSibling();
+                        // then move all children to this element.
+                        while (child != null)
+                        {
+                            next = child.NextSibling();
 
-                        child = newElement.RemoveChild(child);
+                            child = newElement.RemoveChild(child);
 
-                        this.AppendChild(child);
+                            this.AppendChild(child);
 
-                        child = next;
+                            child = next;
+                        }
                     }
                 }
             }

--- a/DocumentFormat.OpenXml/src/Framework/OpenXmlElement.cs
+++ b/DocumentFormat.OpenXml/src/Framework/OpenXmlElement.cs
@@ -563,7 +563,7 @@ namespace DocumentFormat.OpenXml
                 {
                     // namespace, this element and attributes
                     StringWriter w = new StringWriter(CultureInfo.InvariantCulture);
-                    XmlTextWriter writer2 = new XmlDOMTextWriter(w);
+                    XmlWriter writer2 = new XmlDOMTextWriter(w);
                     try
                     {
                         this.WriteTo(writer2);

--- a/DocumentFormat.OpenXml/src/Framework/OpenXmlElement.cs
+++ b/DocumentFormat.OpenXml/src/Framework/OpenXmlElement.cs
@@ -524,17 +524,14 @@ namespace DocumentFormat.OpenXml
             {
                 if (this.XmlParsed)
                 {
-                    StringWriter w = new StringWriter(CultureInfo.InvariantCulture);
-                    XmlDOMTextWriter writer2 = new XmlDOMTextWriter(w);
-                    try
+                    using (StringWriter w = new StringWriter(CultureInfo.InvariantCulture))
                     {
-                        this.WriteContentTo(writer2);
+                        using (XmlDOMTextWriter writer2 = new XmlDOMTextWriter(w))
+                        {
+                            this.WriteContentTo(writer2);
+                        }
+                        return w.ToString();
                     }
-                    finally
-                    {
-                        writer2.Close();
-                    }
-                    return w.ToString();
                 }
                 else
                 {
@@ -562,17 +559,14 @@ namespace DocumentFormat.OpenXml
                 if (this.XmlParsed)
                 {
                     // namespace, this element and attributes
-                    StringWriter w = new StringWriter(CultureInfo.InvariantCulture);
-                    XmlWriter writer2 = new XmlDOMTextWriter(w);
-                    try
+                    using (StringWriter w = new StringWriter(CultureInfo.InvariantCulture))
                     {
-                        this.WriteTo(writer2);
+                        using (XmlDOMTextWriter writer2 = new XmlDOMTextWriter(w))
+                        {
+                            this.WriteTo(writer2);
+                        }
+                        return w.ToString();
                     }
-                    finally
-                    {
-                        writer2.Close();
-                    }
-                    return w.ToString();
                 }
                 else
                 {

--- a/DocumentFormat.OpenXml/src/Framework/OpenXmlLeafTextElement.cs
+++ b/DocumentFormat.OpenXml/src/Framework/OpenXmlLeafTextElement.cs
@@ -101,17 +101,14 @@ namespace DocumentFormat.OpenXml
                 }
                 else
                 {
-                    StringWriter w = new StringWriter(CultureInfo.InvariantCulture);
-                    XmlDOMTextWriter writer2 = new XmlDOMTextWriter(w);
-                    try
+                    using (StringWriter w = new StringWriter(CultureInfo.InvariantCulture))
                     {
-                        this.WriteContentTo(writer2);
+                        using (XmlDOMTextWriter writer2 = new XmlDOMTextWriter(w))
+                        {
+                            this.WriteContentTo(writer2);
+                        }
+                        return w.ToString();
                     }
-                    finally
-                    {
-                        writer2.Close();
-                    }
-                    return w.ToString();
                 }
             }
 

--- a/DocumentFormat.OpenXml/src/Framework/OpenXmlNonElementNode.cs
+++ b/DocumentFormat.OpenXml/src/Framework/OpenXmlNonElementNode.cs
@@ -76,13 +76,11 @@ namespace DocumentFormat.OpenXml
                 using (XmlReader xmlReader = XmlConvertingReaderFactory.Create(stringReader, settings))
                 {
                     xmlReader.Read();
-                
+
                     if (xmlReader.NodeType != nodeType)
                     {
                         throw new ArgumentException(ExceptionMessages.InvalidOuterXmlForMiscNode);
                     }
-
-                    xmlReader.Close();
                 }
             }
 
@@ -151,7 +149,6 @@ namespace DocumentFormat.OpenXml
                             {
                                 xmlReader.Read();
                                 localName = xmlReader.LocalName;
-                                xmlReader.Close();
                             }
                         }
                         break;

--- a/DocumentFormat.OpenXml/src/Framework/OpenXmlReader.cs
+++ b/DocumentFormat.OpenXml/src/Framework/OpenXmlReader.cs
@@ -112,7 +112,7 @@ namespace DocumentFormat.OpenXml
                 this.Close();
             }
 
-            ((IDisposable)this.BaseReader).Dispose();
+            this.BaseReader.Dispose();
         }
 
         /// <summary>
@@ -1630,7 +1630,6 @@ namespace DocumentFormat.OpenXml
             this._elementStack.Clear();
             this._xmlReader.Close();
         }
-
 
         #region private methods
 

--- a/DocumentFormat.OpenXml/src/Framework/XmlDOMTextWriter.cs
+++ b/DocumentFormat.OpenXml/src/Framework/XmlDOMTextWriter.cs
@@ -1,35 +1,65 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.IO;
 using System.Xml;
 
 namespace DocumentFormat.OpenXml
 {
-    internal class XmlDOMTextWriter : XmlTextWriter
+    internal class XmlDOMTextWriter : XmlWriter
     {
-        // Methods
+        private readonly XmlWriter _writer;
+
         public XmlDOMTextWriter(TextWriter w)
-            : base(w)
         {
+            var xwSettings = new XmlWriterSettings
+            {
+                Encoding = w.Encoding,
+                OmitXmlDeclaration = true,
+                ConformanceLevel = ConformanceLevel.Fragment
+            };
+
+            _writer = Create(w, xwSettings);
         }
 
-        public XmlDOMTextWriter(Stream w, Encoding encoding)
-            : base(w, encoding)
-        {
-        }
+        public override WriteState WriteState => _writer.WriteState;
 
-        public XmlDOMTextWriter(string filename, Encoding encoding)
-            : base(filename, encoding)
-        {
-        }
+        public override void Flush() => _writer.Flush();
+
+        public override string LookupPrefix(string ns) => _writer.LookupPrefix(ns);
+
+        public override void WriteBase64(byte[] buffer, int index, int count) => _writer.WriteBase64(buffer, index, count);
+
+        public override void WriteCData(string text) => _writer.WriteCData(text);
+
+        public override void WriteCharEntity(char ch) => _writer.WriteCharEntity(ch);
+
+        public override void WriteChars(char[] buffer, int index, int count) => _writer.WriteChars(buffer, index, count);
+
+        public override void WriteComment(string text) => _writer.WriteComment(text);
+
+        public override void WriteDocType(string name, string pubid, string sysid, string subset) => _writer.WriteDocType(name, pubid, sysid, subset);
+
+        public override void WriteEndAttribute() => _writer.WriteEndAttribute();
+
+        public override void WriteEndDocument() => _writer.WriteEndDocument();
+
+        public override void WriteEndElement() => _writer.WriteEndElement();
+
+        public override void WriteEntityRef(string name) => _writer.WriteEntityRef(name);
+
+        public override void WriteFullEndElement() => _writer.WriteFullEndElement();
+
+        public override void WriteProcessingInstruction(string name, string text) => _writer.WriteProcessingInstruction(name, text);
+
+        public override void WriteRaw(string data) => _writer.WriteRaw(data);
+
+        public override void WriteRaw(char[] buffer, int index, int count) => _writer.WriteRaw(buffer, index, count);
 
         public override void WriteStartAttribute(string prefix, string localName, string ns)
         {
-            if (String.IsNullOrEmpty(localName))
+            if (string.IsNullOrEmpty(localName))
             {
-                throw new ArgumentNullException("localName");
+                throw new ArgumentNullException(nameof(localName));
             }
 
             if (prefix == null)
@@ -43,14 +73,18 @@ namespace DocumentFormat.OpenXml
                 prefix = string.Empty;
             }
 
-            base.WriteStartAttribute(prefix, localName, ns);
+            _writer.WriteStartAttribute(prefix, localName, ns);
         }
+
+        public override void WriteStartDocument() => _writer.WriteStartDocument();
+
+        public override void WriteStartDocument(bool standalone) => _writer.WriteStartDocument(standalone);
 
         public override void WriteStartElement(string prefix, string localName, string ns)
         {
-            if (String.IsNullOrEmpty(localName))
+            if (string.IsNullOrEmpty(localName))
             {
-                throw new ArgumentNullException("localName");
+                throw new ArgumentNullException(nameof(localName));
             }
 
             if (prefix == null)
@@ -63,7 +97,36 @@ namespace DocumentFormat.OpenXml
             {
                 prefix = string.Empty;
             }
-            base.WriteStartElement(prefix, localName, ns);
+
+            _writer.WriteStartElement(prefix, localName, ns);
+        }
+
+        public override void WriteString(string text)
+        {
+            if (!string.IsNullOrEmpty(text))
+            {
+                _writer.WriteString(text);
+            }
+        }
+
+        public override void WriteSurrogateCharEntity(char lowChar, char highChar) => _writer.WriteSurrogateCharEntity(lowChar, highChar);
+
+        public override void WriteWhitespace(string ws) => _writer.WriteWhitespace(ws);
+
+        public override XmlWriterSettings Settings => _writer.Settings;
+
+        public override string XmlLang => _writer.XmlLang;
+
+        public override XmlSpace XmlSpace => _writer.XmlSpace;
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                _writer.Dispose();
+            }
         }
     }
 }


### PR DESCRIPTION
.NET Standard does not expose XmlTextWriter, so this change mimics the
behavior of deriving from XmlWriter instead of XmlTextWriter

This is a part of #111

@tomjebo 