### PR TITLE
Fix some project and schema issues

### DIFF
--- a/BinaryFormatConverter/BinaryFormatConverter.csproj
+++ b/BinaryFormatConverter/BinaryFormatConverter.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SourceCodeSerializer" Version="0.1.0" />
+    <PackageReference Include="SourceCodeSerializer" Version="0.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/BinaryFormatConverter/Program.cs
+++ b/BinaryFormatConverter/Program.cs
@@ -46,7 +46,7 @@ namespace Converter
                 return GetRootDirectory(Directory.GetCurrentDirectory());
             }
 
-            if (File.Exists(Path.Combine(path, "global.json")))
+            if (File.Exists(Path.Combine(path, "Open-XML-SDK.sln")))
             {
                 return Path.GetFullPath(path);
             }

--- a/DocumentFormat.OpenXml/DocumentFormat.OpenXml.csproj
+++ b/DocumentFormat.OpenXml/DocumentFormat.OpenXml.csproj
@@ -20,11 +20,13 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Compile Remove="src\GeneratedCode\Office2007Schema.cs;src\GeneratedCode\Office2010Schema.cs;src\GeneratedCode\Office2013Schema.cs;src\ofapi\Validation\SchemaValidation\OfficeStaticSchemaDatas.cs" />
-    <EmbeddedResource Include="src\GeneratedCode\O12SchemaConstraintDatas.bin;src\GeneratedCode\O14SchemaConstraintDatas.bin;src\GeneratedCode\O15SchemaConstraintDatas.bin" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
-
-    <!-- This file does not get included or is removed somehow. Manually adding it back for net45 gets it included -->
-    <Compile Include="src\ofapi\Validation\SchemaValidation\SdbDataHead.cs" />
+    <Compile Remove="src\GeneratedCode\Office2007Schema.cs" />
+    <Compile Remove="src\GeneratedCode\Office2010Schema.cs" />
+    <Compile Remove="src\GeneratedCode\Office2013Schema.cs" />
+    <Compile Remove="src\ofapi\Validation\SchemaValidation\OfficeStaticSchemaDatas.cs" />
+    <EmbeddedResource Include="src\GeneratedCode\O12SchemaConstraintDatas.bin" />
+    <EmbeddedResource Include="src\GeneratedCode\O14SchemaConstraintDatas.bin" />
+    <EmbeddedResource Include="src\GeneratedCode\O15SchemaConstraintDatas.bin" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/DocumentFormat.OpenXml/src/ofapi/Validation/SchemaValidation/SimpleTypes.cs
+++ b/DocumentFormat.OpenXml/src/ofapi/Validation/SchemaValidation/SimpleTypes.cs
@@ -325,13 +325,13 @@ namespace DocumentFormat.OpenXml.Internal.SchemaValidation
         /// </summary>
         private sealed class DocumentFormatBinder : System.Runtime.Serialization.SerializationBinder
         {
-            private const string FullStrongName = "DocumentFormat.OpenXml, Version=2.6.0.0, Culture=neutral, PublicKeyToken=null";
-
             private static readonly System.Reflection.Assembly s_assembly = typeof(DocumentFormatBinder).Assembly;
 
             public override Type BindToType(string assemblyName, string typeName)
             {
-                if (string.Equals(assemblyName, FullStrongName, StringComparison.Ordinal))
+                var name = new System.Reflection.AssemblyName(assemblyName);
+
+                if (string.Equals(name.Name, "DocumentFormat.OpenXml", StringComparison.Ordinal))
                 {
                     return s_assembly.GetType(typeName);
                 }


### PR DESCRIPTION
This fixes a couple of project structure issues introduced with VS17, as well as fixes the schema source generator to not have a warning and to run correctly as a signed assembly.