### PR TITLE
[WIP] Flush package when save is called

### DIFF
--- a/DocumentFormat.OpenXml.Tests/SaveAndCloneTests.cs
+++ b/DocumentFormat.OpenXml.Tests/SaveAndCloneTests.cs
@@ -302,6 +302,36 @@ namespace DocumentFormat.OpenXml.Tests
         }
 
         [Fact]
+        public void CanSaveWithOutClosing()
+        {
+            byte[] GetNewSpreadsheet()
+            {
+                using (var stream = new MemoryStream())
+                using (var source = SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook))
+                {
+                    source.AddWorkbookPart();
+                    source.WorkbookPart.Workbook = new Spreadsheet.Workbook();
+                    source.WorkbookPart.Workbook.AppendChild(new Spreadsheet.Sheets());
+                    source.Save();
+                    source.WorkbookPart.Workbook.AppendChild(new Spreadsheet.Sheets());
+
+                    Assert.Equal(2, source.WorkbookPart.Workbook.ChildElements.Count);
+
+                    return stream.ToArray();
+                }
+            }
+
+            var bytes = GetNewSpreadsheet();
+            Assert.NotEmpty(bytes);
+
+            using (var stream = new MemoryStream(bytes))
+            using (var source = SpreadsheetDocument.Open(stream, false))
+            {
+                Assert.Single(source.WorkbookPart.Workbook.ChildElements);
+            }
+        }
+
+        [Fact]
         public void CanSaveAsWord()
         {
             using (var tempFile = TemporaryFile.Create())

--- a/DocumentFormat.OpenXml/src/Framework/OpenXmlPackage.cs
+++ b/DocumentFormat.OpenXml/src/Framework/OpenXmlPackage.cs
@@ -1538,8 +1538,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 lock (_saveAndCloneLock)
                 {
                     SavePartContents();
-                    // TODO: Revisit.
-                    // Package.Flush();
+                    Package.Flush();
                 }
             }
         }


### PR DESCRIPTION
When Save is called, the underlying package is currently not flushed. This makes Save act in a weird way where you expect that the data is persisted, but it has not been. This change fixes that so saving flushes the package to whatever data source it is from. This does not, however, remove any unused data parts, which will still only be removed on close.

Fixes #294 