### PR TITLE
Fix binary formatter to deserialize internal types correctly

### DIFF
--- a/DocumentFormat.OpenXml/src/ofapi/Validation/SchemaValidation/SimpleTypes.cs
+++ b/DocumentFormat.OpenXml/src/ofapi/Validation/SchemaValidation/SimpleTypes.cs
@@ -305,14 +305,41 @@ namespace DocumentFormat.OpenXml.Internal.SchemaValidation
         /// <returns></returns>
         internal static SimpleTypeRestrictions Deserialize(Stream stream, FileFormatVersions fileFormat)
         {
-            BinaryFormatter binaryFormatter = new BinaryFormatter();
-            binaryFormatter.AssemblyFormat = System.Runtime.Serialization.Formatters.FormatterAssemblyStyle.Full;
+            var binaryFormatter = new BinaryFormatter
+            {
+                AssemblyFormat = System.Runtime.Serialization.Formatters.FormatterAssemblyStyle.Full,
+                Binder = new DocumentFormatBinder()
+            };
+
             var simpleTypeRestrictions = (SimpleTypeRestrictions)(binaryFormatter.Deserialize(stream));
             foreach (var simpleType in simpleTypeRestrictions.SimpleTypes)
             {
                 simpleType.FileFormat = fileFormat;
             }
             return simpleTypeRestrictions;
+        }
+
+        /// <summary>
+        /// The validation data is contained in a binary file that was generated with an older, non-signed version of the library.
+        /// Deserialization will fail without this binder, which redirects any attempt at loading the old type to the new type
+        /// </summary>
+        private sealed class DocumentFormatBinder : System.Runtime.Serialization.SerializationBinder
+        {
+            private const string FullStrongName = "DocumentFormat.OpenXml, Version=2.6.0.0, Culture=neutral, PublicKeyToken=null";
+
+            private static readonly System.Reflection.Assembly s_assembly = typeof(DocumentFormatBinder).Assembly;
+
+            public override Type BindToType(string assemblyName, string typeName)
+            {
+                if (string.Equals(assemblyName, FullStrongName, StringComparison.Ordinal))
+                {
+                    return s_assembly.GetType(typeName);
+                }
+                else
+                {
+                    return null;
+                }
+            }
         }
 #endif
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ We are also happy to announce the release of Open-Xml-PowerTools on GitHub.  Ope
 Change Log
 ==========
 
+Version 2.7.1 : January 31, 2017
+- Fixed crash when validation is invoked on .NET Framework with strong-naming enforced
+
 Version 2.7.0 : January 24, 2017
 - Added support for .NET Standard 1.3
 - Moved to using System.IO.Packaging from dotnet/corefx for .NET Standard 1.3 and WindowsBase for .NET 4.5


### PR DESCRIPTION
The binary file was created with a 2.6.0 version of the library with no strong name. If Validate is called without this fix, there is a deserialization exception that will cause a crash. By redirecting the binding, we can force the deserialization to load internal types from the current instance of the assembly and don't need to worry about any later version causing a binding failure.

Fixes #159 