### PR TITLE
Ensure all files are UTF8 with BOM

### DIFF
--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/ChartTrackingRefBased/GeneratedDocument.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/ChartTrackingRefBased/GeneratedDocument.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Presentation;
 using P = DocumentFormat.OpenXml.Presentation;

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/CommentEx/GeneratedDocument.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/CommentEx/GeneratedDocument.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using DocumentFormat.OpenXml.Packaging;
 using Ap = DocumentFormat.OpenXml.ExtendedProperties;
 using Vt = DocumentFormat.OpenXml.VariantTypes;

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/CommentExPeople/GeneratedDocument.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/CommentExPeople/GeneratedDocument.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using DocumentFormat.OpenXml.Packaging;
 using Ap = DocumentFormat.OpenXml.ExtendedProperties;
 using Vt = DocumentFormat.OpenXml.VariantTypes;

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/ContentControl/GeneratedDocument.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/ContentControl/GeneratedDocument.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using DocumentFormat.OpenXml.Packaging;
 using Ap = DocumentFormat.OpenXml.ExtendedProperties;
 using Vt = DocumentFormat.OpenXml.VariantTypes;

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/FootnoteColumns/GeneratedDocument.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/FootnoteColumns/GeneratedDocument.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using DocumentFormat.OpenXml.Packaging;
 using Ap = DocumentFormat.OpenXml.ExtendedProperties;
 using DocumentFormat.OpenXml.Wordprocessing;

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/Guide/GeneratedDocument.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/Guide/GeneratedDocument.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Presentation;
 using P = DocumentFormat.OpenXml.Presentation;

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/Pivot/ConnectionGeneratedDocument.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/Pivot/ConnectionGeneratedDocument.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using DocumentFormat.OpenXml.Packaging;
 using Ap = DocumentFormat.OpenXml.ExtendedProperties;
 using Vt = DocumentFormat.OpenXml.VariantTypes;

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/PresetTransition/GeneratedDocument.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/PresetTransition/GeneratedDocument.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Presentation;
 using P = DocumentFormat.OpenXml.Presentation;

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/Slicer/GeneratedDocument.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/Slicer/GeneratedDocument.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using DocumentFormat.OpenXml.Packaging;
 using Ap = DocumentFormat.OpenXml.ExtendedProperties;
 using Vt = DocumentFormat.OpenXml.VariantTypes;

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/Theme/GeneratedDocument.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/Theme/GeneratedDocument.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Presentation;
 using P = DocumentFormat.OpenXml.Presentation;

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/ThreadingInfo/GeneratedDocument.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/ThreadingInfo/GeneratedDocument.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Presentation;
 using P = DocumentFormat.OpenXml.Presentation;

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/Timeline/GeneratedDocument.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/Timeline/GeneratedDocument.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using DocumentFormat.OpenXml.Packaging;
 using Ap = DocumentFormat.OpenXml.ExtendedProperties;
 using Vt = DocumentFormat.OpenXml.VariantTypes;

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/Timeline/TimeLineTest.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/Timeline/TimeLineTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using System;
 using System.IO;
 

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/WebExtension/WebExtensionData.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/WebExtension/WebExtensionData.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using DocumentFormat.OpenXml.Packaging;
 using Wetp = DocumentFormat.OpenXml.Office2013.WebExtentionPane;
 using DocumentFormat.OpenXml;

--- a/DocumentFormat.OpenXml.Tests/ConformanceTest/WorkbookPr/GeneratedDocument.cs
+++ b/DocumentFormat.OpenXml.Tests/ConformanceTest/WorkbookPr/GeneratedDocument.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using DocumentFormat.OpenXml.Packaging;
 using Ap = DocumentFormat.OpenXml.ExtendedProperties;
 using Vt = DocumentFormat.OpenXml.VariantTypes;

--- a/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlValidatorTest.cs
+++ b/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlValidatorTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using DocumentFormat.OpenXml;
 using Xunit;
 using System.IO;

--- a/rules.ruleset
+++ b/rules.ruleset
@@ -116,7 +116,7 @@
     <Rule Id="SA1409" Action="None" />
     <Rule Id="SA1410" Action="None" />
     <Rule Id="SA1411" Action="None" />
-    <Rule Id="SA1412" Action="None" />
+    <Rule Id="SA1412" Action="Warning" />
     <Rule Id="SA1413" Action="None" />
     <Rule Id="SA1500" Action="None" />
     <Rule Id="SA1501" Action="None" />


### PR DESCRIPTION
GIT and many other tools work best with UTF8+BOM encoding. Most files in the repo were encoded as such, but a few weren't. This enables StyleCop to check for the encoding, and updates those files that aren't encoded correctly. Part of #197
