### PR TITLE
Add FxCop analyzers

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -7,7 +7,11 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    
+
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0-beta2">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+
     <!-- GitVersionTask is not compiled against .NET Core, so importing the targets will
          result in a failure because it will try to resolve Microsoft.Build.Utilities v4.0 -->
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012" Condition=" '$(MSBuildRuntimeType)' != 'Core' ">
@@ -17,5 +21,5 @@
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)\Tests.targets" />
-  
+
 </Project>

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Build Instructions
 
 This project uses the new csproj format and the release versions of the tooling in Visual Studio 2017. For more information on how to use this project type to build your project, see the release notes for Visual Studio 2017: https://www.visualstudio.com/en-us/news/releasenotes/vs2017-relnotes#dotnetcore. Other editors that support the latest .NET project files include VS Code, VS for Mac, or .NET CLI. See https://www.microsoft.com/net/download/core for details.
 
+The project will often require the latest release of the C# compiler as many new features come on-line that greatly aid in ease of development. As of now, the C# 7.2 compiler is required (which was released in December 2017) and comes standard in Visual Studio 2017 Update 5, with other IDEs providing updates to the compiler as well.
+
 To build the Open XML SDK:
 - Clone the repo at https://github.com/OfficeDev/Open-XML-SDK
 - Open the solution with an editor that supports the latest .NET project files

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ after_build:
   - ps: .\build\SignPackage.ps1
 
 test_script:
-  - cmd: msbuild /t:test .\Open-Xml-SDK.sln /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+  - cmd: msbuild /m /t:test .\Open-Xml-SDK.sln /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
 deploy:
   provider: NuGet

--- a/rules.ruleset
+++ b/rules.ruleset
@@ -193,4 +193,31 @@
     <Rule Id="SA1651" Action="None" />
     <Rule Id="SA1652" Action="None" />
   </Rules>
+  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
+    <Rule Id="CA1000" Action="None" />
+    <Rule Id="CA1018" Action="None" />
+    <Rule Id="CA1040" Action="None" />
+    <Rule Id="CA1052" Action="None" />
+    <Rule Id="CA1054" Action="None" />
+    <Rule Id="CA1056" Action="None" />
+    <Rule Id="CA1065" Action="None" />
+    <Rule Id="CA1304" Action="None" />
+    <Rule Id="CA1305" Action="None" />
+    <Rule Id="CA1307" Action="None" />
+    <Rule Id="CA1507" Action="None" />
+    <Rule Id="CA1707" Action="None" />
+    <Rule Id="CA1710" Action="None" />
+    <Rule Id="CA1721" Action="None" />
+    <Rule Id="CA1724" Action="None" />
+    <Rule Id="CA1801" Action="None" />
+    <Rule Id="CA1802" Action="None" />
+    <Rule Id="CA1816" Action="None" />
+    <Rule Id="CA1823" Action="None" />
+    <Rule Id="CA1825" Action="None" />
+    <Rule Id="CA2208" Action="None" />
+    <Rule Id="CA2222" Action="None" />
+    <Rule Id="CA2225" Action="None" />
+    <Rule Id="CA2235" Action="None" />
+    <Rule Id="CA3075" Action="None" />
+  </Rules>
 </RuleSet>


### PR DESCRIPTION
This adds the new FxCop analyzers that are supported in 15.5. This change adds the analyzers but disables all failing rules, which can be enabled in future PRs.