### PR TITLE
Remove test initializer infrastructure

### DIFF
--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/ChartTrackingRefBased/ChartTrackingRefBasedTest.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/ChartTrackingRefBased/ChartTrackingRefBasedTest.cs
@@ -12,7 +12,6 @@ namespace DocumentFormat.OpenXml.Tests.ChartTrackingRefBased
 
     public class ChartTrackingRefBasedTest : OpenXmlTestBase
     {
-        //private readonly string generateDocumentFile = "TestChartTrackingRefBasedBase.pptx";
         private readonly string generateDocumentFile = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".pptx");
         private readonly string editDocumentFile = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".pptx");
         private readonly string deleteDocumentFile = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".pptx");
@@ -20,39 +19,17 @@ namespace DocumentFormat.OpenXml.Tests.ChartTrackingRefBased
 
         private TestEntities testEntities = null;
 
-        #region Constructor
         /// <summary>
         /// Constructor
         /// </summary>
         public ChartTrackingRefBasedTest(ITestOutputHelper output)
-            :base(output)
+            : base(output)
         {
-        }
-        #endregion
-
-        #region Initialize
-        /// <summary>
-        /// Creates a base Power Point file for the tests
-        /// </summary>
-        /// <param name="createFilePath">Create Power Point file path</param>
-        private void Initialize(string createFilePath)
-        {
+            string createFilePath = this.GetTestFilePath(this.generateDocumentFile);
             GeneratedDocument generatedDocument = new GeneratedDocument();
             generatedDocument.CreatePackage(createFilePath);
 
             this.testEntities = new TestEntities(createFilePath);
-        }
-        #endregion
-
-        #region Test Methods
-        /// <summary>
-        /// Creates a base Power Point file for the tests
-        /// </summary>
-        protected override void TestInitializeOnce()
-        {
-            string generatDocumentFilePath = this.GetTestFilePath(this.generateDocumentFile);
-
-            Initialize(generatDocumentFilePath);
         }
 
         /// <summary>
@@ -61,7 +38,6 @@ namespace DocumentFormat.OpenXml.Tests.ChartTrackingRefBased
         [Fact]
         public void ChartTrackingRefBasedTest01()
         {
-            this.MyTestInitialize();
             string originalFilepath = this.GetTestFilePath(this.generateDocumentFile);
             string editFilePath = this.GetTestFilePath(this.editDocumentFile);
 
@@ -77,8 +53,6 @@ namespace DocumentFormat.OpenXml.Tests.ChartTrackingRefBased
         [Fact]
         public void ChartTrackingRefBasedTest03DeleteElement()
         {
-            this.MyTestInitialize();
-
             string originalFilepath = this.GetTestFilePath(this.generateDocumentFile);
             string deleteFilePath = this.GetTestFilePath(this.deleteDocumentFile);
             string addFilePath = this.GetTestFilePath(this.addDocumentFile);
@@ -97,7 +71,5 @@ namespace DocumentFormat.OpenXml.Tests.ChartTrackingRefBased
 
             this.Log.Pass("Element deletion is complete.");
         }
-
-        #endregion
     }
 }

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/CommentEx/CommentExTest.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/CommentEx/CommentExTest.cs
@@ -34,23 +34,13 @@ namespace DocumentFormat.OpenXml.Tests.CommentEx
         private readonly string editedDocumentFilePath = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".docx");
         private readonly string deleteDocumentFilePath = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".docx");
 
-        #region Constructor
         /// <summary>
         /// Constructor
         /// </summary>
         public CommentExTest(ITestOutputHelper output)
             : base(output)
         {
-        }
-        #endregion
-
-        #region Initialize
-        /// <summary>
-        /// Creates a base Word file for the tests
-        /// </summary>
-        /// <param name="createFilePath">Create Word file path</param>
-        private void Initialize(string createFilePath)
-        {
+            string createFilePath = this.GetTestFilePath(this.generatedDocumentFilePath);
             GeneratedDocument generatedDocument = new GeneratedDocument();
             generatedDocument.CreatePackage(createFilePath);
 
@@ -58,24 +48,11 @@ namespace DocumentFormat.OpenXml.Tests.CommentEx
         }
 
         /// <summary>
-        /// Creates a base Word file for the tests
-        /// </summary>
-        protected override void TestInitializeOnce()
-        {
-            string generatDocumentFilePath = this.GetTestFilePath(this.generatedDocumentFilePath);
-
-            Initialize(generatDocumentFilePath);
-        }
-        #endregion
-
-        #region Test Methods
-        /// <summary>
         /// Office15TCM: xxxxx: OASys#283293: OOXML SDK : COMPS : Invalid format on CommentEx
         /// </summary>
         [Fact]
         public void CommentExInvalidFormat()
         {
-            this.MyTestInitialize();
             TestDataStorage dataStorage = new TestDataStorage();
             var entries = dataStorage.GetEntries(
                 TestDataStorage.DataGroups.O15ConformanceWord).Where(i => i.FilePath.Contains("Invalid_Word15Comments.docx"));
@@ -91,8 +68,6 @@ namespace DocumentFormat.OpenXml.Tests.CommentEx
         [Fact]
         public void CommentEx02VerifyEdit()
         {
-            this.MyTestInitialize();
-
             string originalFilepath = this.GetTestFilePath(this.generatedDocumentFilePath);
             string editFilePath = this.GetTestFilePath(this.editedDocumentFilePath);
 
@@ -109,8 +84,6 @@ namespace DocumentFormat.OpenXml.Tests.CommentEx
         [Fact]
         public void CommentEx04VerifyDelete()
         {
-            this.MyTestInitialize();
-
             string originalFilepath = this.GetTestFilePath(this.generatedDocumentFilePath);
             string deleteFilePath = this.GetTestFilePath(this.deleteDocumentFilePath);
 
@@ -120,6 +93,5 @@ namespace DocumentFormat.OpenXml.Tests.CommentEx
             testEntities.DeleteElements(deleteFilePath, this.Log);
             testEntities.VerifyDeletedElements(deleteFilePath, this.Log);
         }
-        #endregion
     }
 }

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/CommentExPeople/CommentExPeopleTest.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/CommentExPeople/CommentExPeopleTest.cs
@@ -18,23 +18,13 @@ namespace DocumentFormat.OpenXml.Tests.CommentExPeople
         private readonly string generateDocumentFilePath = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".docx");
         private readonly string editedDocumentFilePath = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".docx");
 
-        #region Constructor
         /// <summary>
         /// Constructor
         /// </summary>
         public CommentExPeopleTest(ITestOutputHelper output)
             : base(output)
         {
-        }
-        #endregion
-
-        #region Initialize
-        /// <summary>
-        /// Creates a base Word file for the tests.
-        /// </summary>
-        /// <param name="createFilePath">Create Word file path</param>
-        private void Initialize(string createFilePath)
-        {
+            string createFilePath = this.GetTestFilePath(this.generateDocumentFilePath);
             GeneratedDocument generatedDocument = new GeneratedDocument();
             generatedDocument.CreatePackage(createFilePath);
 
@@ -42,25 +32,11 @@ namespace DocumentFormat.OpenXml.Tests.CommentExPeople
         }
 
         /// <summary>
-        /// Creates a base Word file for the tests.
-        /// </summary>
-        protected override void TestInitializeOnce()
-        {
-            string generatDocumentFilePath = this.GetTestFilePath(this.generateDocumentFilePath);
-
-            Initialize(generatDocumentFilePath);
-        }
-        #endregion
-
-        #region Test Methods
-        /// <summary>
         /// Element reading test for "Comment PeoplePart".
         /// </summary>
         [Fact]
         public void CommentExPeople01ReadElement()
         {
-            this.MyTestInitialize();
-
             string originalFilepath = this.GetTestFilePath(this.generateDocumentFilePath);
 
             TestEntities testEntities = new TestEntities();
@@ -73,8 +49,6 @@ namespace DocumentFormat.OpenXml.Tests.CommentExPeople
         [Fact]
         public void CommentExPeople02EditElement()
         {
-            this.MyTestInitialize();
-
             string originalFilepath = this.GetTestFilePath(this.generateDocumentFilePath);
             string editFilePath = this.GetTestFilePath(this.editedDocumentFilePath);
 
@@ -84,6 +58,5 @@ namespace DocumentFormat.OpenXml.Tests.CommentExPeople
             testEntities.EditElements(editFilePath, this.Log);
             testEntities.VerifyElements(editFilePath, this.Log);
         }
-        #endregion
     }
 }

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/ContentControl/ContentControlTest.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/ContentControl/ContentControlTest.cs
@@ -1,17 +1,13 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace DocumentFormat.OpenXml.Tests.ContentControl
 {
-    using Xunit;
-    using DocumentFormat.OpenXml.Tests.TaskLibraries;
-    using DocumentFormat.OpenXml.Tests.TaskLibraries.DataStorage;
     using DocumentFormat.OpenXml.Tests.ContentControlClass;
-    using System.IO;
+    using DocumentFormat.OpenXml.Tests.TaskLibraries;
     using OxTest;
+    using System.IO;
+    using Xunit;
     using Xunit.Abstractions;
 
     /// <summary>
@@ -23,39 +19,17 @@ namespace DocumentFormat.OpenXml.Tests.ContentControl
         private readonly string editedDocumentFilePath = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".docx");
         private readonly string deletedDocumentFilePath = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".docx");
 
-        #region Constructor
         /// <summary>
         /// Constructor
         /// </summary>
         public ContentControlTest(ITestOutputHelper output)
             : base(output)
         {
-        }
-        #endregion
-
-        #region Initialize
-        /// <summary>
-        /// Creates a base Word file for the tests
-        /// </summary>
-        /// <param name="createFilePath">Create Word file path</param>
-        private void Initialize(string createFilePath)
-        {
+            string createFilePath = this.GetTestFilePath(this.generatedDocumentFilePath);
             GeneratedDocument generatedDocument = new GeneratedDocument();
             generatedDocument.CreatePackage(createFilePath);
 
             this.Log.Pass("Create Word file. File path=[{0}]", createFilePath);
-        }
-        #endregion
-
-        #region Test Methods
-        /// <summary>
-        /// Creates a base Word file for the tests
-        /// </summary>
-        protected override void TestInitializeOnce()
-        {
-            string generatDocumentFilePath = this.GetTestFilePath(this.generatedDocumentFilePath);
-
-            Initialize(generatDocumentFilePath);
         }
 
         /// <summary>
@@ -64,8 +38,6 @@ namespace DocumentFormat.OpenXml.Tests.ContentControl
         [Fact]
         public void ContentControl01EditElement()
         {
-            this.MyTestInitialize();
-
             string originalFilepath = this.GetTestFilePath(this.generatedDocumentFilePath);
             string editFilePath = this.GetTestFilePath(this.editedDocumentFilePath);
 
@@ -81,8 +53,6 @@ namespace DocumentFormat.OpenXml.Tests.ContentControl
         [Fact]
         public void ContentControl03DeleteElement()
         {
-            this.MyTestInitialize();
-
             string originalFilepath = this.GetTestFilePath(this.generatedDocumentFilePath);
             string deleteFilePath = this.GetTestFilePath(this.deletedDocumentFilePath);
 
@@ -92,6 +62,5 @@ namespace DocumentFormat.OpenXml.Tests.ContentControl
             DeleteElement.DeleteContentControlElements(deleteFilePath, this.Log);
             int sdtElementNum = VerifyDeletedElement.DeletedElementVerify(deleteFilePath, this.Log);
         }
-        #endregion
     }
 }

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/FootnoteColumns/FootnoteColumnTest.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/FootnoteColumns/FootnoteColumnTest.cs
@@ -23,14 +23,12 @@ namespace DocumentFormat.OpenXml.Tests.FootnoteColumns
         {
         }
 
-        #region Test Methods
         /// <summary>
         /// Document Read/Write Test for FootnoteColumns
         /// </summary>
         [Fact]
         public void FootnoteColumnsReadWriteTest()
         {
-            this.MyTestInitialize();
             this.SimpleReadWriteTest(
                 (e) =>
                 {
@@ -49,6 +47,5 @@ namespace DocumentFormat.OpenXml.Tests.FootnoteColumns
                         "Verified the updated attribute");
                 });
         }
-        #endregion
     }
 }

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/General/ConformanceTestBase.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/General/ConformanceTestBase.cs
@@ -2,16 +2,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Reflection;
 
 namespace DocumentFormat.OpenXml.Tests
 {
-    using Xunit;
-    using DocumentFormat.OpenXml.Tests.TaskLibraries;
-
     using DocumentFormat.OpenXml;
     using DocumentFormat.OpenXml.Packaging;
+    using DocumentFormat.OpenXml.Tests.TaskLibraries;
     using Xunit.Abstractions;
 
     public abstract class ConformanceTestBase<TReflectedCode, TPackage, TElement> : OpenXmlTestBase
@@ -55,24 +52,15 @@ namespace DocumentFormat.OpenXml.Tests
         }
         #endregion
 
-        #region Initialize
         /// <summary>
         /// Default Constructor
         /// </summary>
         public ConformanceTestBase(ITestOutputHelper output)
             : base(output)
         {
-        }
-
-        /// <summary>
-        /// Creates a base Word file for the tests.
-        /// </summary>
-        protected override void TestInitializeOnce()
-        {
             // Creates the test document
             this.CreatePackage(this.GetTestFilePath(this.BaseFileName));
         }
-        #endregion
 
         #region Preset Tests
         protected delegate void ElementHandler(TElement element);

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/Guide/GuideTest.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/Guide/GuideTest.cs
@@ -19,43 +19,21 @@ namespace DocumentFormat.OpenXml.Tests.GuideTest
         private readonly string editDocumentFile = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".pptx");
         private readonly string deleteDocumentFile = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".pptx");
         private readonly string addDocumentFile = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".pptx");
-        TestEntities testEntities = null;
+        private readonly TestEntities testEntities;
 
-        #region Constructor
         /// <summary>
         /// Constructor
         /// </summary>
         public GuideTest(ITestOutputHelper output)
             : base(output)
         {
-        }
-        #endregion
-
-        #region Initialize
-        /// <summary>
-        /// Creates a base Word file for the tests
-        /// </summary>
-        /// <param name="createFilePath">Create Word file path</param>
-        private void Initialize(string createFilePath)
-        {
+            string createFilePath = this.GetTestFilePath(this.generateDocumentFile);
             GeneratedDocument generatedDocument = new GeneratedDocument();
             generatedDocument.CreatePackage(createFilePath);
 
             this.Log.Pass("Create Power Point file. File path=[{0}]", createFilePath);
 
             this.testEntities = new TestEntities(createFilePath);
-        }
-        #endregion
-
-        #region Test Methods
-        /// <summary>
-        /// Creates a base Excel file for the tests
-        /// </summary>
-        protected override void TestInitializeOnce()
-        {
-            string generatDocumentFilePath = this.GetTestFilePath(this.generateDocumentFile);
-
-            Initialize(generatDocumentFilePath);
         }
 
         /// <summary>
@@ -64,8 +42,6 @@ namespace DocumentFormat.OpenXml.Tests.GuideTest
         [Fact]
         public void Guide01EditElement()
         {
-            this.MyTestInitialize();
-
             string originalFilepath = this.GetTestFilePath(this.generateDocumentFile);
             string editFilePath = this.GetTestFilePath(this.editDocumentFile);
 
@@ -81,8 +57,6 @@ namespace DocumentFormat.OpenXml.Tests.GuideTest
         [Fact]
         public void Guide03DeleteAddElement()
         {
-            this.MyTestInitialize();
-
             string originalFilepath = this.GetTestFilePath(this.generateDocumentFile);
             string deleteFilePath = this.GetTestFilePath(this.deleteDocumentFile);
             string addFilePath = this.GetTestFilePath(this.addDocumentFile);
@@ -97,7 +71,5 @@ namespace DocumentFormat.OpenXml.Tests.GuideTest
             this.testEntities.AddElement(addFilePath, this.Log);
             this.testEntities.VerifyAddedElemenet(addFilePath, this.Log);
         }
-
-        #endregion
     }
 }

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/Pivot/PivotTest.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/Pivot/PivotTest.cs
@@ -24,41 +24,19 @@ namespace DocumentFormat.OpenXml.Tests.Pivot
         private readonly string deletedOldbConnectionDocumentFile = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".xlsx");
         private readonly string addedOldbConnectionDocumentFile = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".xlsx");
 
-        #region Constructor
         /// <summary>
         /// Constructor
         /// </summary>
         public PivotTest(ITestOutputHelper output)
             : base(output)
         {
-        }
-        #endregion
-
-        #region Initialize
-        /// <summary>
-        /// Creates a base Word file for the tests
-        /// </summary>
-        /// <param name="createFilePath">Create Word file path</param>
-        private void Initialize(string createFilePath)
-        {
+            string createFilePath = this.GetTestFilePath(this.generatedOldbConnectionDocumentFile);
             ConnectionGeneratedDocument connectionGeneratedDocument = new ConnectionGeneratedDocument();
             connectionGeneratedDocument.CreatePackage(createFilePath);
 
             this.Log.Pass("Create Word file. File path=[{0}]", createFilePath);
 
             this.connectionTestEntities = new ConnectionTestEntities(createFilePath);
-        }
-        #endregion
-
-        #region Test Methods
-        /// <summary>
-        /// Creates a base Excel file for the tests
-        /// </summary>
-        protected override void TestInitializeOnce()
-        {
-            string generatDocumentFilePath = this.GetTestFilePath(this.generatedOldbConnectionDocumentFile);
-
-            Initialize(generatDocumentFilePath);
         }
 
         /// <summary>
@@ -67,8 +45,6 @@ namespace DocumentFormat.OpenXml.Tests.Pivot
         [Fact]
         public void PivotConnection01EditElement()
         {
-            this.MyTestInitialize();
-
             string originalFilepath = this.GetTestFilePath(this.generatedOldbConnectionDocumentFile);
             string editFilePath = this.GetTestFilePath(this.editedOldbConnectionDocumentFile);
 
@@ -84,8 +60,6 @@ namespace DocumentFormat.OpenXml.Tests.Pivot
         [Fact]
         public void PivotConnection03DeleteAddElement()
         {
-            this.MyTestInitialize();
-
             string originalFilepath = this.GetTestFilePath(this.generatedOldbConnectionDocumentFile);
             string deleteFilePath = this.GetTestFilePath(this.deletedOldbConnectionDocumentFile);
             string addFilePath = this.GetTestFilePath(this.addedOldbConnectionDocumentFile);
@@ -100,6 +74,5 @@ namespace DocumentFormat.OpenXml.Tests.Pivot
             this.connectionTestEntities.AddElement(addFilePath, this.Log);
             this.connectionTestEntities.VerifyAddedElement(addFilePath, this.Log);
         }
-        #endregion
     }
 }

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/PresetTransition/PresetTransitionTest.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/PresetTransition/PresetTransitionTest.cs
@@ -31,7 +31,6 @@ namespace DocumentFormat.OpenXml.Tests.PresetTransition
         [Fact]
         public void PresetTransitionReadWriteTest()
         {
-            this.MyTestInitialize();
             this.SimpleReadWriteTest(
                 (e) =>
                 {

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/Slicer/SlicerTest.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/Slicer/SlicerTest.cs
@@ -1,48 +1,30 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace DocumentFormat.OpenXml.Tests.Slicer
 {
-    using Xunit;
-    using DocumentFormat.OpenXml.Tests.TaskLibraries;
-    using DocumentFormat.OpenXml.Tests.TaskLibraries.DataStorage;
     using DocumentFormat.OpenXml.Tests.SlicerClass;
-    using System.IO;
+    using DocumentFormat.OpenXml.Tests.TaskLibraries;
     using OxTest;
+    using System.IO;
+    using Xunit;
     using Xunit.Abstractions;
 
     /// <summary>
     /// Test for Slicer elements
     /// </summary>
-
     public class SlicerTest : OpenXmlTestBase
     {
-
-        //private readonly string generateDocumentFilePath = "TestSlicerBase.xlsx";
-        //private readonly string editeDocumentFilePath = "EditedSlicer.xlsx";
         private readonly string generateDocumentFilePath = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".xlsx");
         private readonly string editeDocumentFilePath = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".xlsx");
 
-        #region Constructor
         /// <summary>
         /// Constructor
         /// </summary>
         public SlicerTest(ITestOutputHelper output)
             : base(output)
         {
-        }
-        #endregion
-
-        #region Initialize
-        /// <summary>
-        /// Creates a base Excel file for the tests
-        /// </summary>
-        /// <param name="createFilePath">Create Excel file path</param>
-        private void Initialize(string createFilePath)
-        {
+            string createFilePath = this.GetTestFilePath(this.generateDocumentFilePath);
             GeneratedDocument generatedDocument = new GeneratedDocument();
             generatedDocument.CreatePackage(createFilePath);
 
@@ -50,25 +32,11 @@ namespace DocumentFormat.OpenXml.Tests.Slicer
         }
 
         /// <summary>
-        /// Creates a base Excel file for the tests
-        /// </summary>
-        protected override void TestInitializeOnce()
-        {
-            string generatDocumentFilePath = this.GetTestFilePath(this.generateDocumentFilePath);
-
-            Initialize(generatDocumentFilePath);
-        }
-        #endregion
-
-        #region Test Methods
-        /// <summary>
         /// Element editing test for "Slicer Cache"
         /// </summary>
         [Fact]
         public void Slicer01EditElement()
         {
-            this.MyTestInitialize();
-
             string originalFilepath = this.GetTestFilePath(this.generateDocumentFilePath);
             string editFilePath = this.GetTestFilePath(this.editeDocumentFilePath);
 
@@ -78,8 +46,5 @@ namespace DocumentFormat.OpenXml.Tests.Slicer
             testEntities.EditElements(editFilePath, this.Log);
             testEntities.VerifyElements(editFilePath, this.Log);
         }
-
-        #endregion
-
     }
 }

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/Theme/ThemeTest.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/Theme/ThemeTest.cs
@@ -1,63 +1,35 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace DocumentFormat.OpenXml.Tests.Theme
 {
     using DocumentFormat.OpenXml.Packaging;
-    using Xunit;
     using DocumentFormat.OpenXml.Tests.TaskLibraries;
     using DocumentFormat.OpenXml.Tests.ThemeClass;
-    using System.IO;
     using OxTest;
+    using System.IO;
+    using Xunit;
     using Xunit.Abstractions;
 
     public class ThemeTest : OpenXmlTestBase
     {
-        //private readonly string generateDocumentFilePath = "TestThemeBase.pptx";
-        //private readonly string editDocumentFilePath = "EditedTheme.pptx";
-        //private readonly string deleteDocumentFilePath = "DeletedTheme.pptx";
-        //private readonly string addDocumentFilePath = "AddedTheme.pptx";
         private readonly string generateDocumentFilePath = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".pptx");
         private readonly string editDocumentFilePath = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".pptx");
         private readonly string deleteDocumentFilePath = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".pptx");
         private readonly string addDocumentFilePath = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".pptx");
 
-        #region Constructor
         /// <summary>
         /// Constructor
         /// </summary>
         public ThemeTest(ITestOutputHelper output)
             : base(output)
         {
-        }
-        #endregion
-
-        #region Initialize
-        /// <summary>
-        /// Creates a base Word file for the tests
-        /// </summary>
-        /// <param name="createFilePath">Create Word file path</param>
-        private void Initialize(string createFilePath)
-        {
+            string createFilePath = this.GetTestFilePath(this.generateDocumentFilePath);
             GeneratedDocument generatedDocument = new GeneratedDocument();
             generatedDocument.CreatePackage(createFilePath);
 
             this.Log.Pass("Create Power Point file. File path=[{0}]", createFilePath);
-        }
-        #endregion
-
-        #region Test Methods
-        /// <summary>
-        /// Creates a base Excel file for the tests
-        /// </summary>
-        protected override void TestInitializeOnce()
-        {
-            string generatDocumentFilePath = this.GetTestFilePath(this.generateDocumentFilePath);
-
-            Initialize(generatDocumentFilePath);
         }
 
         /// <summary>
@@ -66,8 +38,6 @@ namespace DocumentFormat.OpenXml.Tests.Theme
         [Fact]
         public void Theme01EditAttribute()
         {
-            this.MyTestInitialize();
-
             string originalFilepath = this.GetTestFilePath(this.generateDocumentFilePath);
             string editFilePath = this.GetTestFilePath(this.editDocumentFilePath);
 
@@ -91,8 +61,6 @@ namespace DocumentFormat.OpenXml.Tests.Theme
         [Fact]
         public void Theme03DeleteAttribute()
         {
-            this.MyTestInitialize();
-
             string originalFilepath = this.GetTestFilePath(this.generateDocumentFilePath);
             string deleteFilePath = this.GetTestFilePath(this.deleteDocumentFilePath);
             string addFilePath = this.GetTestFilePath(this.addDocumentFilePath);
@@ -112,7 +80,5 @@ namespace DocumentFormat.OpenXml.Tests.Theme
 
             this.Log.Pass("Deleted the thm15:id attribute is complete.");
         }
-
-        #endregion
     }
 }

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/ThreadingInfo/ThreadingInfoTest.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/ThreadingInfo/ThreadingInfoTest.cs
@@ -1,66 +1,36 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace DocumentFormat.OpenXml.Tests.ThreadingInfo
 {
-    using Xunit;
-    using DocumentFormat.OpenXml.Tests.TaskLibraries;
     using DocumentFormat.OpenXml.Tests.ChartTrackingRefBasedClass;
-    using System.IO;
+    using DocumentFormat.OpenXml.Tests.TaskLibraries;
     using OxTest;
+    using System.IO;
+    using Xunit;
     using Xunit.Abstractions;
 
     public class ThreadingInfoTest : OpenXmlTestBase
     {
-        //private readonly string generateDocumentFile = "TestThreadingInfoBase.pptx";
-        //private readonly string editDocumentFile = "EditedThreadingInfo.pptx";
-        //private readonly string deleteDocumentFile = "DeletedThreadingInfo.pptx";
-        //private readonly string addDocumentFile = "AddedThreadingInfo.pptx";
         private readonly string generateDocumentFile = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".pptx");
         private readonly string editDocumentFile = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".pptx");
         private readonly string deleteDocumentFile = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".pptx");
         private readonly string addDocumentFile = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".pptx");
+        private readonly TestEntities testEntities;
 
-        TestEntities testEntities = null;
-
-        #region Constructor
         /// <summary>
         /// Constructor
         /// </summary>
         public ThreadingInfoTest(ITestOutputHelper output)
             : base(output)
         {
-        }
-        #endregion
-
-        #region Initialize
-        /// <summary>
-        /// Creates a base Word file for the tests
-        /// </summary>
-        /// <param name="createFilePath">Create Power Point file path</param>
-        private void Initialize(string createFilePath)
-        {
+            string createFilePath = this.GetTestFilePath(this.generateDocumentFile);
             GeneratedDocument generatedDocument = new GeneratedDocument();
             generatedDocument.CreatePackage(createFilePath);
 
             this.Log.Pass("Create Power Point file. File path=[{0}]", createFilePath);
 
             this.testEntities = new TestEntities(createFilePath);
-        }
-        #endregion
-
-        #region Test Methods
-        /// <summary>
-        /// Creates a base Excel file for the tests
-        /// </summary>
-        protected override void TestInitializeOnce()
-        {
-            string generatDocumentFilePath = this.GetTestFilePath(this.generateDocumentFile);
-
-            Initialize(generatDocumentFilePath);
         }
 
         /// <summary>
@@ -69,8 +39,6 @@ namespace DocumentFormat.OpenXml.Tests.ThreadingInfo
         [Fact]
         public void ThreadingInfo01EditElement()
         {
-            this.MyTestInitialize();
-
             string originalFilepath = this.GetTestFilePath(this.generateDocumentFile);
             string editFilePath = this.GetTestFilePath(this.editDocumentFile);
 
@@ -86,8 +54,6 @@ namespace DocumentFormat.OpenXml.Tests.ThreadingInfo
         [Fact]
         public void ThreadingInfo03DeleteAddElement()
         {
-            this.MyTestInitialize();
-
             string originalFilepath = this.GetTestFilePath(this.generateDocumentFile);
             string deleteFilePath = this.GetTestFilePath(this.deleteDocumentFile);
             string addFilePath = this.GetTestFilePath(this.addDocumentFile);
@@ -102,7 +68,5 @@ namespace DocumentFormat.OpenXml.Tests.ThreadingInfo
             this.testEntities.AddElements(addFilePath, this.Log);
             this.testEntities.VerifyAddElements(addFilePath, this.Log);
         }
-
-        #endregion
     }
 }

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/Timeline/TimeLineTest.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/Timeline/TimeLineTest.cs
@@ -10,62 +10,30 @@ namespace DocumentFormat.OpenXml.Tests.TimeLine
     using Xunit;
     using Xunit.Abstractions;
 
-
     /// <summary>
     /// Tests for TimeLine elements
     /// </summary>
-
     public class TimeLineTest : OpenXmlTestBase
     {
-        //private readonly string generateDocumentFile = "TestTimeLineBase.xlsx";
-        //private readonly string editeDocumentFile = "EditedTimeLine.xlsx";
-        //private readonly string deleteTimelineStyleDocumentFile = "DeletedTimelineStyleTimeLine.xlsx";
-        //private readonly string addTimelineStyleDocumentFile = "AddedTimelineStyleTimeLine.xlsx";
         private readonly string generateDocumentFile = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".xlsx");
         private readonly string editeDocumentFile = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".xlsx");
         private readonly string deleteTimelineStyleDocumentFile = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".xlsx");
         private readonly string addTimelineStyleDocumentFile = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".xlsx");
+        private readonly TestEntities testEntities = null;
 
-
-
-        TestEntities testEntities = null;
-
-        #region Constructor
         /// <summary>
         /// Constructor
         /// </summary>
         public TimeLineTest(ITestOutputHelper output)
             : base(output)
         {
-        }
-        #endregion
-
-        #region Initialize
-        /// <summary>
-        /// Create is a Excel file, It's test base file.
-        /// </summary>
-        /// <param name="createFilePath">Create Excel file path</param>
-        /// <returns>Excel file path</returns>
-        private void Initialize(string createFilePath)
-        {
+            string createFilePath = this.GetTestFilePath(this.generateDocumentFile);
             GeneratedDocument generatedDocument = new GeneratedDocument();
             generatedDocument.CreatePackage(createFilePath);
 
             this.Log.Pass("Create Excel file. File path=[{0}]", createFilePath);
 
             this.testEntities = new TestEntities(createFilePath);
-        }
-        #endregion
-
-        #region Test Methods
-        /// <summary>
-        /// Creates a base Excel file for the tests
-        /// </summary>
-        protected override void TestInitializeOnce()
-        {
-            string generatDocumentFilePath = this.GetTestFilePath(this.generateDocumentFile);
-
-            Initialize(generatDocumentFilePath);
         }
 
         /// <summary>
@@ -74,8 +42,6 @@ namespace DocumentFormat.OpenXml.Tests.TimeLine
         [Fact]
         public void TimeLine01EditDeleteAddAttribute()
         {
-            this.MyTestInitialize();
-
             string originalFilepath = this.GetTestFilePath(this.generateDocumentFile);
             string editFilePath = this.GetTestFilePath(this.editeDocumentFile);
             string deleteTimelineStyleFilePath = this.GetTestFilePath(this.deleteTimelineStyleDocumentFile);
@@ -96,7 +62,5 @@ namespace DocumentFormat.OpenXml.Tests.TimeLine
             this.testEntities.AddTimelineStyle(addTimelineStyleFilePath, this.Log);
             this.testEntities.VerifyAddedTimelineStyle(addTimelineStyleFilePath, this.Log);
         }
-
-        #endregion
     }
 }

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/WebExtension/WebExtensionTest.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/WebExtension/WebExtensionTest.cs
@@ -49,7 +49,6 @@ namespace DocumentFormat.OpenXml.Tests.WebExtension
         [Fact]
         public void WebExtensionAcceptance()
         {
-            this.MyTestInitialize();
             TestDataStorage dataStorage = new TestDataStorage();
             var entries = dataStorage.GetEntries(TestDataStorage.DataGroups.O15ConformanceExcel).Where(e => e.FilePath.Contains(@"WebExtension\"));
 
@@ -92,8 +91,6 @@ namespace DocumentFormat.OpenXml.Tests.WebExtension
         [Fact]
         public void WebExtensionInvalidFormat()
         {
-            this.MyTestInitialize();
-
             // Instanciating a DataStorage object to get test files
             TestDataStorage dataStorage = new TestDataStorage();
 
@@ -129,8 +126,6 @@ namespace DocumentFormat.OpenXml.Tests.WebExtension
         [Fact]
         public void WebExtensionFullyFledgedValidation()
         {
-            this.MyTestInitialize();
-
             // create an Excel file containing a fully fledged WebExtension here:
             string filePath = Path.Combine(TestUtil.TestResultsDirectory, "WebExtensionFullFledgeValidation.xlsx");
             WebExtensionData gen = new WebExtensionData();

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/WorkbookPr/WorkBookPrTest.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/WorkbookPr/WorkBookPrTest.cs
@@ -1,66 +1,36 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace DocumentFormat.OpenXml.Tests.WorkBookPr
 {
-    using Xunit;
     using DocumentFormat.OpenXml.Tests.TaskLibraries;
     using DocumentFormat.OpenXml.Tests.WorkBookPrClass;
-    using System.IO;
     using OxTest;
+    using System.IO;
+    using Xunit;
     using Xunit.Abstractions;
 
     public class WorkBookPrTest : OpenXmlTestBase
     {
-        TestEntities testEntities = null;
-
-        //private readonly string generatedDocumentFile = "TestWorkBookPrBase.xlsx";
-        //private readonly string editedDocumentFile = "EditWorkBookPr.xlsx";
-        //private readonly string deletedDocumentFile = "DeleteWorkBookPr.xlsx";
-        //private readonly string addedDocumentFile = "AddedWorkBookPr.xlsx";
         private readonly string generatedDocumentFile = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".xlsx");
         private readonly string editedDocumentFile = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".xlsx");
         private readonly string deletedDocumentFile = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".xlsx");
         private readonly string addedDocumentFile = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".xlsx");
+        private readonly TestEntities testEntities = null;
 
-        #region Constructor
         /// <summary>
         /// Constructor
         /// </summary>
         public WorkBookPrTest(ITestOutputHelper output)
             : base(output)
         {
-        }
-        #endregion
-
-        #region Initialize
-        /// <summary>
-        /// Creates a base Word file for the tests
-        /// </summary>
-        /// <param name="createFilePath">Create Word file path</param>
-        private void Initialize(string createFilePath)
-        {
+            string createFilePath = this.GetTestFilePath(this.generatedDocumentFile);
             GeneratedDocument generatedDocument = new GeneratedDocument();
             generatedDocument.CreatePackage(createFilePath);
 
             this.Log.Pass("Create Word file. File path=[{0}]", createFilePath);
 
             this.testEntities = new TestEntities(createFilePath);
-        }
-        #endregion
-
-        #region Test Methods
-        /// <summary>
-        /// Creates a base Excel file for the tests
-        /// </summary>
-        protected override void TestInitializeOnce()
-        {
-            string generatDocumentFilePath = this.GetTestFilePath(this.generatedDocumentFile);
-
-            Initialize(generatDocumentFilePath);
         }
 
         /// <summary>
@@ -69,8 +39,6 @@ namespace DocumentFormat.OpenXml.Tests.WorkBookPr
         [Fact]
         public void WorkBookPr01EditElement()
         {
-            this.MyTestInitialize();
-
             string originalFilepath = this.GetTestFilePath(this.generatedDocumentFile);
             string editFilePath = this.GetTestFilePath(this.editedDocumentFile);
 
@@ -86,8 +54,6 @@ namespace DocumentFormat.OpenXml.Tests.WorkBookPr
         [Fact]
         public void WorkBookPr03DeleteElement()
         {
-            this.MyTestInitialize();
-
             string originalFilepath = this.GetTestFilePath(this.generatedDocumentFile);
             string deleteFilePath = this.GetTestFilePath(this.deletedDocumentFile);
             string addFilePath = this.GetTestFilePath(this.addedDocumentFile);
@@ -103,7 +69,5 @@ namespace DocumentFormat.OpenXml.Tests.WorkBookPr
             this.testEntities.AddElement(addFilePath, this.Log);
             this.testEntities.VerifyAddElements(addFilePath, this.Log);
         }
-
-        #endregion
     }
 }

--- a/DocumentFormat.OpenXml.Tests/IsoStrictTest/IsoStrictTest.cs
+++ b/DocumentFormat.OpenXml.Tests/IsoStrictTest/IsoStrictTest.cs
@@ -36,7 +36,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void TestISOStrictNamespaceWordprocessingML()
         {
-            this.MyTestInitialize();
             TestDataStorage dataStorage = new TestDataStorage();
             var entries = dataStorage.GetEntries(TestDataStorage.DataGroups.O14IsoStrictWord);
 
@@ -52,7 +51,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void TestISOStrictNamespacePresentationML()
         {
-            this.MyTestInitialize();
             TestDataStorage dataStorage = new TestDataStorage();
             var entries = dataStorage.GetEntries(TestDataStorage.DataGroups.O14IsoStrictPowerPoint);
 
@@ -68,7 +66,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ValidateISOStrictNamespaceSpreadsheetML()
         {
-            this.MyTestInitialize();
             TestDataStorage dataStorage = new TestDataStorage();
             var entries = dataStorage.GetEntries(TestDataStorage.DataGroups.O14IsoStrictExcel).Take(10);
 
@@ -84,7 +81,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ValidateISOStrictNamespacePresentationML()
         {
-            this.MyTestInitialize();
             TestDataStorage dataStorage = new TestDataStorage();
             var entries = dataStorage.GetEntries(TestDataStorage.DataGroups.O14IsoStrictPowerPoint).Take(50);
 
@@ -100,7 +96,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ValidateISOStrictNamespaceDrawingML()
         {
-            this.MyTestInitialize();
             TestDataStorage dataStorage = new TestDataStorage();
             var entries = dataStorage.GetEntries(TestDataStorage.DataGroups.O14IsoStrictGraphics).Take(50);
 
@@ -116,7 +111,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ValidateISOStrictNamespaceWordprocessingML()
         {
-            this.MyTestInitialize();
             TestDataStorage dataStorage = new TestDataStorage();
             var entries = dataStorage.GetEntries(TestDataStorage.DataGroups.O14IsoStrictWord).Take(50);
 

--- a/DocumentFormat.OpenXml.Tests/OFCatTest/Robustness.cs
+++ b/DocumentFormat.OpenXml.Tests/OFCatTest/Robustness.cs
@@ -1,27 +1,12 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Collections;
-using System.Linq;
-using System.Text;
-using System.IO;
-using System.IO.Packaging;
-using System.Reflection;
-using System.Xml;
-using System.Xml.Linq;
 
 namespace DocumentFormat.OpenXml.Tests
 {
     using DocumentFormat.OpenXml;
-    using DocumentFormat.OpenXml.Validation;
-    using DocumentFormat.OpenXml.Packaging;
-    using DocumentFormat.OpenXml.Presentation;
-    using DocumentFormat.OpenXml.Spreadsheet;
-    using DocumentFormat.OpenXml.Wordprocessing;
-
-    using Xunit;
     using DocumentFormat.OpenXml.Tests.TaskLibraries;
     using DocumentFormat.OpenXml.Tests.TaskLibraries.DataStorage;
+    using DocumentFormat.OpenXml.Validation;
+    using Xunit;
     using Xunit.Abstractions;
 
     /// <summary>
@@ -29,7 +14,6 @@ namespace DocumentFormat.OpenXml.Tests
     /// </summary>
     public class Robustness : OpenXmlTestBase
     {
-        #region Constructor
         /// <summary>
         /// Constructor
         /// </summary>
@@ -37,14 +21,10 @@ namespace DocumentFormat.OpenXml.Tests
             : base(output)
         {
         }
-        #endregion
 
-        #region Test Methods
         [Fact]
         public void OFCATFull()
         {
-            this.MyTestInitialize();
-
             TestDataStorage dataStorage = new TestDataStorage();
             var entries = dataStorage.GetEntries(
                 TestDataStorage.DataGroups.RobustnessOFCAT);
@@ -53,6 +33,5 @@ namespace DocumentFormat.OpenXml.Tests
 
             this.ValidateDocuments(validator, entries);
         }
-        #endregion
     }
 }

--- a/DocumentFormat.OpenXml.Tests/OpenXmlDomTaskLibrary/TestScripts/OpenXmlTestBase.cs
+++ b/DocumentFormat.OpenXml.Tests/OpenXmlDomTaskLibrary/TestScripts/OpenXmlTestBase.cs
@@ -17,64 +17,23 @@ namespace DocumentFormat.OpenXml.Tests.TaskLibraries
     /// </summary>
     public class OpenXmlTestBase
     {
-        protected OpenXmlTestBase(ITestOutputHelper output)
+        protected OpenXmlTestBase(ITestOutputHelper output, string path = null)
         {
             Log = new VerifiableLog(output);
+
+            if (path == null)
+            {
+                SourcePath = TestUtil.TestDataStorage;
+            }
+            else
+            {
+                SourcePath = Path.Combine(TestUtil.TestDataStorage, path);
+            }
         }
 
         protected VerifiableLog Log { get; }
 
-        #region Initialize/Cleanup
-        public void MyTestInitialize()
-        {
-            // Initialize the list of created result folders
-            this.resultFoldersCreated = new List<string>();
-
-
-            // Create result root directory if not exists
-            if (!Directory.Exists(TestResultsDirectory))
-            {
-                Directory.CreateDirectory(TestResultsDirectory);
-            }
-
-            // Record test start time to summary log
-            var summaryLog = this.Log;
-            summaryLog.Comment("Test has been started.");
-
-            // Calls overridable logics
-            if (this.initialized == false)
-            {
-                this.TestInitializeOnce();
-                this.initialized = true;
-            }
-            TestInitialize();
-        }
-
-        /// <summary>
-        /// The method is called once prior to call the first test method.
-        /// Use TestInitialize() instead if you need everytime initialization for each test method.
-        /// </summary>
-        protected virtual void TestInitializeOnce() { }
-
-        /// <summary>
-        /// The method is called multiply prior to call each test method.
-        /// Use TestInitializeOnce() instead if you need once initialization.
-        /// </summary>
-        protected virtual void TestInitialize() { }
-        protected virtual void TestCleanup() { }
-
-        private bool initialized = false;
-        #endregion
-
         #region TestFiles
-
-        /// <summary>
-        /// List of created result folders.
-        /// This will basically contains one directory path,
-        /// but if test logic specifies sub test name, it could have two or more paths.
-        /// </summary>
-        private List<string> resultFoldersCreated;
-
         /// <summary>
         /// Get current result folder path.
         /// If result folder is not yet created, create it and return the path.
@@ -93,56 +52,14 @@ namespace DocumentFormat.OpenXml.Tests.TaskLibraries
         private string currentResultFolder;
 
         /// <summary>
-        /// Alias of SourcePath
-        /// </summary>
-        protected String sourcePath
-        {
-            get { return this.SourcePath; }
-        }
-
-        /// <summary>
-        /// Alias of ResultRootPath.
-        /// </summary>
-        protected String resultPath
-        {
-            get { return this.ResultPath; }
-        }
-
-        public String indexFolder = @"\\no-such-server\bjoffhost12\resultfile\_index";
-
-        /// <summary>
         /// Root of source folder.
         /// </summary>
-        public static string SourceRootPath
-        {
-            get
-            {
-                _SourceRootPath = TestUtil.TestDataStorage;
-                return _SourceRootPath;
-            }
-        }
-        private static string _SourceRootPath = null;
-        protected void SetSourceRootPath(string path)
-        {
-            _SourceRootPath = path;
-        }
+        public static string SourceRootPath { get; } = TestUtil.TestDataStorage;
 
         /// <summary>
         /// Source folder.
         /// </summary>
-        public string SourcePath
-        {
-            get
-            {
-                return _SourcePath ?? TestUtil.TestDataStorage;
-            }
-            set
-            {
-                // Expand the specified relative path based on source root folder
-                this._SourcePath = Path.Combine(SourceRootPath, value);
-            }
-        }
-        private String _SourcePath = null;
+        public string SourcePath { get; }
 
         /// <summary>
         /// Root of result folder.
@@ -152,35 +69,13 @@ namespace DocumentFormat.OpenXml.Tests.TaskLibraries
         /// Test pass script specifies _OXMLSDKLOG environment variable so that
         /// it becomes the value for this property.
         /// </summary>
-        public static string TestResultsDirectory
-        {
-            get
-            {
-                return TestUtil.TestResultsDirectory;
-            }
-        }
+        public static string TestResultsDirectory { get; } = TestUtil.TestResultsDirectory;
 
-        public string ResultPath
-        {
-            get
-            {
-                if (this._ResultPath == null)
-                {
-                    this._ResultPath = TestResultsDirectory;
-                }
-                return this._ResultPath;
-            }
-            set
-            {
-                // Expand the specified relative path based on result root folder
-                this._ResultPath = Path.Combine(TestResultsDirectory, value);
-            }
-        }
-        private string _ResultPath = null;
+        public string ResultPath { get; } = TestResultsDirectory;
 
         public string GetTestFilePath(string filename)
         {
-            string testFileFolder = Path.Combine(resultPath, this.TestClassName + "_files");
+            string testFileFolder = Path.Combine(ResultPath, this.TestClassName + "_files");
             string testFilePath = Path.Combine(testFileFolder, filename);
 
             if (Directory.Exists(testFileFolder) == false)
@@ -194,14 +89,6 @@ namespace DocumentFormat.OpenXml.Tests.TaskLibraries
             return testFilePath;
         }
 
-        public FileInfo GetSourceFile(FileInfo testFile)
-        {
-            if (File.Exists("source-" + testFile.Name))
-                File.Delete("source-" + testFile.Name);
-
-            return testFile.CopyTo("source-" + testFile.Name);
-        }
-
         /// <summary>
         /// Get test files in the test file storage.
         /// </summary>
@@ -212,7 +99,7 @@ namespace DocumentFormat.OpenXml.Tests.TaskLibraries
         /// <returns></returns>
         public IEnumerable<FileInfo> GetTestFiles(string sourceFolder, string subFolder)
         {
-            string inputPath = Path.Combine(sourcePath, sourceFolder, subFolder);
+            string inputPath = Path.Combine(SourcePath, sourceFolder, subFolder);
             return new DirectoryInfo(inputPath).GetFiles("*", SearchOption.AllDirectories);
         }
 
@@ -224,7 +111,7 @@ namespace DocumentFormat.OpenXml.Tests.TaskLibraries
         /// <returns></returns>
         public FileInfo GetTestFileOne(string sourceFile)
         {
-            string inputPath = Path.Combine(sourcePath, sourceFile);
+            string inputPath = Path.Combine(SourcePath, sourceFile);
             return new FileInfo(inputPath);
         }
 
@@ -280,7 +167,7 @@ namespace DocumentFormat.OpenXml.Tests.TaskLibraries
         /// <returns></returns>
         public IEnumerable<FileInfo> CopyTestFiles(string sourceFolder, bool recursive, string searchPattern, Func<FileInfo, bool> pred, int? maxFiles = null)
         {
-            string inputPath = Path.Combine(sourcePath, sourceFolder);
+            string inputPath = Path.Combine(SourcePath, sourceFolder);
             string outputPath = this.CurrentResultFolder;
 
             // Cd to the outputPath folder
@@ -321,20 +208,6 @@ namespace DocumentFormat.OpenXml.Tests.TaskLibraries
         }
 
         /// <summary>
-        /// Copy the test file specified with the sourceFile parameter.
-        /// </summary>
-        /// <param name="sourceFile"></param>
-        /// <returns></returns>
-        public FileInfo CopyTestFileOne(string sourceFile)
-        {
-            var sourceFolder = Path.GetDirectoryName(sourceFile);
-            var sourceFileName = Path.GetFileName(sourceFile);
-            Func<FileInfo, bool> pred =
-                file => file.Name.Equals(sourceFileName, StringComparison.OrdinalIgnoreCase);
-            return CopyTestFiles(sourceFolder, false, sourceFileName, pred).First();
-        }
-
-        /// <summary>
         /// Helper method to create result folder.
         /// </summary>
         /// <param name="outputPath"></param>
@@ -371,14 +244,9 @@ namespace DocumentFormat.OpenXml.Tests.TaskLibraries
         {
             // Caculate result folder path
             var resultFolder = this.TestClassName;
-            string outputPath = Path.Combine(resultPath, resultFolder);
+            string outputPath = Path.Combine(ResultPath, resultFolder);
 
-            // Create folder
-            if (!resultFoldersCreated.Contains(outputPath))
-            {
-                resultFoldersCreated.Add(outputPath);
-                CreateResultFolder(outputPath);
-            }
+            CreateResultFolder(outputPath);
 
             // Return folder path
             return outputPath;

--- a/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/AutoSaveTestClass.cs
+++ b/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/AutoSaveTestClass.cs
@@ -44,7 +44,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void DefaultStreamReadOnly()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt")
                .Where(f => f.IsOpenXmlFile());
             foreach (var testfile in testfiles)
@@ -137,7 +136,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void DefaultStreamReadWrite()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt")
                .Where(f => f.IsOpenXmlFile());
             foreach (var testfile in testfiles)
@@ -206,7 +204,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void DefaultStreamWrite()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt")
                .Where(f => f.IsOpenXmlFile());
             foreach (var testfile in testfiles)
@@ -277,7 +274,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void DefaultWithFilePath()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt")
                .Where(f => f.IsOpenXmlFile());
             foreach (var testfile in testfiles)
@@ -339,28 +335,24 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void DefaultPackage_Read_Editable()
         {
-            this.MyTestInitialize();
             OpenPackage(FileAccess.Read, true);
         }
 
         [Fact]
         public void DefaultPackage_Read_NonEditable()
         {
-            this.MyTestInitialize();
             OpenPackage(FileAccess.Read, false);
         }
 
         [Fact]
         public void DefaultPackage_ReadWrite_Editable()
         {
-            this.MyTestInitialize();
             OpenPackage(FileAccess.ReadWrite, true);
         }
 
         [Fact]
         public void DefaultPackage_ReadWrite_NonEditable()
         {
-            this.MyTestInitialize();
             OpenPackage(FileAccess.ReadWrite, false);
         }
 
@@ -411,7 +403,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void AutoSaveStream2x2()
         {
-            this.MyTestInitialize();
             foreach (bool e in IsEditable)
             {
                 foreach (bool s in AutoSave)
@@ -460,21 +451,18 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void AutoSaveMc_2007_NoProcess()
         {
-            this.MyTestInitialize();
             OpenMcPackage(FileFormatVersions.Office2007, MarkupCompatibilityProcessMode.NoProcess);
         }
 
         [Fact]
         public void AutoSaveMc_2007_ProcessAllParts()
         {
-            this.MyTestInitialize();
             OpenMcPackage(FileFormatVersions.Office2007, MarkupCompatibilityProcessMode.ProcessAllParts);
         }
 
         [Fact]
         public void AutoSaveMc_2007_ProcessLoadedParts()
         {
-            this.MyTestInitialize();
             OpenMcPackage(FileFormatVersions.Office2007, MarkupCompatibilityProcessMode.ProcessLoadedPartsOnly);
         }
 
@@ -526,7 +514,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void OpenWithInvalidFileFormatTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles("bvt")
                 .Where(fi => fi.IsOpenXmlFile());
             var testfile = testfiles.FirstOrDefault();
@@ -559,7 +546,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void OpenWithFileFormatVersionsDefaultValueTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles("bvt")
                 .Where(fi => fi.IsOpenXmlFile());
             var testfile = testfiles.FirstOrDefault();
@@ -592,7 +578,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void OpenWithFileFormatVersionsDefaultValueNoMCProcessTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles("bvt")
                 .Where(fi => fi.IsOpenXmlFile());
             var testfile = testfiles.FirstOrDefault();
@@ -634,7 +619,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void CreateWithFalseAutoSaveTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles("bvt")
                 .Where(fi => fi.IsOpenXmlFile());
 
@@ -694,7 +678,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void CreateWithTrueAutoSaveTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles("bvt")
                 .Where(fi => fi.IsOpenXmlFile());
 
@@ -756,7 +739,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void CreateWithNoAutoSaveTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles("bvt")
                 .Where(fi => fi.IsOpenXmlFile());
 

--- a/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/CodeGenSanityTest.cs
+++ b/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/CodeGenSanityTest.cs
@@ -26,7 +26,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ThemeAsPartRootClassTest()
         {
-            this.MyTestInitialize();
             var testfile = CopyTestFiles(@"wordprocessing", true, "complex0.docx", f => f.IsWordprocessingFile())
                 .FirstOrDefault();
 
@@ -99,7 +98,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ThemeAsClassWithFixedOrderChildTest()
         {
-            this.MyTestInitialize();
             var testfile = CopyTestFiles(@"wordprocessing", true, "complex0.docx", f => f.IsWordprocessingFile())
                 .Where(f => f.IsWordprocessingFile() || f.IsSpreadsheetFile())
                 .FirstOrDefault();
@@ -168,7 +166,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ColorAsLeafElementTest()
         {
-            this.MyTestInitialize();
             var testfile = CopyTestFiles(@"wordprocessing", true, "complex0.docx", f => f.IsWordprocessingFile())
                 .FirstOrDefault();
 
@@ -219,7 +216,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void FieldCodeAsLeafTextElement()
         {
-            this.MyTestInitialize();
             var testfile = CopyTestFiles(@"wordprocessing", true, "complex0.docx", f => f.IsWordprocessingFile())
                 .FirstOrDefault();
 
@@ -272,7 +268,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Bug225919_MitigateNamespaceIssue()
         {
-            this.MyTestInitialize();
             //var testfiles = GetTestfile(@"wordprocessing", MethodInfo.GetCurrentMethod().Name)
             //    .Where(f => f.IsWordprocessingFile());
             //var testfiles = GetTestfile(@"spreadsheet", MethodInfo.GetCurrentMethod().Name)

--- a/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/DocumentTraverseTest.cs
+++ b/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/DocumentTraverseTest.cs
@@ -273,7 +273,6 @@ namespace DocumentFormat.OpenXml.Tests
 
         public void TraverseWordDocument()
         {
-            this.MyTestInitialize();
             //description = " Case ID: 75567, 75568, 75505, 75506, 76083, 76084";
             foreach (var testfile in CopyTestFiles(Path.Combine(@"wordprocessing", "paragraph"), false, 3))
             {
@@ -320,7 +319,6 @@ namespace DocumentFormat.OpenXml.Tests
 
         public void TraverseSpreadSheetDocument()
         {
-            this.MyTestInitialize();
             foreach (var testfile in CopyTestFiles(Path.Combine(@"spreadsheet", "smallset"), false, 3))
             {
                 Log.BeginGroup(testfile.Name);
@@ -367,7 +365,6 @@ namespace DocumentFormat.OpenXml.Tests
 
         public void TraversePPTDocument()
         {
-            this.MyTestInitialize();
             foreach (var testfile in CopyTestFiles(Path.Combine(@"presentation", "smallset"), false, 3))
             {
                 Log.BeginGroup(testfile.Name);

--- a/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/GenerateList4LowLevelTest.cs
+++ b/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/GenerateList4LowLevelTest.cs
@@ -24,7 +24,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void TestAutosaveAfterSettingNullRootElement()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault(f => f.IsWordprocessingFile());
 
@@ -54,7 +53,6 @@ namespace DocumentFormat.OpenXml.Tests
         // [Description("O14:537826")]
         public void TestRootElementOfVmlDrawingPartIsLoadedAsUnknown()
         {
-            this.MyTestInitialize();
             var file = CopyTestFiles(@"bugregression", true, "537826.vmlpart.xlsx", f => f.IsSpreadsheetFile())
                 .FirstOrDefault();
 
@@ -75,7 +73,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void TestAssertInInnerTextForPlusSymbol()
         {
-            this.MyTestInitialize();
 
             // same issue for SByteValue, Int16Value, IntegerValue, DecimalValue, SingleValue, DoubleValue
             {
@@ -160,7 +157,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void TestAssertInInnerTextOfDoubleValue()
         {
-            this.MyTestInitialize();
             var v = new DoubleValue();
             v.InnerText = "0.51200000000000001";
             double v2 = v.Value;
@@ -174,7 +170,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void TwiceCallsToLoadAttributeOnUnknown()
         {
-            this.MyTestInitialize();
             var rawxml = @"<dgm14:cNvPr xmlns:dgm14=""http://schemas.microsoft.com/officeart/2007/7/20/diagram"" id=""0"" name="""" />";
             var ele = OpenXmlUnknownElement.CreateOpenXmlUnknownElement(rawxml);
             Log.VerifyTrue(ele.GetAttributes().Count == 2, "ele.GetAttributes().Count"); // The count should be 2 as now namespace declaration is not considered as attribute.
@@ -188,7 +183,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ExceptionForDuplicatedNsDeclarionWhenClosePackage()
         {
-            this.MyTestInitialize();
             var file = CopyTestFiles(@"ForTestCase", true, "Bug571679_Brownbag.pptx", f => f.IsPresentationFile())
                 .FirstOrDefault();
 
@@ -209,7 +203,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void MaxNumberOfErrorsTest()
         {
-            this.MyTestInitialize();
             var file = CopyTestFiles(@"ForTestCase", true, "Bug539654_529755.xlsm", f => f.IsSpreadsheetFile())
                 .FirstOrDefault();
             using (var package = file.OpenPackage(false))
@@ -240,7 +233,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ChangeRelationshipId()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault().GetCopy();
             using (var package = testfile.OpenPackage(true, true))
@@ -322,7 +314,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void LoadCurrentElementTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault().GetCopy();
             using (var package = testfile.OpenPackage(true, true))
@@ -342,7 +333,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void LoadParagraphWithRedefinedPrefixTest()
         {
-            this.MyTestInitialize();
             Log.Comment("Constructing a Paragraph with rawxml...");
             var rawxml = "<w:p w:rsidR=\"006B669D\" w:rsidRDefault=\"006B669D\" w:rsidP=\"006B669D\" xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\" xmlns:myw=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\" >\n"
                 + "	<w12:r xmlns:w12=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\" >\n"
@@ -369,7 +359,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void NamespaceDeclarationForNewUnknownElement()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt")
                 .Where(fi => fi.IsOpenXmlFile());
 

--- a/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/MarkupCompatibilityTest.cs
+++ b/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/MarkupCompatibilityTest.cs
@@ -60,7 +60,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void NonIgnored_UnknownAttribute_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -96,7 +95,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void NonIgnored_UnknownAttribute_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -129,7 +127,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_NonIgnored_UnknownAttribute()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -155,7 +152,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void NonIgnored_UnknownElement_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -189,7 +185,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void NonIgnored_UnknownElement_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -223,7 +218,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_NonIgnored_UnknownElement()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -249,7 +243,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Ignored_UnknownAttribute_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -281,7 +274,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Ignored_UnknownAttribute_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -311,7 +303,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_Ignored_UnknownAttribute()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -334,7 +325,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Ignored_KnownAttribute_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -363,7 +353,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Ignored_KnownAttribute_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -391,7 +380,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_Ignored_KnownAttribute()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -411,7 +399,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Ignored_UnknownElement_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -443,7 +430,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Ignored_UnknownElement_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -475,7 +461,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_Ignored_UnknownElement()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -498,7 +483,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Ignored_KnownElement_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -527,7 +511,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Ignored_KnownElement_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -555,7 +538,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_Ignored_KnownElement()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -575,7 +557,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Ignore_Whitespaces_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -603,7 +584,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_Ignore_Whitespaces()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -630,7 +610,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ProcessContent_Ignored_UnknownElement_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -678,7 +657,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ProcessContent_Ignored_UnknownElement_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -726,7 +704,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_ProcessContent_Ignored_UnknownElement()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -759,7 +736,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ProcessContent_Ignored_UnknownElement_Wildcard_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -807,7 +783,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ProcessContent_NonIgnored_UnknownElement_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -856,7 +831,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ProcessContent_NonIgnored_UnknownElement_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -914,7 +888,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_ProcessContent_NonIgnored_UnknownElement()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -949,7 +922,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ProcessContent_Ignored_KnownElement_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -994,7 +966,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ProcessContent_Ignored_KnownElement_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -1035,7 +1006,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_ProcessContent_Ignored_KnownElement()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -1068,7 +1038,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ProcessContent_xmlSpace_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -1120,7 +1089,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ProcessContent_xmlLang_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -1172,7 +1140,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_ProcessContent_xmlLang()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -1211,7 +1178,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Preserve_Ignored_UnknownElement_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -1269,7 +1235,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Preserve_Ignored_UnknownElement_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -1331,7 +1296,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_Preserve_Ignored_UnknownElement()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -1377,7 +1341,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Preserve_Ignored_UnknownElement_InnerIgnorable_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -1449,7 +1412,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Preserve_Ignored_UnknownElement_InnerIgnorable_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -1523,7 +1485,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_Preserve_Ignored_UnknownElement_InnerIgnorable()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -1581,7 +1542,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Preserve_Ignored_UnknownElement_Wildcard_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -1639,7 +1599,6 @@ namespace DocumentFormat.OpenXml.Tests
         //[Fact]
         public void Preserve_Ignored_UnknownElement_Wildcard_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -1701,7 +1660,6 @@ namespace DocumentFormat.OpenXml.Tests
         //[Fact]
         public void Validate_Preserve_Ignored_UnknownElement_Wildcard()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -1747,7 +1705,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Preserve_NonIgnored_UnknownElement_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -1803,7 +1760,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Preserve_NonIgnored_UnknownElement_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -1866,7 +1822,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_Preserve_NonIgnored_UnknownElement()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -1910,7 +1865,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Preserve_NonIgnored_UnknownAttribute_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -1963,7 +1917,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Preserve_NonIgnored_UnknownAttribute_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2025,7 +1978,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_Preserve_NonIgnored_UnknownAttribute()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2068,7 +2020,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Preserve_NoElement_UnknownAttribute_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2124,7 +2075,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Preserve_NoElement_UnknownAttribute_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2188,7 +2138,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_Preserve_NoElement_UnknownAttribute()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2236,7 +2185,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void MustUnderstand_Ignored_UnknownElement_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2284,7 +2232,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void MustUnderstand_Ignored_UnknownElement_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2341,7 +2288,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_MustUnderstand_Ignored_UnknownElement()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2378,7 +2324,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void MustUnderstand_NonIgnored_UnknownElement_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2420,7 +2365,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void MustUnderstand_NonIgnored_UnknownElement_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2472,7 +2416,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_MustUnderstand_NonIgnored_UnknownElement()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2509,7 +2452,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void NoChoice_NoFallback_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2538,7 +2480,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void NoChoice_NoFallback_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2572,7 +2513,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_NoChoice_NoFallback()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2591,7 +2531,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void OneChoice_NoFallback_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2621,7 +2560,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void OneChoice_NoFallback_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2647,7 +2585,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_OneChoice_NoFallback()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2666,7 +2603,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void MultipleChoice_NoMatches_NoFallback_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2693,7 +2629,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void MultipleChoice_NoMatches_NoFallback_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2723,7 +2658,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_MultipleChoice_NoMatches_NoFallback()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2743,7 +2677,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void MultipleChoice_NoMatches_OneFallback_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2770,7 +2703,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void MultipleChoice_NoMatches_OneFallback_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2800,7 +2732,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_MultipleChoice_NoMatches_OneFallback()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2819,7 +2750,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void MultipleChoice_OneFallback_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2845,7 +2775,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void MultipleChoice_OneFallback_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2871,7 +2800,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_MultipleChoice_OneFallback()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2890,7 +2818,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void MultipleChoice_LeadingFallback_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2916,7 +2843,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void MultipleChoice_LeadingFallback_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2954,7 +2880,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_MultipleChoice_LeadingFallback()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2973,7 +2898,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void OneChoice_MultipleFallback_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -2999,7 +2923,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void OneChoice_MultipleFallback_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -3036,7 +2959,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_OneChoice_MultipleFallback()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -3055,7 +2977,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void MustUnderstand_Unselected_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -3093,7 +3014,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void MustUnderstand_Unselected_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -3141,7 +3061,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_MustUnderstand_Unselected()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -3171,7 +3090,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void MultipleChoice_OneFallback_Ignorable_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -3206,7 +3124,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void MultipleChoice_OneFallback_Ignorable_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -3241,7 +3158,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_MultipleChoice_OneFallback_Ignorable()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -3269,7 +3185,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void MultipleChoice_OneFallback_UnPrefixedMCAttributes_FullMode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -3305,7 +3220,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void MultipleChoice_OneFallback_UnPrefixedMCAttributes_O12Mode()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 
@@ -3341,7 +3255,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_MultipleChoice_OneFallback_UnPrefixedMCAttributes()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"bvt");
             var testfile = testfiles.FirstOrDefault();
 

--- a/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/OpenXmlCompositeElementTestClass.cs
+++ b/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/OpenXmlCompositeElementTestClass.cs
@@ -21,7 +21,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void DummyObjectForEmptyChildElementsTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -48,7 +47,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void AppendArrayPPTTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "presentation")
                 .Where(f => f.IsPresentationFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
@@ -61,7 +59,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void AppendArrayXSLTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "spreadsheet")
                 .Where(f => f.IsSpreadsheetFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
@@ -74,7 +71,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void AppendIEnumerableTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -86,7 +82,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void AppendIEnumerablePPTTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "presentation")
                 .Where(f => f.IsPresentationFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
@@ -98,7 +93,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void AppendIEnumerableXSLTest()
         {
-            this.MyTestInitialize();
 
             FileInfo source = GetTestFiles(@"asSources", "spreadsheet")
                 .Where(f => f.IsSpreadsheetFile()).FirstOrDefault();
@@ -116,7 +110,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void AppendChildTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -129,7 +122,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void AppendChildPPTTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "presentation")
                 .Where(f => f.IsPresentationFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
@@ -142,7 +134,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void AppendChildXSLTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "spreadsheet")
                 .Where(f => f.IsSpreadsheetFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
@@ -155,7 +146,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void PreppendChildTest()
         {
-            this.MyTestInitialize();
 			FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -168,7 +158,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void PreppendChildPPTTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "presentation")
                 .Where(f => f.IsPresentationFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
@@ -180,7 +169,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void PreppendChildXSLTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "spreadsheet")
                 .Where(f => f.IsSpreadsheetFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
@@ -196,7 +184,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void InsertBeforeTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -211,7 +198,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void InsertBeforePPTTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "presentation")
                 .Where(f => f.IsPresentationFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
@@ -227,7 +213,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void InsertBeforeXSLTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "spreadsheet")
                 .Where(f => f.IsSpreadsheetFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
@@ -242,7 +227,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void InsertAfterTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -257,7 +241,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void InsertAfterPPTTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "presentation")
                 .Where(f => f.IsPresentationFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
@@ -272,7 +255,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void InsertAfterXSLTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "spreadsheet")
                 .Where(f => f.IsSpreadsheetFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
@@ -291,7 +273,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void InsertAtTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -306,7 +287,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void InsertAtPPTTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "presentation")
                 .Where(f => f.IsPresentationFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
@@ -324,7 +304,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void InsertAtXSLTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "spreadsheet")
                 .Where(f => f.IsSpreadsheetFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
@@ -346,7 +325,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void InsertRelativeTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -361,7 +339,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void InsertRelativePPTTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "presentation")
                 .Where(f => f.IsPresentationFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
@@ -376,7 +353,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void InsertRelativeXSLTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "spreadsheet")
                 .Where(f => f.IsSpreadsheetFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
@@ -395,7 +371,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void RemoveAllChildrenTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -409,7 +384,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void RemoveAllChildrenPPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                 .Where(f => f.IsPresentationFile());
 
@@ -424,7 +398,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void RemoveAllChildrenXSLTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
                 .Where(f => f.IsSpreadsheetFile());
 
@@ -439,7 +412,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void RemoveAllTypedChildrenTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -452,7 +424,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void RemoveAllTypedChildrenPPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                 .Where(f => f.IsPresentationFile());
 
@@ -467,7 +438,6 @@ namespace DocumentFormat.OpenXml.Tests
         //cannot getAnyWithLeafAndCompositeElement
         public void RemoveAllTypedChildrenXSLTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
                 .Where(f => f.IsSpreadsheetFile());
 
@@ -485,7 +455,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void RemoveChildTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -498,7 +467,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void RemoveChildPPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                 .Where(f => f.IsPresentationFile());
 
@@ -513,7 +481,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void RemoveChildXSLTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
                 .Where(f => f.IsSpreadsheetFile());
 
@@ -528,7 +495,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void RemoveTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -542,7 +508,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void RemovePPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                 .Where(f => f.IsPresentationFile());
 
@@ -558,7 +523,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void RemoveXSLTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
                 .Where(f => f.IsSpreadsheetFile());
 
@@ -577,7 +541,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ReplaceChildTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -592,7 +555,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ReplaceChildPPTTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "presentation")
                 .Where(f => f.IsPresentationFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
@@ -609,7 +571,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ReplaceChildXSLTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "spreadsheet")
                 .Where(f => f.IsSpreadsheetFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
@@ -642,7 +603,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void OpenXmlAttributeValueTypeTest()
         {
-            this.MyTestInitialize();
             Log.Comment("Constructing a default OpenXmlAttribute and assign it to another variable...");
             var oxaX = default(OpenXmlAttribute);
             var oxaY = oxaX;
@@ -665,7 +625,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void OpenXmlAttributeEqualTest()
         {
-            this.MyTestInitialize();
             Log.Comment("Comparing two default OpenXmlAttribute...");
             var defaultA = default(OpenXmlAttribute);
             var defaultB = default(OpenXmlAttribute);
@@ -697,7 +656,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void DummyIEnumerableForExtendedAttributesTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -720,7 +678,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void GetAttributeTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -733,7 +690,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void GetAttributePPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                 .Where(f => f.IsPresentationFile());
 
@@ -746,7 +702,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void GetAttributeXSLTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
                 .Where(f => f.IsSpreadsheetFile());
 
@@ -764,7 +719,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void GetAttributesTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -778,7 +732,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void GetAttributesPPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                 .Where(f => f.IsPresentationFile());
 
@@ -792,7 +745,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void GetAttributesXSLTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
                 .Where(f => f.IsSpreadsheetFile());
 
@@ -810,7 +762,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void SetAttributeTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -825,7 +776,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void SetAttributePPTTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "presentation")
                 .Where(f => f.IsPresentationFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
@@ -840,7 +790,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void SetAttributeXSLTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "spreadsheet")
                 .Where(f => f.IsSpreadsheetFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
@@ -855,7 +804,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void SetAttributesTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -871,7 +819,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void SetAttributesPPTTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources","presentation")
                 .Where(f => f.IsPresentationFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
@@ -887,7 +834,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void SetAttributesXSLTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "spreadsheet")
                 .Where(f => f.IsSpreadsheetFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
@@ -907,7 +853,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void RemoveAttributeTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -923,7 +868,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void RemoveAttributePPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                .Where(f => f.IsPresentationFile());
 
@@ -936,7 +880,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void RemoveAttributeXSLTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
                 .Where(f => f.IsSpreadsheetFile());
 
@@ -953,7 +896,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ClearAllAttributesTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -967,7 +909,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ClearAllAttributesPPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                .Where(f => f.IsPresentationFile());
 
@@ -981,7 +922,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ClearAllAttributesXSLTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
                 .Where(f => f.IsSpreadsheetFile());
 
@@ -998,7 +938,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void AddNamespaceDeclarationTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -1016,7 +955,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void NamespaceDeclarationsTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -1032,7 +970,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void RemoveNamespaceDeclarationTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -1050,7 +987,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void GetOuterXmlTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -1066,7 +1002,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void GetOuterXmlPPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                .Where(f => f.IsPresentationFile());
 
@@ -1082,7 +1017,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void GetOuterXmlXSLTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
                 .Where(f => f.IsSpreadsheetFile());
 
@@ -1102,7 +1036,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void CloneTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -1118,7 +1051,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ClonePPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                .Where(f => f.IsPresentationFile());
 
@@ -1134,7 +1066,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void CloneXSLTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
                 .Where(f => f.IsSpreadsheetFile());
 
@@ -1150,7 +1081,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void CloneNodeFalseTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(System.IO.Path.Combine(@"wordprocessing", "paragraph"), true, "empty.docx", f => f.IsWordprocessingFile(), 1);
 
             foreach (var testfile in testfiles)
@@ -1165,7 +1095,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void CloneNodeFalsePPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                .Where(f => f.IsPresentationFile());
 
@@ -1181,7 +1110,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void CloneNodeFalseXSLTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
                 .Where(f => f.IsSpreadsheetFile());
 
@@ -1201,7 +1129,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void GetInnerXmlTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -1215,7 +1142,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void GetInnerXmlPPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                .Where(f => f.IsPresentationFile());
 
@@ -1229,7 +1155,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void GetInnerXmlXSLTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
                 .Where(f => f.IsSpreadsheetFile());
 
@@ -1243,7 +1168,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void SetInnerXmlPPTTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "presentation")
                 .Where(f => f.IsPresentationFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
@@ -1261,7 +1185,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void SetInnerXmlXSLTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "spreadsheet")
                 .Where(f => f.IsSpreadsheetFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
@@ -1283,7 +1206,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void WriteToTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -1299,7 +1221,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void WriteToPPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                .Where(f => f.IsPresentationFile());
 
@@ -1315,7 +1236,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void WriteToXSLTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
                 .Where(f => f.IsSpreadsheetFile());
 
@@ -1341,7 +1261,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventAppendChildTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -1357,7 +1276,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventPreppendChildTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -1373,7 +1291,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventAppendArrayTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -1390,7 +1307,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventAppendIEnumerableTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -1406,7 +1322,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventInsertBeforeTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -1425,7 +1340,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventInsertAfterTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -1444,7 +1358,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventInsertAtTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -1462,7 +1375,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventInsertRelativeTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -1481,7 +1393,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventRemoveAllChildrenTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -1498,7 +1409,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventRemoveAllTypedChildrenTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -1514,7 +1424,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventRemoveChildTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -1530,7 +1439,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventRemoveTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -1548,7 +1456,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventReplaceChildTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -1572,7 +1479,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventGetAttributeTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -1586,7 +1492,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventGetAttributesTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -1606,7 +1511,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventSetAttributeTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -1626,7 +1530,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventSetAttributesTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -1648,7 +1551,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventRemoveAttributeTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -1668,7 +1570,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventClearAllAttributesTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -1690,7 +1591,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventGetOuterXmlTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -1710,7 +1610,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventCloneTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -1730,7 +1629,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventCloneNodeFalseTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -1750,7 +1648,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventGetInnerXmlTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -1768,7 +1665,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventSetInnerXmlTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -1789,7 +1685,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventWriteToTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -1811,7 +1706,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventAppendChildPPTTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "presentation")
                 .Where(f => f.IsPresentationFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
@@ -1827,7 +1721,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventPreppendChildPPTTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "presentation")
                 .Where(f => f.IsPresentationFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
@@ -1843,7 +1736,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventAppendArrayPPTTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "presentation")
                 .Where(f => f.IsPresentationFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
@@ -1860,7 +1752,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventAppendIEnumerablePPTTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "presentation")
                 .Where(f => f.IsPresentationFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
@@ -1877,7 +1768,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventInsertBeforePPTTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "presentation")
                 .Where(f => f.IsPresentationFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
@@ -1894,7 +1784,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventInsertAfterPPTTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "presentation")
                 .Where(f => f.IsPresentationFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
@@ -1911,7 +1800,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventInsertAtPPTTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "presentation")
                 .Where(f => f.IsPresentationFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
@@ -1931,7 +1819,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventInertRelativePPTTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "presentation")
                 .Where(f => f.IsPresentationFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
@@ -1948,7 +1835,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventRemoveAllChildrenPPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                .Where(f => f.IsPresentationFile());
 
@@ -1964,7 +1850,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventRemoveAllTypedChildrenPPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                .Where(f => f.IsPresentationFile());
 
@@ -1978,7 +1863,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventRemoveChildPPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                .Where(f => f.IsPresentationFile());
 
@@ -1996,7 +1880,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventRemovePPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                .Where(f => f.IsPresentationFile());
 
@@ -2015,7 +1898,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventReplaceChildPPTTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "presentation")
                 .Where(f => f.IsPresentationFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
@@ -2041,7 +1923,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventGetAttributePPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                 .Where(f => f.IsPresentationFile());
 
@@ -2055,7 +1936,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventGetAttributesPPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                 .Where(f => f.IsPresentationFile());
 
@@ -2071,7 +1951,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventSetAttributePPTTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "presentation")
                 .Where(f => f.IsPresentationFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
@@ -2093,7 +1972,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventSetAttributesPPTTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "presentation")
                 .Where(f => f.IsPresentationFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
@@ -2113,7 +1991,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventRemoveAttributePPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                 .Where(f => f.IsPresentationFile());
 
@@ -2130,7 +2007,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventClearAllAttributesPPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                 .Where(f => f.IsPresentationFile());
 
@@ -2148,7 +2024,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventGetOuterXmlPPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                 .Where(f => f.IsPresentationFile());
 
@@ -2168,7 +2043,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventClonePPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                 .Where(f => f.IsPresentationFile());
 
@@ -2188,7 +2062,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventCloneNodeFalsePPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                 .Where(f => f.IsPresentationFile());
 
@@ -2208,7 +2081,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventGetInnerXmlPPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                 .Where(f => f.IsPresentationFile());
 
@@ -2226,7 +2098,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventSetInnerXmlPPTTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "presentation")
                 .Where(f => f.IsPresentationFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
@@ -2250,7 +2121,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EventWriteToPPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                 .Where(f => f.IsPresentationFile());
 
@@ -2281,7 +2151,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void AnnotationTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -2307,7 +2176,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void AnnotationPPTTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"presentation", "smallset")
                .Where(f => f.IsPresentationFile());
 
@@ -2333,7 +2201,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void AnnotationXSLTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"spreadsheet", "smallset")
               .Where(f => f.IsSpreadsheetFile());
 
@@ -2363,7 +2230,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void AppendArrayWithElementsOnTree()
         {
-            this.MyTestInitialize();
             CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile())
                .FirstOrDefault().OpenPackage(true).MainPart().RootElement()
@@ -2379,7 +2245,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void AppentArryWithElementsOnTreePPT()
         {
-            this.MyTestInitialize();
             CopyTestFiles(@"presentation", "smallset")
                 .Where(f => f.IsPresentationFile())
                 .FirstOrDefault().OpenPackage(true).MainPart().RootElement()
@@ -2395,7 +2260,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void AppentArryWithElementsOnTreeXSLT()
         {
-            this.MyTestInitialize();
             CopyTestFiles(@"spreadsheet", "smallset")
                 .Where(f => f.IsSpreadsheetFile())
                 .FirstOrDefault().OpenPackage(true).MainPart().RootElement()
@@ -2415,7 +2279,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Bug242463_SetRootXmlTest()
         {
-            this.MyTestInitialize();
             FileInfo source = GetTestFiles(@"asSources", "wordprocessing")
                 .Where(f => f.IsWordprocessingFile()).FirstOrDefault();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
@@ -2436,7 +2299,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Bug247894_LoadDocumentTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph")
                .Where(f => f.IsWordprocessingFile());
 
@@ -2454,7 +2316,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Bug242602_UnknownElement_Text()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"ForTestCase", true, "*.docx", f => f.IsOpenXmlFile() && f.Name.EndsWith(@"Bug242602_SDT - unknown.docx"));
 
             foreach (var testfile in testfiles)
@@ -2478,7 +2339,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Bug201775_lockedCanvas()
         {
-            this.MyTestInitialize();
             var testfile = CopyTestFiles(@"ForTestCase", true, "Bug201775_testfile.docx", f => f.IsOpenXmlFile()).FirstOrDefault();
 
             using (var package = testfile.OpenPackage(false))
@@ -2502,7 +2362,6 @@ namespace DocumentFormat.OpenXml.Tests
         // [Description("Office14: 687665")]
         public void Bug687665_NewElementFromOuterXmlWithACB()
         {
-            this.MyTestInitialize();
             try
             {
                 Log.Comment("Constructing Paragraph with OuterXml...");
@@ -2531,7 +2390,6 @@ namespace DocumentFormat.OpenXml.Tests
         // [Description("Office14: 680607")]
         public void Bug680607_SaveOutWord14Beta2File()
         {
-            this.MyTestInitialize();
             var testfile = CopyTestFiles("bugregression", true, "680607.HelloO14.docx", f => f.IsWordprocessingFile())
                 .FirstOrDefault();
 
@@ -2586,7 +2444,6 @@ namespace DocumentFormat.OpenXml.Tests
         // [Description("671248")]
         public void Bug671248_ExtendedAndMcAttributesAfterConstructingWithOuterXml()
         {
-            this.MyTestInitialize();
             string paragraphXml = "<w:p xmlns:mc=\"http://schemas.openxmlformats.org/markup-compatibility/2006\" mc:Ignorable=\"w14\" "
                 + "xmlns:w14=\"http://schemas.microsoft.com/office/word/2007/5/30/wordml\" "
                 + "xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\" "

--- a/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/OpenXmlDomTestBase.cs
+++ b/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/OpenXmlDomTestBase.cs
@@ -26,10 +26,8 @@ namespace DocumentFormat.OpenXml.Tests
     public class OpenXmlDomTestBase : OpenXmlTestBase
     {
         public OpenXmlDomTestBase(ITestOutputHelper output)
-            : base(output)
+            : base(output, "v2FxTestFiles")
         {
-            // Specify source path which includes test input files
-            this.SourcePath = @"v2FxTestFiles";
         }
 
         #region Delegation ...

--- a/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/OpenXmlReaderWriterTest.cs
+++ b/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/OpenXmlReaderWriterTest.cs
@@ -93,7 +93,6 @@ namespace DocumentFormat.OpenXml.Tests
 
         public void WriteStartDocumentTest()
         {
-            this.MyTestInitialize();
             TestWriteStartDocument(WConstrWithPart, WriteStartD, null);
         }
 
@@ -101,7 +100,6 @@ namespace DocumentFormat.OpenXml.Tests
 
         public void WriteStartDocumentWithStandalone()
         {
-            this.MyTestInitialize();
             TestWriteStartDocument(WConstrWithPartEnc, WriteStartD, true);
         }
 
@@ -109,8 +107,8 @@ namespace DocumentFormat.OpenXml.Tests
 
         public void WriteStartDocumentMultiple()
         {
-            this.MyTestInitialize();
             string file = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString().Replace("-", "") + ".docx");
+
             using (WordprocessingDocument newDoc = WordprocessingDocument.Create(file, WordprocessingDocumentType.Document))
             {
                 MainDocumentPart part = newDoc.AddMainDocumentPart();
@@ -135,7 +133,6 @@ namespace DocumentFormat.OpenXml.Tests
 
         public void WriteStartDocumentOtherPlace()
         {
-            this.MyTestInitialize();
             string file = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString().Replace("-", "") + ".docx");
             using (WordprocessingDocument newDoc = WordprocessingDocument.Create(file, WordprocessingDocumentType.Document))
             {
@@ -162,7 +159,6 @@ namespace DocumentFormat.OpenXml.Tests
 
         public void WriteStartElementWithOpenXmlReaderAttr()
         {
-            this.MyTestInitialize();
             Paragraph p = new Paragraph(new Run(new Text("test"))) { RsidParagraphAddition = "00000000", RsidRunAdditionDefault = "00B27B3B" };
             OpenXmlReader reader = OpenXmlReader.Create(p);
             reader.Read();
@@ -174,7 +170,6 @@ namespace DocumentFormat.OpenXml.Tests
 
         public void WriteStartElementWithOpenXmlReader()
         {
-            this.MyTestInitialize();
             Paragraph p = new Paragraph(new Run(new Text("test"))) { RsidParagraphAddition = "00000000", RsidRunAdditionDefault = "00B27B3B" };
             OpenXmlReader reader = OpenXmlReader.Create(p);
             reader.Read();
@@ -186,7 +181,6 @@ namespace DocumentFormat.OpenXml.Tests
 
         public void WriteStartElementWithEndElementReader()
         {
-            this.MyTestInitialize();
             Paragraph p = new Paragraph(new Run(new Text("test"))) { RsidParagraphAddition = "00000000", RsidRunAdditionDefault = "00B27B3B" };
             OpenXmlReader reader = OpenXmlReader.Create(p);
             reader.Read();
@@ -207,7 +201,6 @@ namespace DocumentFormat.OpenXml.Tests
 
         public void WriteStartElementWithOpenXmlElementAttr()
         {
-            this.MyTestInitialize();
             Paragraph p = new Paragraph(new Run(new Text("test"))) { RsidParagraphAddition = "00000000", RsidRunAdditionDefault = "00B27B3B" };
 
             TestWriteStartElement(WConstrWithStream, WriteStartE, p, GetTestAttributes(), null);
@@ -217,7 +210,6 @@ namespace DocumentFormat.OpenXml.Tests
 
         public void WriteStartElementWithOpenXmlElement()
         {
-            this.MyTestInitialize();
             Paragraph p = new Paragraph(new Run(new Text("test"))) { RsidParagraphAddition = "00000000", RsidRunAdditionDefault = "00B27B3B" };
 
             TestWriteStartElement(WConstrWithStream, WriteStartE, p, null, null);
@@ -227,7 +219,6 @@ namespace DocumentFormat.OpenXml.Tests
 
         public void WriteStringAndEndElement()
         {
-            this.MyTestInitialize();
             string file = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString().Replace("-", "") + ".docx");
 
             Text t = new Text();
@@ -261,7 +252,6 @@ namespace DocumentFormat.OpenXml.Tests
 
         public void WriteEndElementWithoutStart()
         {
-            this.MyTestInitialize();
             string file = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString().Replace("-", "") + ".docx");
             Text t = new Text();
             using (WordprocessingDocument newDoc = WordprocessingDocument.Create(file, WordprocessingDocumentType.Document))
@@ -286,10 +276,8 @@ namespace DocumentFormat.OpenXml.Tests
         // Comment out as the result of bug 2352836
         //
         [Fact]
-
         public void WriteStringWithNonLeafText()
         {
-            this.MyTestInitialize();
             Paragraph p = new Paragraph() { RsidParagraphAddition = "00000000", RsidRunAdditionDefault = "00B27B3B" };
             string file = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".docx");
             using (WordprocessingDocument newDoc = WordprocessingDocument.Create(file, WordprocessingDocumentType.Document))
@@ -312,10 +300,8 @@ namespace DocumentFormat.OpenXml.Tests
         }
 
         [Fact]
-
         public void WriteElement()
         {
-            this.MyTestInitialize();
             Paragraph p = new Paragraph(new Run(new Text("test"))) { RsidParagraphAddition = "00000000", RsidRunAdditionDefault = "00B27B3B" };
             string file = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".docx");
             using (WordprocessingDocument newDoc = WordprocessingDocument.Create(file, WordprocessingDocumentType.Document))
@@ -335,11 +321,8 @@ namespace DocumentFormat.OpenXml.Tests
         }
 
         [Fact]
-
         public void WriteStartElementWithMisc()
         {
-
-            this.MyTestInitialize();
             OpenXmlMiscNode node = new OpenXmlMiscNode(XmlNodeType.Comment);
 
             OpenXmlReader miscReader = OpenXmlReader.Create(node, true);
@@ -359,7 +342,6 @@ namespace DocumentFormat.OpenXml.Tests
 
         private void TestWriteStartDocument(ConstrWriter writerConstr, WriteStartDoc write, bool? standalone)
         {
-            this.MyTestInitialize();
             string file = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString().Replace("-", "") + ".docx");
             using (WordprocessingDocument newDoc = WordprocessingDocument.Create(file, WordprocessingDocumentType.Document))
             {
@@ -439,7 +421,6 @@ namespace DocumentFormat.OpenXml.Tests
 
         private void TestWriteStartElement(ConstrWriter writerConstr, WriteStartEle write, object writeSource, IEnumerable<OpenXmlAttribute> attributes, IEnumerable<KeyValuePair<string, string>> namespaceDeclarations)
         {
-            this.MyTestInitialize();
             string file = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString().Replace("-", "") + ".docx");
             using (WordprocessingDocument newDoc = WordprocessingDocument.Create(file, WordprocessingDocumentType.Document))
             {
@@ -1242,7 +1223,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void bug247883()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph").Where(fi => fi.IsWordprocessingFile());
             var testfile0 = testfiles.ElementAtOrDefault(0);
             var testfile1 = testfiles.ElementAtOrDefault(1);
@@ -1259,7 +1239,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void bug251677()
         {
-            this.MyTestInitialize();
             Body body = new Body(new Paragraph(new ParagraphProperties(), new Run(new Text("test"))));
             body.PrependChild(new OpenXmlMiscNode(System.Xml.XmlNodeType.Comment, "<!-- start body -->"));
 
@@ -1273,7 +1252,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void bug251835_ReaderDispose()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles(@"wordprocessing", "paragraph").Where(fi => fi.IsWordprocessingFile());
             var testfile = testfiles.FirstOrDefault();
             try
@@ -1297,7 +1275,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Bug253893_Write2Declaration()
         {
-            this.MyTestInitialize();
             string file = Path.Combine(TestUtil.TestResultsDirectory, Guid.NewGuid().ToString() + ".docx");
             using (WordprocessingDocument doc = WordprocessingDocument.Create(file, WordprocessingDocumentType.Document))
             {

--- a/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/OpenXmlRootElementTestClass.cs
+++ b/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/OpenXmlRootElementTestClass.cs
@@ -15,7 +15,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void PartRootElementFactoryTest()
         {
-            this.MyTestInitialize();
             var testfiles = CopyTestFiles("asSources")
                .Where(f => f.IsOpenXmlFile());
 

--- a/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/SimpleTypeTest.cs
+++ b/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/SimpleTypeTest.cs
@@ -1,15 +1,8 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+using DocumentFormat.OpenXml.Wordprocessing;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.IO;
-using System.Reflection;
-
-using DocumentFormat.OpenXml;
-using DocumentFormat.OpenXml.Packaging;
-using DocumentFormat.OpenXml.Wordprocessing;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -36,8 +29,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void EnumValueTest()
         {
-            this.MyTestInitialize();
-
             DocumentFormat.OpenXml.Wordprocessing.TableCellMarginDefault tablecellmar = new DocumentFormat.OpenXml.Wordprocessing.TableCellMarginDefault();
             tablecellmar.AppendChild(new DocumentFormat.OpenXml.Wordprocessing.LeftMargin());
             var leftmar = tablecellmar.TableCellLeftMargin;
@@ -257,7 +248,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ListValueTest()
         {
-            this.MyTestInitialize();
             //String, Int32, UInt32, Boolean used as T in OpenXml SDK
             String defaultValue = default(String);
             String validString = "Normal String Content";
@@ -386,7 +376,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void StringValueTest()
         {
-            this.MyTestInitialize();
             String defaultValue = default(String);
             String validValue = "Normal String Content";
             String specialString = @"</pPr>";
@@ -510,7 +499,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Base64BinaryValueTest()
         {
-            this.MyTestInitialize();
             String defaultValue = default(String);
             String validValue = "Normal String Content";
             String specialString = @"</pPr>";
@@ -634,7 +622,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void HexBinaryValueTest()
         {
-            this.MyTestInitialize();
             String defaultValue = default(String);
             String validValue = "Normal String Content";
             String specialString = @"</pPr>";
@@ -758,7 +745,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void OnOffValueTest()
         {
-            this.MyTestInitialize();
             bool maxValue = true;
             bool minValue = false;
             bool validValue = true;
@@ -870,7 +856,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void TrueFalseBlankValueTest()
         {
-            this.MyTestInitialize();
             bool maxValue = true;
             bool minValue = false;
             bool validValue = true;
@@ -1121,7 +1106,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void BooleanValueTest()
         {
-            this.MyTestInitialize();
             Boolean defaultValue = default(Boolean);
             Boolean maxValue = true;
             Boolean minValue = false;
@@ -1240,7 +1224,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void ByteValueTest()
         {
-            this.MyTestInitialize();
             Byte defaultValue = default(Byte);
             Byte maxValue = Byte.MaxValue;
             Byte minValue = Byte.MinValue;
@@ -1308,7 +1291,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void SByteValueTest()
         {
-            this.MyTestInitialize();
             SByte defaultValue = default(SByte);
             SByte maxValue = SByte.MaxValue;
             SByte minValue = SByte.MinValue;
@@ -1376,7 +1358,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void UInt16ValueTest()
         {
-            this.MyTestInitialize();
             UInt16 defaultValue = default(UInt16);
             UInt16 maxValue = UInt16.MaxValue;
             UInt16 minValue = UInt16.MinValue;
@@ -1444,7 +1425,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void UInt32ValueTest()
         {
-            this.MyTestInitialize();
             UInt32 defaultValue = default(UInt32);
             UInt32 maxValue = UInt32.MaxValue;
             UInt32 minValue = UInt32.MinValue;
@@ -1512,7 +1492,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Int32ValueTest()
         {
-            this.MyTestInitialize();
             Int32 defaultValue = default(Int32);
             Int32 maxValue = Int32.MaxValue;
             Int32 minValue = Int32.MinValue;
@@ -1580,7 +1559,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void UInt64ValueTest()
         {
-            this.MyTestInitialize();
             UInt64 defaultValue = default(UInt64);
             UInt64 maxValue = UInt64.MaxValue;
             UInt64 minValue = UInt64.MinValue;
@@ -1648,7 +1626,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Int64ValueTest()
         {
-            this.MyTestInitialize();
             Int64 defaultValue = default(Int64);
             Int64 maxValue = Int64.MaxValue;
             Int64 minValue = Int64.MinValue;
@@ -1719,7 +1696,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void IntegerValueTest()
         {
-            this.MyTestInitialize();
             Int64 defaultValue = default(Int64);
             Int64 maxValue = Int64.MaxValue;
             Int64 minValue = Int64.MinValue;
@@ -1790,7 +1766,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void DecimalValueTest()
         {
-            this.MyTestInitialize();
             Decimal defaultValue = default(Decimal);
             Decimal maxValue = Decimal.MaxValue;
             Decimal minValue = Decimal.MinValue;
@@ -1871,7 +1846,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void SingleValueTest()
         {
-            this.MyTestInitialize();
             Single defaultValue = default(Single);
             Single maxValue = Single.MaxValue;
             Single minValue = Single.MinValue;
@@ -2005,7 +1979,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void DoubleValueTest()
         {
-            this.MyTestInitialize();
             Double defaultValue = default(Double);
             Double maxValue = Double.MaxValue;
             Double minValue = Double.MinValue;
@@ -2139,7 +2112,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void DateTimeValueTest()
         {
-            this.MyTestInitialize();
             DateTime defaultValue = default(DateTime);
             DateTime maxValue = DateTime.MaxValue;
             DateTime minValue = DateTime.MinValue;

--- a/DocumentFormat.OpenXml.Tests/ofapiTest/BugRegressionTest.cs
+++ b/DocumentFormat.OpenXml.Tests/ofapiTest/BugRegressionTest.cs
@@ -20,7 +20,6 @@ namespace DocumentFormat.OpenXml.Tests
     /// <summary>
     /// Summary description for BugRegressionTest
     /// </summary>
-
     public class BugRegressionTest : OpenXmlDomTestBase
     {
         /// <summary>
@@ -29,28 +28,7 @@ namespace DocumentFormat.OpenXml.Tests
         public BugRegressionTest(ITestOutputHelper output)
             : base(output)
         {
-            //
-            // TODO: Add constructor logic here
-            //
         }
-
-        //private TestContext testContextInstance;
-
-        ///// <summary>
-        /////Gets or sets the test context which provides
-        /////information about and functionality for the current test run.
-        /////</summary>
-        //public TestContext TestContext
-        //{
-        //    get
-        //    {
-        //        return testContextInstance;
-        //    }
-        //    set
-        //    {
-        //        testContextInstance = value;
-        //    }
-        //}
 
         /// <summary>
         /// Regress OpenXmlValidator bugs when validating against Office2007.
@@ -58,7 +36,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validator2007BugRegressionTest()
         {
-            this.MyTestInitialize();
 
             OpenXmlValidator validator = new OpenXmlValidator(FileFormatVersions.Office2007);
 
@@ -85,7 +62,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validator2010BugRegressionTest()
         {
-            this.MyTestInitialize();
 
             OpenXmlValidator validator = new OpenXmlValidator(FileFormatVersions.Office2010);
 
@@ -460,7 +436,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Bug448241()
         {
-            this.MyTestInitialize();
             DocumentFormat.OpenXml.Wordprocessing.TableCellMarginDefault tablecellmar = new DocumentFormat.OpenXml.Wordprocessing.TableCellMarginDefault();
             var wrongChild = tablecellmar.AppendChild(new DocumentFormat.OpenXml.Wordprocessing.LeftMargin());
             var leftmar = tablecellmar.TableCellLeftMargin;
@@ -517,7 +492,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Bug396358()
         {
-            this.MyTestInitialize();
             string file = Path.Combine(TestUtil.TestResultsDirectory, this.TestClassName, Guid.NewGuid().ToString().Replace("-", "") + ".xlsx");
             CopyFileStream(TestFileStreams.mailmerge, file);
             using (WordprocessingDocument doc = WordprocessingDocument.Open(file, true))
@@ -551,7 +525,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Bug537858()
         {
-            this.MyTestInitialize();
             string file = Path.Combine(TestUtil.TestResultsDirectory, this.TestClassName, Guid.NewGuid().ToString().Replace("-", "") + ".xlsx");
             CopyFileStream(TestFileStreams.animation, file);
             OpenSettings s = new OpenSettings();
@@ -572,7 +545,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Bug544244()
         {
-            this.MyTestInitialize();
             var pageMargins = new DocumentFormat.OpenXml.Spreadsheet.PageMargins();
             pageMargins.Header = new DoubleValue();
             pageMargins.Header.InnerText = "0.51200000000000001";
@@ -590,7 +562,6 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Bug665268()
         {
-            this.MyTestInitialize();
             var comment = new DocumentFormat.OpenXml.Wordprocessing.Comment();
             comment.Date = new DateTimeValue();
             comment.Date.InnerText = "2007-04-24T15:42:11.037";


### PR DESCRIPTION
Xunit will construct a new instance of the object for each test run, so
initialization code should be done in the constructor. This helps clean
up a ton of hard-to-reason about code.
