### PR TITLE
Allow saving when autosave is false

### DIFF
--- a/DocumentFormat.OpenXml.Tests/SaveAndCloneTests.cs
+++ b/DocumentFormat.OpenXml.Tests/SaveAndCloneTests.cs
@@ -269,6 +269,33 @@ namespace DocumentFormat.OpenXml.Tests
         }
 
         [Fact]
+        public void CanSaveAutosaveFalse()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var package = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document))
+                {
+                    package.AddMainDocumentPart();
+                }
+
+                using (var package = WordprocessingDocument.Open(stream, true, new OpenSettings { AutoSave = false }))
+                {
+                    Assert.Null(package.MainDocumentPart.Document);
+                    package.MainDocumentPart.Document = new Document();
+                    Assert.NotNull(package.MainDocumentPart.Document);
+
+                    package.Save();
+                }
+
+                using (var package = WordprocessingDocument.Open(stream, false, new OpenSettings { AutoSave = false }))
+                {
+                    Assert.NotNull(package.MainDocumentPart);
+                    Assert.NotNull(package.MainDocumentPart.Document);
+                }
+            }
+        }
+
+        [Fact]
         public void CanSave()
         {
             using (var stream = GetStream(TestFiles.Document))

--- a/DocumentFormat.OpenXml/src/Framework/OpenXmlPackage.cs
+++ b/DocumentFormat.OpenXml/src/Framework/OpenXmlPackage.cs
@@ -831,7 +831,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 if (disposing)
                 {
                     // Try to save contents of every part in the package
-                    SavePartContents();
+                    SavePartContents(AutoSave);
                     DeleteUnusedDataPartOnClose();
 
                     // TODO: Close resources
@@ -909,7 +909,7 @@ namespace DocumentFormat.OpenXml.Packaging
             }
         }
 
-        private void SavePartContents()
+        private void SavePartContents(bool save)
         {
             OpenXmlPackagePartIterator iterator;
             bool isAnyPartChanged;
@@ -919,10 +919,10 @@ namespace DocumentFormat.OpenXml.Packaging
                 return; // do nothing if the package is open in read-only mode.
             }
 
-            // When this.StrictTranslation is true, we ignore AutoSave to do the translation if isAnyPartChanged is true. That's the way to keep consistency.
-            if (!this.AutoSave && !this.StrictTranslation)
+            // When this.StrictTranslation is true, we ignore the save argument to do the translation if isAnyPartChanged is true. That's the way to keep consistency.
+            if (!save && !this.StrictTranslation)
             {
-                return; // do nothing if AutoSave is false.
+                return; // do nothing if saving is false.
             }
 
             // Traversal the whole package and save changed contents.
@@ -1537,9 +1537,7 @@ namespace DocumentFormat.OpenXml.Packaging
             {
                 lock (_saveAndCloneLock)
                 {
-                    SavePartContents();
-                    // TODO: Revisit.
-                    // Package.Flush();
+                    SavePartContents(true);
                 }
             }
         }


### PR DESCRIPTION
Currently, if a document is opened with `AutoSave = false`, then calls to `.Save()` will fail. This change allows packages that are opened with `AutoSave = false` to be manually saved if desired, while maintaining previous behavior when `AutoSave = true`.

Fixes #262 