### PR TITLE
Add an extension method to expand FileFormatVersion to include all alter versions

### DIFF
--- a/DocumentFormat.OpenXml/FileFormatVersions.cs
+++ b/DocumentFormat.OpenXml/FileFormatVersions.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace DocumentFormat.OpenXml
+{
+    /// <summary>
+    /// Defines the Office Open XML file format version.
+    /// </summary>
+    [Flags]
+    public enum FileFormatVersions
+    {
+        /// <summary>
+        /// Represents an invalid value which will cause an exception.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Represents Microsoft Office 2007.
+        /// </summary>
+        Office2007 = 0x1,
+
+        /// <summary>
+        /// Represents Microsoft Office 2010.
+        /// </summary>
+        Office2010 = 0x2,
+
+        /// <summary>
+        /// Represents Microsoft Office 2013.
+        /// </summary>
+        Office2013 = 0x4
+    }
+}

--- a/DocumentFormat.OpenXml/OfficeAvailabilityAttribute.cs
+++ b/DocumentFormat.OpenXml/OfficeAvailabilityAttribute.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace DocumentFormat.OpenXml
+{
+    /// <summary>
+    /// Defines an OfficeAvailabilityAttribute class to indicate whether the property is available in a specific version of an Office application.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class | AttributeTargets.Field)]
+    public sealed class OfficeAvailabilityAttribute : Attribute
+    {
+        /// <summary>
+        /// Gets the Office version of the available property.
+        /// </summary>
+        public FileFormatVersions OfficeVersion { get; internal set; }
+
+        /// <summary>
+        /// Initializes a new instance of the OfficeAvailabilityAttribute class.
+        /// </summary>
+        /// <param name="officeVersion">The Office version where this class or property is available. 
+        /// If there is more than one version, use bitwise OR to specify multiple versions.</param>
+        public OfficeAvailabilityAttribute(FileFormatVersions officeVersion)
+        {
+            OfficeVersion = officeVersion;
+        }
+    }
+}

--- a/DocumentFormat.OpenXml/OfficeVersions.cs
+++ b/DocumentFormat.OpenXml/OfficeVersions.cs
@@ -1,18 +1,12 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 
 namespace DocumentFormat.OpenXml
 {
     internal static class OfficeVersions
     {
-        /// <summary>
-        /// Represents an enum for all office versions.
-        /// </summary>
-        public const FileFormatVersions All = FileFormatVersions.Office2007
-                                            | FileFormatVersions.Office2010
-                                            | FileFormatVersions.Office2013;
-
         /// <summary>
         /// Determines whether the supplied version is within the known set of versions
         /// </summary>
@@ -23,6 +17,25 @@ namespace DocumentFormat.OpenXml
             return version == FileFormatVersions.Office2007
                 || version == FileFormatVersions.Office2010
                 || version == FileFormatVersions.Office2013;
+        }
+
+        public static FileFormatVersions AndLater(this FileFormatVersions version)
+        {
+            switch (version)
+            {
+                case FileFormatVersions.Office2007:
+                    return FileFormatVersions.Office2007
+                         | FileFormatVersions.Office2010
+                         | FileFormatVersions.Office2013;
+                case FileFormatVersions.Office2010:
+                    return FileFormatVersions.Office2010
+                         | FileFormatVersions.Office2013;
+                case FileFormatVersions.Office2013:
+                    return FileFormatVersions.Office2013;
+                default:
+                    Debug.Assert(false, "This should only be called with a single version");
+                    return version;
+            }
         }
 
         /// <summary>

--- a/DocumentFormat.OpenXml/OfficeVersions.cs
+++ b/DocumentFormat.OpenXml/OfficeVersions.cs
@@ -4,33 +4,6 @@ using System;
 
 namespace DocumentFormat.OpenXml
 {
-    /// <summary>
-    /// Defines the Office Open XML file format version.
-    /// </summary>
-    [Flags]
-    public enum FileFormatVersions
-    {
-        /// <summary>
-        /// Represents an invalid value which will cause an exception.
-        /// </summary>
-        None = 0,
-
-        /// <summary>
-        /// Represents Microsoft Office 2007.
-        /// </summary>
-        Office2007 = 0x1,
-
-        /// <summary>
-        /// Represents Microsoft Office 2010.
-        /// </summary>
-        Office2010 = 0x2,
-
-        /// <summary>
-        /// Represents Microsoft Office 2013.
-        /// </summary>
-        Office2013 = 0x4
-    }
-
     internal static class OfficeVersions
     {
         /// <summary>
@@ -78,28 +51,6 @@ namespace DocumentFormat.OpenXml
 
                 throw new ArgumentOutOfRangeException(parameterName, message);
             }
-        }
-    }
-
-    /// <summary>
-    /// Defines an OfficeAvailabilityAttribute class to indicate whether the property is available in a specific version of an Office application.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class | AttributeTargets.Field)]
-    public sealed class OfficeAvailabilityAttribute : Attribute
-    {
-        /// <summary>
-        /// Gets the Office version of the available property.
-        /// </summary>
-        public FileFormatVersions OfficeVersion { get; internal set; }
-
-        /// <summary>
-        /// Initializes a new instance of the OfficeAvailabilityAttribute class.
-        /// </summary>
-        /// <param name="officeVersion">The Office version where this class or property is available. 
-        /// If there is more than one version, use bitwise OR to specify multiple versions.</param>
-        public OfficeAvailabilityAttribute(FileFormatVersions officeVersion)
-        {
-            OfficeVersion = officeVersion;
         }
     }
 }

--- a/DocumentFormat.OpenXml/OfficeVersions.cs
+++ b/DocumentFormat.OpenXml/OfficeVersions.cs
@@ -19,6 +19,11 @@ namespace DocumentFormat.OpenXml
                 || version == FileFormatVersions.Office2013;
         }
 
+        /// <summary>
+        /// Combines values for the given version and all versions that come after it
+        /// </summary>
+        /// <param name="version">Version to which all other versions are added</param>
+        /// <returns>A version instance with <paramref name="version"/> and all later versions</returns>
         public static FileFormatVersions AndLater(this FileFormatVersions version)
         {
             switch (version)

--- a/DocumentFormat.OpenXml/src/Framework/AlternateContent.cs
+++ b/DocumentFormat.OpenXml/src/Framework/AlternateContent.cs
@@ -995,7 +995,7 @@ namespace DocumentFormat.OpenXml
         #region Helper functions
         internal OpenXmlCompositeElement GetContentFromACBlock(AlternateContent acblk, FileFormatVersions format)
         {
-            Debug.Assert(format != OfficeVersions.All);
+            Debug.Assert(format != FileFormatVersions.Office2007.AndLater());
 
             foreach (var choice in acblk.ChildElements.OfType<AlternateContentChoice>())
             {

--- a/DocumentFormat.OpenXml/src/Framework/OpenXmlElementContext.cs
+++ b/DocumentFormat.OpenXml/src/Framework/OpenXmlElementContext.cs
@@ -70,7 +70,7 @@ namespace DocumentFormat.OpenXml
             {
                 if (_mcSettings == null)
                 {
-                    _mcSettings = new MarkupCompatibilityProcessSettings(MarkupCompatibilityProcessMode.NoProcess, OfficeVersions.All);
+                    _mcSettings = new MarkupCompatibilityProcessSettings(MarkupCompatibilityProcessMode.NoProcess, FileFormatVersions.Office2007.AndLater());
                 }
                 return _mcSettings;
             }

--- a/DocumentFormat.OpenXml/src/ofapi/PackageDocument.cs
+++ b/DocumentFormat.OpenXml/src/ofapi/PackageDocument.cs
@@ -15,28 +15,28 @@ namespace DocumentFormat.OpenXml.Packaging
     /// </summary>
     public class WordprocessingDocument : OpenXmlPackage
     {
-        private static System.Collections.Generic.Dictionary<string, PartConstraintRule> _partConstraint;
-        private static System.Collections.Generic.Dictionary<string, PartConstraintRule> _dataPartReferenceConstraint;
+        private static Dictionary<string, PartConstraintRule> _partConstraint;
+        private static Dictionary<string, PartConstraintRule> _dataPartReferenceConstraint;
 
         /// <summary>
         /// Gets part constraint data.
         /// </summary>
         /// <returns>The constraint data of the part.</returns>
-        internal sealed override System.Collections.Generic.IDictionary<string, PartConstraintRule> GetPartConstraint()
+        internal sealed override IDictionary<string, PartConstraintRule> GetPartConstraint()
         {
             if (_partConstraint == null)
             {
-                System.Collections.Generic.Dictionary<string, PartConstraintRule> tempData = new System.Collections.Generic.Dictionary<string, PartConstraintRule>();
-                tempData.Add("http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument", new PartConstraintRule("MainDocumentPart", null, true, false, OfficeVersions.All));
-                tempData.Add("http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties", new PartConstraintRule("CoreFilePropertiesPart", CoreFilePropertiesPart.ContentTypeConstant, false, false, OfficeVersions.All));
-                tempData.Add("http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties", new PartConstraintRule("ExtendedFilePropertiesPart", ExtendedFilePropertiesPart.ContentTypeConstant, false, false, OfficeVersions.All));
-                tempData.Add("http://schemas.openxmlformats.org/officeDocument/2006/relationships/custom-properties", new PartConstraintRule("CustomFilePropertiesPart", CustomFilePropertiesPart.ContentTypeConstant, false, false, OfficeVersions.All));
-                tempData.Add("http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail", new PartConstraintRule("ThumbnailPart", null, false, false, OfficeVersions.All));
-                tempData.Add("http://schemas.openxmlformats.org/package/2006/relationships/digital-signature/origin", new PartConstraintRule("DigitalSignatureOriginPart", DigitalSignatureOriginPart.ContentTypeConstant, false, false, OfficeVersions.All));
-                tempData.Add("http://schemas.microsoft.com/office/2006/relationships/ui/userCustomization", new PartConstraintRule("QuickAccessToolbarCustomizationsPart", QuickAccessToolbarCustomizationsPart.ContentTypeConstant, false, false, OfficeVersions.All));
-                tempData.Add("http://schemas.microsoft.com/office/2006/relationships/ui/extensibility", new PartConstraintRule("RibbonExtensibilityPart", RibbonExtensibilityPart.ContentTypeConstant, false, false, OfficeVersions.All));
-                tempData.Add("http://schemas.microsoft.com/office/2007/relationships/ui/extensibility", new PartConstraintRule("RibbonAndBackstageCustomizationsPart", RibbonAndBackstageCustomizationsPart.ContentTypeConstant, false, false, FileFormatVersions.Office2010 | FileFormatVersions.Office2013));
-                tempData.Add("http://schemas.microsoft.com/office/2011/relationships/webextensiontaskpanes", new PartConstraintRule("WebExTaskpanesPart", WebExTaskpanesPart.ContentTypeConstant, false, false, FileFormatVersions.Office2013));
+                Dictionary<string, PartConstraintRule> tempData = new Dictionary<string, PartConstraintRule>();
+                tempData.Add("http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument", new PartConstraintRule("MainDocumentPart", null, true, false, FileFormatVersions.Office2007.AndLater()));
+                tempData.Add("http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties", new PartConstraintRule("CoreFilePropertiesPart", CoreFilePropertiesPart.ContentTypeConstant, false, false, FileFormatVersions.Office2007.AndLater()));
+                tempData.Add("http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties", new PartConstraintRule("ExtendedFilePropertiesPart", ExtendedFilePropertiesPart.ContentTypeConstant, false, false, FileFormatVersions.Office2007.AndLater()));
+                tempData.Add("http://schemas.openxmlformats.org/officeDocument/2006/relationships/custom-properties", new PartConstraintRule("CustomFilePropertiesPart", CustomFilePropertiesPart.ContentTypeConstant, false, false, FileFormatVersions.Office2007.AndLater()));
+                tempData.Add("http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail", new PartConstraintRule("ThumbnailPart", null, false, false, FileFormatVersions.Office2007.AndLater()));
+                tempData.Add("http://schemas.openxmlformats.org/package/2006/relationships/digital-signature/origin", new PartConstraintRule("DigitalSignatureOriginPart", DigitalSignatureOriginPart.ContentTypeConstant, false, false, FileFormatVersions.Office2007.AndLater()));
+                tempData.Add("http://schemas.microsoft.com/office/2006/relationships/ui/userCustomization", new PartConstraintRule("QuickAccessToolbarCustomizationsPart", QuickAccessToolbarCustomizationsPart.ContentTypeConstant, false, false, FileFormatVersions.Office2007.AndLater()));
+                tempData.Add("http://schemas.microsoft.com/office/2006/relationships/ui/extensibility", new PartConstraintRule("RibbonExtensibilityPart", RibbonExtensibilityPart.ContentTypeConstant, false, false, FileFormatVersions.Office2007.AndLater()));
+                tempData.Add("http://schemas.microsoft.com/office/2007/relationships/ui/extensibility", new PartConstraintRule("RibbonAndBackstageCustomizationsPart", RibbonAndBackstageCustomizationsPart.ContentTypeConstant, false, false, FileFormatVersions.Office2010.AndLater()));
+                tempData.Add("http://schemas.microsoft.com/office/2011/relationships/webextensiontaskpanes", new PartConstraintRule("WebExTaskpanesPart", WebExTaskpanesPart.ContentTypeConstant, false, false, FileFormatVersions.Office2013.AndLater()));
                 _partConstraint = tempData;
             }
             return _partConstraint;
@@ -46,11 +46,11 @@ namespace DocumentFormat.OpenXml.Packaging
         /// Gets the constraint rule of DataPartReferenceRelationship.
         /// </summary>
         /// <returns>The constraint data of the part.</returns>
-        internal sealed override System.Collections.Generic.IDictionary<string, PartConstraintRule> GetDataPartReferenceConstraint()
+        internal sealed override IDictionary<string, PartConstraintRule> GetDataPartReferenceConstraint()
         {
             if (_dataPartReferenceConstraint == null)
             {
-                System.Collections.Generic.Dictionary<string, PartConstraintRule> tempData = new System.Collections.Generic.Dictionary<string, PartConstraintRule>();
+                Dictionary<string, PartConstraintRule> tempData = new Dictionary<string, PartConstraintRule>();
 
                 _dataPartReferenceConstraint = tempData;
             }
@@ -1006,28 +1006,28 @@ namespace DocumentFormat.OpenXml.Packaging
     /// </summary>
     public class SpreadsheetDocument : OpenXmlPackage
     {
-        private static System.Collections.Generic.Dictionary<string, PartConstraintRule> _partConstraint;
-        private static System.Collections.Generic.Dictionary<string, PartConstraintRule> _dataPartReferenceConstraint;
+        private static Dictionary<string, PartConstraintRule> _partConstraint;
+        private static Dictionary<string, PartConstraintRule> _dataPartReferenceConstraint;
 
         /// <summary>
         /// Gets part constraint data.
         /// </summary>
         /// <returns>The constraint data of the part.</returns>
-        internal sealed override System.Collections.Generic.IDictionary<string, PartConstraintRule> GetPartConstraint()
+        internal sealed override IDictionary<string, PartConstraintRule> GetPartConstraint()
         {
             if (_partConstraint == null)
             {
-                System.Collections.Generic.Dictionary<string, PartConstraintRule> tempData = new System.Collections.Generic.Dictionary<string, PartConstraintRule>();
-                tempData.Add("http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument", new PartConstraintRule("WorkbookPart", null, true, false, OfficeVersions.All));
-                tempData.Add("http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties", new PartConstraintRule("CoreFilePropertiesPart", CoreFilePropertiesPart.ContentTypeConstant, false, false, OfficeVersions.All));
-                tempData.Add("http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties", new PartConstraintRule("ExtendedFilePropertiesPart", ExtendedFilePropertiesPart.ContentTypeConstant, false, false, OfficeVersions.All));
-                tempData.Add("http://schemas.openxmlformats.org/officeDocument/2006/relationships/custom-properties", new PartConstraintRule("CustomFilePropertiesPart", CustomFilePropertiesPart.ContentTypeConstant, false, false, OfficeVersions.All));
-                tempData.Add("http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail", new PartConstraintRule("ThumbnailPart", null, false, false, OfficeVersions.All));
-                tempData.Add("http://schemas.openxmlformats.org/package/2006/relationships/digital-signature/origin", new PartConstraintRule("DigitalSignatureOriginPart", DigitalSignatureOriginPart.ContentTypeConstant, false, false, OfficeVersions.All));
-                tempData.Add("http://schemas.microsoft.com/office/2006/relationships/ui/userCustomization", new PartConstraintRule("QuickAccessToolbarCustomizationsPart", QuickAccessToolbarCustomizationsPart.ContentTypeConstant, false, false, OfficeVersions.All));
-                tempData.Add("http://schemas.microsoft.com/office/2006/relationships/ui/extensibility", new PartConstraintRule("RibbonExtensibilityPart", RibbonExtensibilityPart.ContentTypeConstant, false, false, OfficeVersions.All));
-                tempData.Add("http://schemas.microsoft.com/office/2007/relationships/ui/extensibility", new PartConstraintRule("RibbonAndBackstageCustomizationsPart", RibbonAndBackstageCustomizationsPart.ContentTypeConstant, false, false, FileFormatVersions.Office2010 | FileFormatVersions.Office2013));
-                tempData.Add("http://schemas.microsoft.com/office/2011/relationships/webextensiontaskpanes", new PartConstraintRule("WebExTaskpanesPart", WebExTaskpanesPart.ContentTypeConstant, false, false, FileFormatVersions.Office2013));
+                Dictionary<string, PartConstraintRule> tempData = new Dictionary<string, PartConstraintRule>();
+                tempData.Add("http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument", new PartConstraintRule("WorkbookPart", null, true, false, FileFormatVersions.Office2007.AndLater()));
+                tempData.Add("http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties", new PartConstraintRule("CoreFilePropertiesPart", CoreFilePropertiesPart.ContentTypeConstant, false, false, FileFormatVersions.Office2007.AndLater()));
+                tempData.Add("http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties", new PartConstraintRule("ExtendedFilePropertiesPart", ExtendedFilePropertiesPart.ContentTypeConstant, false, false, FileFormatVersions.Office2007.AndLater()));
+                tempData.Add("http://schemas.openxmlformats.org/officeDocument/2006/relationships/custom-properties", new PartConstraintRule("CustomFilePropertiesPart", CustomFilePropertiesPart.ContentTypeConstant, false, false, FileFormatVersions.Office2007.AndLater()));
+                tempData.Add("http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail", new PartConstraintRule("ThumbnailPart", null, false, false, FileFormatVersions.Office2007.AndLater()));
+                tempData.Add("http://schemas.openxmlformats.org/package/2006/relationships/digital-signature/origin", new PartConstraintRule("DigitalSignatureOriginPart", DigitalSignatureOriginPart.ContentTypeConstant, false, false, FileFormatVersions.Office2007.AndLater()));
+                tempData.Add("http://schemas.microsoft.com/office/2006/relationships/ui/userCustomization", new PartConstraintRule("QuickAccessToolbarCustomizationsPart", QuickAccessToolbarCustomizationsPart.ContentTypeConstant, false, false, FileFormatVersions.Office2007.AndLater()));
+                tempData.Add("http://schemas.microsoft.com/office/2006/relationships/ui/extensibility", new PartConstraintRule("RibbonExtensibilityPart", RibbonExtensibilityPart.ContentTypeConstant, false, false, FileFormatVersions.Office2007.AndLater()));
+                tempData.Add("http://schemas.microsoft.com/office/2007/relationships/ui/extensibility", new PartConstraintRule("RibbonAndBackstageCustomizationsPart", RibbonAndBackstageCustomizationsPart.ContentTypeConstant, false, false, FileFormatVersions.Office2010.AndLater()));
+                tempData.Add("http://schemas.microsoft.com/office/2011/relationships/webextensiontaskpanes", new PartConstraintRule("WebExTaskpanesPart", WebExTaskpanesPart.ContentTypeConstant, false, false, FileFormatVersions.Office2013.AndLater()));
 
                 _partConstraint = tempData;
             }
@@ -1038,11 +1038,11 @@ namespace DocumentFormat.OpenXml.Packaging
         /// Gets the constraint rule of DataPartReferenceRelationship.
         /// </summary>
         /// <returns>The constraint data of the part.</returns>
-        internal sealed override System.Collections.Generic.IDictionary<string, PartConstraintRule> GetDataPartReferenceConstraint()
+        internal sealed override IDictionary<string, PartConstraintRule> GetDataPartReferenceConstraint()
         {
             if (_dataPartReferenceConstraint == null)
             {
-                System.Collections.Generic.Dictionary<string, PartConstraintRule> tempData = new System.Collections.Generic.Dictionary<string, PartConstraintRule>();
+                Dictionary<string, PartConstraintRule> tempData = new Dictionary<string, PartConstraintRule>();
 
                 _dataPartReferenceConstraint = tempData;
             }
@@ -1956,28 +1956,28 @@ namespace DocumentFormat.OpenXml.Packaging
     /// </summary>
     public class PresentationDocument : OpenXmlPackage
     {
-        private static System.Collections.Generic.Dictionary<string, PartConstraintRule> _partConstraint;
-        private static System.Collections.Generic.Dictionary<string, PartConstraintRule> _dataPartReferenceConstraint;
+        private static Dictionary<string, PartConstraintRule> _partConstraint;
+        private static Dictionary<string, PartConstraintRule> _dataPartReferenceConstraint;
 
         /// <summary>
         /// Gets part constraint data.
         /// </summary>
         /// <returns>The constraint data of the part.</returns>
-        internal sealed override System.Collections.Generic.IDictionary<string, PartConstraintRule> GetPartConstraint()
+        internal sealed override IDictionary<string, PartConstraintRule> GetPartConstraint()
         {
             if (_partConstraint == null)
             {
-                System.Collections.Generic.Dictionary<string, PartConstraintRule> tempData = new System.Collections.Generic.Dictionary<string, PartConstraintRule>();
-                tempData.Add("http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument", new PartConstraintRule("PresentationPart", null, true, false, OfficeVersions.All));
-                tempData.Add("http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties", new PartConstraintRule("CoreFilePropertiesPart", CoreFilePropertiesPart.ContentTypeConstant, false, false, OfficeVersions.All));
-                tempData.Add("http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties", new PartConstraintRule("ExtendedFilePropertiesPart", ExtendedFilePropertiesPart.ContentTypeConstant, false, false, OfficeVersions.All));
-                tempData.Add("http://schemas.openxmlformats.org/officeDocument/2006/relationships/custom-properties", new PartConstraintRule("CustomFilePropertiesPart", CustomFilePropertiesPart.ContentTypeConstant, false, false, OfficeVersions.All));
-                tempData.Add("http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail", new PartConstraintRule("ThumbnailPart", null, false, false, OfficeVersions.All));
-                tempData.Add("http://schemas.openxmlformats.org/package/2006/relationships/digital-signature/origin", new PartConstraintRule("DigitalSignatureOriginPart", DigitalSignatureOriginPart.ContentTypeConstant, false, false, OfficeVersions.All));
-                tempData.Add("http://schemas.microsoft.com/office/2006/relationships/ui/userCustomization", new PartConstraintRule("QuickAccessToolbarCustomizationsPart", QuickAccessToolbarCustomizationsPart.ContentTypeConstant, false, false, OfficeVersions.All));
-                tempData.Add("http://schemas.microsoft.com/office/2006/relationships/ui/extensibility", new PartConstraintRule("RibbonExtensibilityPart", RibbonExtensibilityPart.ContentTypeConstant, false, false, OfficeVersions.All));
-                tempData.Add("http://schemas.microsoft.com/office/2007/relationships/ui/extensibility", new PartConstraintRule("RibbonAndBackstageCustomizationsPart", RibbonAndBackstageCustomizationsPart.ContentTypeConstant, false, false, FileFormatVersions.Office2010 | FileFormatVersions.Office2013));
-                tempData.Add("http://schemas.microsoft.com/office/2011/relationships/webextensiontaskpanes", new PartConstraintRule("WebExTaskpanesPart", WebExTaskpanesPart.ContentTypeConstant, false, false, FileFormatVersions.Office2013));
+                Dictionary<string, PartConstraintRule> tempData = new Dictionary<string, PartConstraintRule>();
+                tempData.Add("http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument", new PartConstraintRule("PresentationPart", null, true, false, FileFormatVersions.Office2007.AndLater()));
+                tempData.Add("http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties", new PartConstraintRule("CoreFilePropertiesPart", CoreFilePropertiesPart.ContentTypeConstant, false, false, FileFormatVersions.Office2007.AndLater()));
+                tempData.Add("http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties", new PartConstraintRule("ExtendedFilePropertiesPart", ExtendedFilePropertiesPart.ContentTypeConstant, false, false, FileFormatVersions.Office2007.AndLater()));
+                tempData.Add("http://schemas.openxmlformats.org/officeDocument/2006/relationships/custom-properties", new PartConstraintRule("CustomFilePropertiesPart", CustomFilePropertiesPart.ContentTypeConstant, false, false, FileFormatVersions.Office2007.AndLater()));
+                tempData.Add("http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail", new PartConstraintRule("ThumbnailPart", null, false, false, FileFormatVersions.Office2007.AndLater()));
+                tempData.Add("http://schemas.openxmlformats.org/package/2006/relationships/digital-signature/origin", new PartConstraintRule("DigitalSignatureOriginPart", DigitalSignatureOriginPart.ContentTypeConstant, false, false, FileFormatVersions.Office2007.AndLater()));
+                tempData.Add("http://schemas.microsoft.com/office/2006/relationships/ui/userCustomization", new PartConstraintRule("QuickAccessToolbarCustomizationsPart", QuickAccessToolbarCustomizationsPart.ContentTypeConstant, false, false, FileFormatVersions.Office2007.AndLater()));
+                tempData.Add("http://schemas.microsoft.com/office/2006/relationships/ui/extensibility", new PartConstraintRule("RibbonExtensibilityPart", RibbonExtensibilityPart.ContentTypeConstant, false, false, FileFormatVersions.Office2007.AndLater()));
+                tempData.Add("http://schemas.microsoft.com/office/2007/relationships/ui/extensibility", new PartConstraintRule("RibbonAndBackstageCustomizationsPart", RibbonAndBackstageCustomizationsPart.ContentTypeConstant, false, false, FileFormatVersions.Office2010.AndLater()));
+                tempData.Add("http://schemas.microsoft.com/office/2011/relationships/webextensiontaskpanes", new PartConstraintRule("WebExTaskpanesPart", WebExTaskpanesPart.ContentTypeConstant, false, false, FileFormatVersions.Office2013.AndLater()));
                 _partConstraint = tempData;
             }
             return _partConstraint;
@@ -1987,11 +1987,11 @@ namespace DocumentFormat.OpenXml.Packaging
         /// Gets the constraint rule of DataPartReferenceRelationship.
         /// </summary>
         /// <returns>The constraint data of the part.</returns>
-        internal sealed override System.Collections.Generic.IDictionary<string, PartConstraintRule> GetDataPartReferenceConstraint()
+        internal sealed override IDictionary<string, PartConstraintRule> GetDataPartReferenceConstraint()
         {
             if (_dataPartReferenceConstraint == null)
             {
-                System.Collections.Generic.Dictionary<string, PartConstraintRule> tempData = new System.Collections.Generic.Dictionary<string, PartConstraintRule>();
+                Dictionary<string, PartConstraintRule> tempData = new Dictionary<string, PartConstraintRule>();
 
                 _dataPartReferenceConstraint = tempData;
             }


### PR DESCRIPTION
This adds an extension method to expand a given version to include itself and all alter versions. This helps to clean up some code so it is clearer conceptually what is going on and to minimize any code churn between the vNext branch and the Office2016 branch.