### PR TITLE
Refactor initial markup compatibility tests to decrease unit test duration

### DIFF
--- a/DocumentFormat.OpenXml.Tests/DocumentFormat.OpenXml.Tests.csproj
+++ b/DocumentFormat.OpenXml.Tests/DocumentFormat.OpenXml.Tests.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
     <PackageReference Include="xunit.runner.console" Version="2.3.0" />
     <PackageReference Include="xunit" Version="2.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">

--- a/DocumentFormat.OpenXml.Tests/DocumentFormat.OpenXml.Tests.csproj
+++ b/DocumentFormat.OpenXml.Tests/DocumentFormat.OpenXml.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
     <AssemblyName>DocumentFormat.OpenXml.Tests</AssemblyName>
   </PropertyGroup>
 

--- a/DocumentFormat.OpenXml.Tests/DocumentFormat.OpenXml.Tests.csproj
+++ b/DocumentFormat.OpenXml.Tests/DocumentFormat.OpenXml.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFrameworks>net452;net46;netcoreapp1.0</TargetFrameworks>
     <AssemblyName>DocumentFormat.OpenXml.Tests</AssemblyName>
   </PropertyGroup>
 

--- a/DocumentFormat.OpenXml.Tests/DocumentFormat.OpenXml.Tests.csproj
+++ b/DocumentFormat.OpenXml.Tests/DocumentFormat.OpenXml.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;net46;netcoreapp1.0</TargetFrameworks>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>DocumentFormat.OpenXml.Tests</AssemblyName>
   </PropertyGroup>
 

--- a/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/MarkupCompatibilityTest.cs
+++ b/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/MarkupCompatibilityTest.cs
@@ -127,26 +127,22 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_NonIgnored_UnknownAttribute()
         {
-            var testfiles = CopyTestFiles(@"bvt");
-            var testfile = testfiles.FirstOrDefault();
+            using (var stream = TestAssets.GetStream(TestAssets.TestDataStorage.V2FxTestFiles.Bvt.complex2005_12rtm).AsMemoryStream())
+            using (var package = WordprocessingDocument.Open(stream, true))
+            {
+                var part = package.MainPart();
+                var host = part
+                    .RootElement()
+                    .Descendants()
+                    .PickSecond();
+                var target = host
+                    .Descendants()
+                    .PickSecond();
 
-            string partUri = null, hostPath = null, targetPath = null;
-            setupElements(testfile,
-                ref partUri, pkg => pkg.MainPart(),
-                ref hostPath, e => e.Descendants().PickSecond(),
-                e =>
-                {
-                    Log.Comment("Skipping setting Ignorable @{0} with value: {1}", e.Path(), unknownAttribute11.Prefix);
-                },
-                ref targetPath, e => e.Descendants().PickSecond(),
-                e =>
-                {
-                    Log.Comment("Setting attribute {0} @{1}...", unknownAttribute11.GetFullName(), e.Path());
-                    e.SetAttribute(unknownAttribute11);
-                });
+                target.SetAttribute(unknownAttribute11);
 
-            Log.Warning("Validating and Expecting validation error for Non-Ignored unknown attribute...");
-            validateMC(testfile, FileFormatVersions.Office2007, hostPath);
+                validateMC(package, FileFormatVersions.Office2007, host.Path(), 1);
+            }
         }
 
         [Fact]

--- a/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/MarkupCompatibilityTest.cs
+++ b/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/MarkupCompatibilityTest.cs
@@ -2913,7 +2913,7 @@ namespace DocumentFormat.OpenXml.Tests
             var testfile = testfiles.FirstOrDefault();
 
             string partUri = null, hostPath = null;
-            OpenXmlElement acb = null, expected = null;
+            OpenXmlElement expected = null;
             setupElements(testfile,
                 ref partUri, pkg => pkg.MainPart(),
                 ref hostPath, e => e.Descendants().PickFirst(d => d is OpenXmlCompositeElement && d.HasChildren && d.ChildElements.Count > 1),

--- a/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/MarkupCompatibilityTest.cs
+++ b/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/MarkupCompatibilityTest.cs
@@ -127,8 +127,8 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_NonIgnored_UnknownAttribute()
         {
-            using (var stream = TestAssets.GetStream(TestAssets.TestDataStorage.V2FxTestFiles.Bvt.complex2005_12rtm).AsMemoryStream())
-            using (var package = WordprocessingDocument.Open(stream, true))
+            using (var stream = TestAssets.GetStream(TestAssets.TestDataStorage.V2FxTestFiles.Bvt.complex2005_12rtm))
+            using (var package = WordprocessingDocument.Open(stream, false))
             {
                 var part = package.MainPart();
                 var host = part
@@ -1861,49 +1861,33 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Preserve_NonIgnored_UnknownAttribute_FullMode()
         {
-            var testfiles = CopyTestFiles(@"bvt");
-            var testfile = testfiles.FirstOrDefault();
+            var unknownElement = new OpenXmlUnknownElement(prefixUnknown1, e1Unknown1, nsUnknown1);
+            var unknownAttribute = new OpenXmlAttribute(prefixUnknown1, a1Unknown1, nsUnknown1, "attribute1 from unknown namespace1.");
 
-            string partUri = null, hostPath = null, targetPath = null;
-            List<OpenXmlElement> children = new List<OpenXmlElement>();
-            OpenXmlElement expectedElement = null;
-            string pehostPath = null;
-            setupElements(testfile,
-                ref partUri, pkg => pkg.MainPart(),
-                ref hostPath, e => e.Descendants().PickFirst(d => d is OpenXmlCompositeElement && d.HasChildren && !d.ChildElements.Any(c => c is OpenXmlUnknownElement)),
-                e =>
-                {
-                    Log.Comment("Skipping setting Ignorable @{0} with value: {1}", e.Path(), unknownElement11.Prefix);
-                    var pehost = e;
-                    pehostPath = pehost.Path();
-
-                    Log.Comment("Skipping setting PreserveElements@ {0} with value: {1}", pehost.Path(), unknownElement11.GetFullName());
-
-                    Log.Comment("Setting PreserveAttributes@ {0} with value: {1}", pehost.Path(), unknownAttribute11.GetFullName());
-                    pehost.SetPreserveAttributes(unknownAttribute11.GetFullName());
-                    pehost.AddNamespaceDeclaration(unknownAttribute11.Prefix, unknownAttribute11.NamespaceUri);
-                },
-                ref targetPath, e => e.Descendants().PickFirst(d => d is OpenXmlCompositeElement && d.HasChildren && !d.ChildElements.Any(c => c is OpenXmlUnknownElement)),
-                e =>
-                {
-                    foreach (var d in e.ChildElements)
-                        children.Add(d.CloneNode(true));
-                    e.AppendChild(unknownElement11);
-                    unknownElement11.SetAttribute(unknownAttribute11);
-                    unknownElement11.SetAttribute(unknownAttribute12);
-                    unknownElement11.SetAttribute(unprefixedAttribute);
-
-                    expectedElement = unknownElement11.CloneNode(true);
-                });
-
-            Log.Comment("ReOpening file:{0}...", testfile.FullName);
-            using (var package = testfile.OpenPackage(true, FileFormatVersions.Office2007, MarkupCompatibilityProcessMode.NoProcess))
+            using (var stream = TestAssets.GetStream(TestAssets.TestDataStorage.V2FxTestFiles.Bvt.complex2005_12rtm))
+            using (var package = WordprocessingDocument.Open(stream, false))
             {
-                OpenXmlElement host, target, pehost;
-                locateElements(package, partUri, hostPath, out host, targetPath, out target);
-                locateElements(package, partUri, hostPath, out host, pehostPath, out pehost);
+                var part = package.MainPart();
+                var host = part
+                    .RootElement()
+                    .Descendants()
+                    .PickFirst(d => d is OpenXmlCompositeElement && d.HasChildren && !d.ChildElements.Any(c => c is OpenXmlUnknownElement));
+                var target = host
+                    .Descendants()
+                    .PickFirst(d => d is OpenXmlCompositeElement && d.HasChildren && !d.ChildElements.Any(c => c is OpenXmlUnknownElement));
 
-                verifyMcAttribute(pehost, "PreserveAttributes", unknownAttribute11.GetFullName());
+                host.SetPreserveAttributes(unknownAttribute.GetFullName());
+                host.AddNamespaceDeclaration(unknownAttribute.Prefix, unknownAttribute.NamespaceUri);
+
+                var children = target.ChildElements.Select(t => t.CloneNode(true)).ToList();
+                target.AppendChild(unknownElement);
+
+                unknownElement.SetAttribute(unknownAttribute);
+                unknownElement.SetAttribute(unknownAttribute12);
+                unknownElement.SetAttribute(unprefixedAttribute);
+
+                var expectedElement = unknownElement.CloneNode(true);
+                verifyMcAttribute(host, "PreserveAttributes", unknownAttribute.GetFullName());
 
                 verifyUnknownElement(target.LastChild, expectedElement);
                 verifyKnownChildren(target, children);
@@ -2284,8 +2268,8 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_MustUnderstand_Ignored_UnknownElement()
         {
-            using (var stream = TestAssets.GetStream(TestAssets.TestDataStorage.V2FxTestFiles.Bvt.complex2005_12rtm).AsMemoryStream())
-            using (var package = WordprocessingDocument.Open(stream, true))
+            using (var stream = TestAssets.GetStream(TestAssets.TestDataStorage.V2FxTestFiles.Bvt.complex2005_12rtm))
+            using (var package = WordprocessingDocument.Open(stream, false))
             {
                 var part = package.MainPart();
                 var partUri = part.Uri.ToString();
@@ -2879,8 +2863,8 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void OneChoice_MultipleFallback_FullMode()
         {
-            using (var stream = TestAssets.GetStream(TestAssets.TestDataStorage.V2FxTestFiles.Bvt.complex2005_12rtm).AsMemoryStream())
-            using (var package = WordprocessingDocument.Open(stream, true))
+            using (var stream = TestAssets.GetStream(TestAssets.TestDataStorage.V2FxTestFiles.Bvt.complex2005_12rtm))
+            using (var package = WordprocessingDocument.Open(stream, false))
             {
                 var part = package.MainPart();
                 var dom = part.RootElement();
@@ -2934,8 +2918,8 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void Validate_OneChoice_MultipleFallback()
         {
-            using (var stream = TestAssets.GetStream(TestAssets.TestDataStorage.V2FxTestFiles.Bvt.complex2005_12rtm).AsMemoryStream())
-            using (var package = WordprocessingDocument.Open(stream, true))
+            using (var stream = TestAssets.GetStream(TestAssets.TestDataStorage.V2FxTestFiles.Bvt.complex2005_12rtm))
+            using (var package = WordprocessingDocument.Open(stream, false))
             {
                 var host = package
                     .MainPart()

--- a/Open-XML-SDK.sln
+++ b/Open-XML-SDK.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27004.2005
+VisualStudioVersion = 15.0.27004.2002
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DocumentFormat.OpenXml", "DocumentFormat.OpenXml\DocumentFormat.OpenXml.csproj", "{16941A4A-F8DE-4C8D-BA2B-3C0774848D4B}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DocumentFormat.OpenXml.Tests", "DocumentFormat.OpenXml.Tests\DocumentFormat.OpenXml.Tests.csproj", "{B92240AF-6E87-4428-9C5A-371178A04E5B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BinaryFormatConverter", "tools\BinaryFormatConverter\BinaryFormatConverter.csproj", "{E97A956D-8113-45B6-9002-2ED651A6CD6C}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0B53C729-D408-450D-B755-7A57184CDE93}"
 	ProjectSection(SolutionItems) = preProject
@@ -35,9 +37,16 @@ Global
 		{B92240AF-6E87-4428-9C5A-371178A04E5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B92240AF-6E87-4428-9C5A-371178A04E5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B92240AF-6E87-4428-9C5A-371178A04E5B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E97A956D-8113-45B6-9002-2ED651A6CD6C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E97A956D-8113-45B6-9002-2ED651A6CD6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E97A956D-8113-45B6-9002-2ED651A6CD6C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E97A956D-8113-45B6-9002-2ED651A6CD6C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{E97A956D-8113-45B6-9002-2ED651A6CD6C} = {76E8A693-7A83-47D6-B09C-3FDE5FB6F87A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6F476383-E917-43D1-A1E5-9A61A47DA3F5}

--- a/Open-XML-SDK.sln
+++ b/Open-XML-SDK.sln
@@ -1,13 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27004.2002
+VisualStudioVersion = 15.0.27004.2005
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DocumentFormat.OpenXml", "DocumentFormat.OpenXml\DocumentFormat.OpenXml.csproj", "{16941A4A-F8DE-4C8D-BA2B-3C0774848D4B}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DocumentFormat.OpenXml.Tests", "DocumentFormat.OpenXml.Tests\DocumentFormat.OpenXml.Tests.csproj", "{B92240AF-6E87-4428-9C5A-371178A04E5B}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BinaryFormatConverter", "tools\BinaryFormatConverter\BinaryFormatConverter.csproj", "{E97A956D-8113-45B6-9002-2ED651A6CD6C}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0B53C729-D408-450D-B755-7A57184CDE93}"
 	ProjectSection(SolutionItems) = preProject
@@ -37,16 +35,9 @@ Global
 		{B92240AF-6E87-4428-9C5A-371178A04E5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B92240AF-6E87-4428-9C5A-371178A04E5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B92240AF-6E87-4428-9C5A-371178A04E5B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E97A956D-8113-45B6-9002-2ED651A6CD6C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E97A956D-8113-45B6-9002-2ED651A6CD6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E97A956D-8113-45B6-9002-2ED651A6CD6C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E97A956D-8113-45B6-9002-2ED651A6CD6C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{E97A956D-8113-45B6-9002-2ED651A6CD6C} = {76E8A693-7A83-47D6-B09C-3FDE5FB6F87A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6F476383-E917-43D1-A1E5-9A61A47DA3F5}


### PR DESCRIPTION
This change fixes the test cases that take the most amount of time, shaving about 30% of the unit test duration. Subsequent PRs will address the rest.