### PR TITLE
Add customizable property to only build for certain targets

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,14 @@
 <Project>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+
+    <!-- Because of the size of the project, to facilitate  quick development, by default only single
+         frameworks will be build. This is customizable with the following possible values:
+
+         - DevFramework: will only build for .NET 4.6
+         - DevCore: Will only build for .NET Core
+         - All: Will build for all platforms -->
+    <ProjectLoadStyle Condition=" '$(ProjectLoadStyle)' == '' ">DevCore</ProjectLoadStyle>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/DocumentFormat.OpenXml.Tests/DocumentFormat.OpenXml.Tests.csproj
+++ b/DocumentFormat.OpenXml.Tests/DocumentFormat.OpenXml.Tests.csproj
@@ -1,7 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;net46;netcoreapp1.0</TargetFrameworks>
+    <!-- TargetFrameworks can be set to various combinations as described in Directory.Build.props -->
+    <TargetFrameworks Condition=" '$(ProjectLoadStyle)' == 'DevCore' ">netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(ProjectLoadStyle)' == 'DevFramework' ">net46</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(ProjectLoadStyle)' == 'All' ">net452;net46;netcoreapp1.0</TargetFrameworks>
+    
     <AssemblyName>DocumentFormat.OpenXml.Tests</AssemblyName>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/DocumentFormat.OpenXml/DocumentFormat.OpenXml.csproj
+++ b/DocumentFormat.OpenXml/DocumentFormat.OpenXml.csproj
@@ -3,11 +3,15 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), DocumentFormat.OpenXml.Package.props))\DocumentFormat.OpenXml.Package.props" />
 
   <PropertyGroup>
+    <!-- TargetFrameworks can be set to various combinations as described in Directory.Build.props -->
     <!--
       .NET Standard target must be first to avoid a ResXFileCodeGenerator issue
       (tracked at https://github.com/dotnet/project-system/issues/1519)
     -->
-    <TargetFrameworks>netstandard1.3;net35;net40;net46</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(ProjectLoadStyle)' == 'DevCore' ">netstandard1.3</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(ProjectLoadStyle)' == 'DevFramework' ">net46</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(ProjectLoadStyle)' == 'All' ">netstandard1.3;net35;net40;net46</TargetFrameworks>
+    
     <NoWarn>$(NoWarn);3003</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
   SignClientUser:
     secure: wPNGuPyt7pAx9YDKurysk5polnxcGU7GiWmJ70r4tpyDUgGEqxRSZhZ8lWvBhwuC
   Configuration: Release
+  ProjectLoadStyle: All
 
 install:
   - ps: nuget install -ExcludeVersion SignClient -Version 0.9.0 -OutputDirectory .\build\


### PR DESCRIPTION
This makes it so when loading in VS, it will by default only load the .NET Standard/.NET Core version. Environment variables may be used to load others. This is because VS gets unstable sometimes with the default configuration. The CI builds will continue to build for all combinations and include tests for them all.