### PR TITLE
Exclude symbols from signing and artifacts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,10 +21,6 @@ after_build:
 test_script:
   - cmd: dotnet test -c Release .\DocumentFormat.OpenXml.Tests
 
-artifacts:
-  - path: '*.nupkg'
-    name: NuGetArtifacts
-
 deploy:
   provider: NuGet
   server: https://dotnet.myget.org/F/open-xml-sdk/api/v2/package

--- a/build/SignPackage.ps1
+++ b/build/SignPackage.ps1
@@ -1,24 +1,24 @@
 $currentDirectory = split-path $MyInvocation.MyCommand.Definition
 
-# See if we have the ClientSecret available
-if([string]::IsNullOrEmpty($env:SignClientSecret)){
-    Write-Host "Client Secret not found, not signing packages"
-    return;
-}
-
 # Setup Variables we need to pass into the sign client tool
-
 $appSettings = "$currentDirectory\SignClientSettings.json"
 $appPath = "$currentDirectory\SignClient\tools\SignClient.dll"
 
-$nupgks = ls $currentDirectory\..\*.nupkg | Select -ExpandProperty FullName
+$nupgks = ls $currentDirectory\..\*.nupkg `
+    | Where Name -NotMatch symbols `
+    | Select -ExpandProperty FullName
 
 foreach ($nupkg in $nupgks){
-    Write-Host "Submitting $nupkg for signing"
+    # See if we have the ClientSecret available
+    if(![string]::IsNullOrEmpty($env:SignClientSecret)){
+         Write-Host "Submitting $nupkg for signing"
 
-    dotnet $appPath 'zip' -c $appSettings -i $nupkg -s $env:SignClientSecret -n 'DocumentFormat.OpenXML' -d 'DocumentFormat.OpenXML' -u 'https://github.com/OfficeDev/Open-XML-SDK' 
+        dotnet $appPath 'zip' -c $appSettings -i $nupkg -s $env:SignClientSecret -n 'DocumentFormat.OpenXML' -d 'DocumentFormat.OpenXML' -u 'https://github.com/OfficeDev/Open-XML-SDK' 
 
-    Write-Host "Finished signing $nupkg"
+        Write-Host "Finished signing $nupkg"
+    } else {
+        Write-Host "Client Secret not found, not signing package $nupkg"
+    }
+    
+    appveyor PushArtifact $nupkg
 }
-
-Write-Host "Sign-package complete"


### PR DESCRIPTION
The symbols are too large to push to myget so we are disabling them. There
is currently no option to exclude symbol package generation, so we will
manually do it in the sign script. This is fixed in preview4 of the tooling
and should simplify the sign script.

@tomjebo 