### PR TITLE
Use a UriKind.RelativeOrAbsolute wrapper for Mono support

### DIFF
--- a/DocumentFormat.OpenXml/src/Framework/OpenXmlPackage.cs
+++ b/DocumentFormat.OpenXml/src/Framework/OpenXmlPackage.cs
@@ -1467,7 +1467,7 @@ namespace DocumentFormat.OpenXml.Packaging
                     string sequenceNumber = this.GetNextSequenceNumber(contentType);
                     string path = Path.Combine(targetPath, targetName + sequenceNumber + targetExt);
 
-                    Uri uri = new Uri(path, UriKind.RelativeOrAbsolute);
+                    Uri uri = new Uri(path, UriHelper.RelativeOrAbsolute);
                     partUri = PackUriHelper.ResolvePartUri(parentUri, uri);
                     // partUri = PackUriHelper.GetNormalizedPartUri(PackUriHelper.CreatePartUri(uri));
                 } while (this.IsReservedUri(partUri));

--- a/DocumentFormat.OpenXml/src/PortabilityExtensions.cs
+++ b/DocumentFormat.OpenXml/src/PortabilityExtensions.cs
@@ -5,6 +5,10 @@ using System.Reflection;
 
 namespace DocumentFormat.OpenXml
 {
+    internal static class UriHelper
+    {
+        public static readonly UriKind RelativeOrAbsolute = Type.GetType ("Mono.Runtime") == null ? UriKind.RelativeOrAbsolute : (UriKind) 300;
+    }
 
 #if !FEATURE_CLONEABLE
     internal interface ICloneable

--- a/DocumentFormat.OpenXml/src/ofapi/PackageDocument.cs
+++ b/DocumentFormat.OpenXml/src/ofapi/PackageDocument.cs
@@ -307,7 +307,7 @@ namespace DocumentFormat.OpenXml.Packaging
                     DocumentSettingsPart documentSettingsPart = mainDocumentPart.DocumentSettingsPart;
                     ExternalRelationship relationship = documentSettingsPart.AddExternalRelationship(
                         "http://schemas.openxmlformats.org/officeDocument/2006/relationships/attachedTemplate",
-                        new Uri(path, UriKind.RelativeOrAbsolute));
+                        new Uri(path, UriHelper.RelativeOrAbsolute));
                     documentSettingsPart.Settings.Append(
                         new DocumentFormat.OpenXml.Wordprocessing.AttachedTemplate() { Id = relationship.Id });
                 }

--- a/DocumentFormat.OpenXml/src/ofapi/Validation/SchemaValidation/SimpleTypes.cs
+++ b/DocumentFormat.OpenXml/src/ofapi/Validation/SchemaValidation/SimpleTypes.cs
@@ -2745,7 +2745,7 @@ namespace DocumentFormat.OpenXml.Internal.SchemaValidation
                     return false;
                 }
             }
-            if (!Uri.TryCreate(uriString, UriKind.RelativeOrAbsolute, out result))
+            if (!Uri.TryCreate(uriString, UriHelper.RelativeOrAbsolute, out result))
             {
                 return false;
             }


### PR DESCRIPTION
In .NET new Uri ("/foo", UriKind.RelativeOrAbsolute) returns a relative
Uri whereas Mono assumes it is an absolute file path.
Mono diverges from .NET because UNIX file paths starting with
'/' are absolute file paths.

This change introduces a UriHelper class that provides a workaround by
redefining RelativeOrAbsolute to a Mono specific value when on that
platform.

For more information, see:
www.mono-project.com/docs/faq/known-issues/urikind-relativeorabsolute/

Fixes #249, #221, #59