### PR TITLE
Standardize property documentation to use get/set

### DIFF
--- a/DocumentFormat.OpenXml/AlternateContent.cs
+++ b/DocumentFormat.OpenXml/AlternateContent.cs
@@ -95,15 +95,13 @@ namespace DocumentFormat.OpenXml
             get { return tagName; }
         }
 
-        /// <summary>
-        /// Gets a value that represents the local name of the
-        /// AlternateContent element.
-        /// </summary>
+        /// <inheritdoc/>
         public override string LocalName
         {
             get { return tagName; }
         }
 
+        /// <inheritdoc/>
         internal override byte NamespaceId
         {
             get { return MarkupCompatibilityNamespaceId; }
@@ -112,6 +110,7 @@ namespace DocumentFormat.OpenXml
         private static string[] attributeTagNames = Cached.Array<string>();
         private static byte[] attributeNamespaceIds = Cached.Array<byte>();
 
+        /// <inheritdoc/>
         internal override string[] AttributeTagNames
         {
             get
@@ -120,6 +119,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
+        /// <inheritdoc/>
         internal override byte[] AttributeNamespaceIds
         {
             get
@@ -128,6 +128,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
+        /// <inheritdoc/>
         internal override OpenXmlElement ElementFactory(byte namespaceId, string name)
         {
             if (MarkupCompatibilityNamespaceId == namespaceId && AlternateContentChoice.TagName == name)
@@ -151,6 +152,7 @@ namespace DocumentFormat.OpenXml
             this.AppendChild(child);
             return child;
         }
+
         /// <summary>
         /// Appends a new child of type T:DocumentFormat.OpenXml.AlternateContentFallback
         ///  to the current element.
@@ -164,41 +166,25 @@ namespace DocumentFormat.OpenXml
             return child;
         }
 
+        /// <inheritdoc/>
         internal override OpenXmlSimpleType AttributeFactory(byte namespaceId, string name)
         {
             return null;
         }
 
-        /// <returns>The cloned node. </returns>
-        /// <summary>
-        /// When a node is overridden in a derived class,
-        /// CloneNode creates a duplicate of the node.
-        /// </summary>
-        /// <param name="deep">
-        /// True to recursively clone the subtree under
-        /// the specified node; False to clone only the node
-        /// itself.
-        /// </param>
+        /// <inheritdoc/>
         public override OpenXmlElement CloneNode(bool deep)
         {
             return CloneImp<AlternateContent>(deep);
         }
 
-        /// <summary>
-        /// The type ID of the element.
-        /// </summary>
+        /// <inheritdoc/>
         internal override int ElementTypeId
         {
             get { return ReservedElementTypeIds.AlternateContentId; }
         }
 
-        /// <summary>
-        /// Indicates whether this element is available in a specific version of an Office Application.
-        /// Always returns true since AlternateContent is allowed
-        /// in every version.
-        /// </summary>
-        /// <param name="version">The Office file format version.</param>
-        /// <returns>Returns true if the element is defined in the specified version.</returns>
+        /// <inheritdoc/>
         internal override bool IsInVersion(FileFormatVersions version)
         {
             return true;

--- a/DocumentFormat.OpenXml/AlternateContentChoice.cs
+++ b/DocumentFormat.OpenXml/AlternateContentChoice.cs
@@ -108,10 +108,9 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
-        /// <para>Gets or sets a whitespace-delimited list of namespace prefixes that identify the
+        /// Gets or sets a whitespace-delimited list of namespace prefixes that identify the
         /// namespaces a markup consumer needs in order to understand and select that
-        /// Choice and process the content.</para>
-        /// <para> Represents the attribute in a schema. </para>
+        /// Choice and process the content.
         /// </summary>
         public StringValue Requires
         {
@@ -155,7 +154,7 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
-        /// The type ID of the element.
+        /// Gets the type ID of the element.
         /// </summary>
         internal override int ElementTypeId
         {

--- a/DocumentFormat.OpenXml/AlternateContentFallback.cs
+++ b/DocumentFormat.OpenXml/AlternateContentFallback.cs
@@ -132,7 +132,7 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
-        /// The type ID of the element.
+        /// Gets the type ID of the element.
         /// </summary>
         internal override int ElementTypeId
         {

--- a/DocumentFormat.OpenXml/Attributes/Translator/CnfStyleTagAttributeTranslator.cs
+++ b/DocumentFormat.OpenXml/Attributes/Translator/CnfStyleTagAttributeTranslator.cs
@@ -31,7 +31,7 @@ namespace DocumentFormat.OpenXml.Attributes.Translator
         }
 
         /// <summary>
-        /// Get the attribute value.
+        /// Gets the attribute value.
         /// </summary>
         /// <returns>The attribute value</returns>
         internal override string Value

--- a/DocumentFormat.OpenXml/Attributes/Translator/IndTagAttributeTranslator.cs
+++ b/DocumentFormat.OpenXml/Attributes/Translator/IndTagAttributeTranslator.cs
@@ -19,19 +19,13 @@ namespace DocumentFormat.OpenXml.Attributes.Translator
             formatter = null;
         }
 
-        /// <summary>
-        /// Set the index to specify the attribte name to translate.
-        /// </summary>
-        /// <returns>The index</returns>
+        /// <inheritdoc/>
         protected override int SetIndex()
         {
             return this.GetIndexByAttributeName();
         }
 
-        /// <summary>
-        /// Get the attribute value.
-        /// </summary>
-        /// <returns>The attribute value</returns>
+        /// <inheritdoc/>
         internal override string Value
         {
             get { return this.strAttrValue; }

--- a/DocumentFormat.OpenXml/Attributes/Translator/TagAttributeTranslator.cs
+++ b/DocumentFormat.OpenXml/Attributes/Translator/TagAttributeTranslator.cs
@@ -93,7 +93,7 @@ namespace DocumentFormat.OpenXml.Attributes.Translator
         abstract protected int SetIndex();
 
         /// <summary>
-        /// Get the Index
+        /// Gets the Index
         /// </summary>
         /// <returns>The index</returns>
         internal virtual int Index
@@ -110,7 +110,7 @@ namespace DocumentFormat.OpenXml.Attributes.Translator
         }
 
         /// <summary>
-        /// Get the LocalName
+        /// Gets the LocalName
         /// </summary>
         /// <returns>The LocalName</returns>
         internal virtual string LocalName
@@ -119,7 +119,7 @@ namespace DocumentFormat.OpenXml.Attributes.Translator
         }
 
         /// <summary>
-        /// Get the Value
+        /// Gets the Value
         /// </summary>
         /// <returns>The value</returns>
         internal virtual string Value
@@ -128,7 +128,7 @@ namespace DocumentFormat.OpenXml.Attributes.Translator
         }
 
         /// <summary>
-        /// Get the Trait.
+        /// Gets the Trait.
         /// </summary>
         /// <returns>The Trait</returns>
         internal virtual long Trait
@@ -137,7 +137,7 @@ namespace DocumentFormat.OpenXml.Attributes.Translator
         }
 
         /// <summary>
-        /// Get the formatter.
+        /// Gets the formatter.
         /// </summary>
         internal virtual AttributeFormatter Formatter
         {

--- a/DocumentFormat.OpenXml/Attributes/Translator/TblLookTagAttributeTranslator.cs
+++ b/DocumentFormat.OpenXml/Attributes/Translator/TblLookTagAttributeTranslator.cs
@@ -30,10 +30,7 @@ namespace DocumentFormat.OpenXml.Attributes.Translator
             return this.GetIndexByAttributeName();
         }
 
-        /// <summary>
-        /// Get the attribute value.
-        /// </summary>
-        /// <returns>The attribute value</returns>
+        /// <inheritdoc/>
         internal override string Value
         {
             get { return this.strAttrValue; }

--- a/DocumentFormat.OpenXml/ChildElementInfoAttribute.cs
+++ b/DocumentFormat.OpenXml/ChildElementInfoAttribute.cs
@@ -11,17 +11,14 @@ namespace DocumentFormat.OpenXml
     [AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = true)]
     public sealed class ChildElementInfoAttribute : Attribute
     {
-        private Type _type;
-        private FileFormatVersions format;
-
         /// <summary>
         /// Initialize a new instance of ChildElementTypeAttribute.
         /// </summary>
         /// <param name="elementType">Specifies the type of the possible child element.</param>
         public ChildElementInfoAttribute(Type elementType)
         {
-            _type = elementType;
-            format = FileFormatVersions.Office2007 | FileFormatVersions.Office2010;
+            ElementType = elementType;
+            AvailableInVersion = FileFormatVersions.Office2007 | FileFormatVersions.Office2010;
         }
 
         /// <summary>
@@ -31,23 +28,18 @@ namespace DocumentFormat.OpenXml
         /// <param name="availableInOfficeVersion">Specifies the office version(s) where the child element is available.</param>
         public ChildElementInfoAttribute(Type elementType, FileFormatVersions availableInOfficeVersion)
         {
-            _type = elementType;
-            format = availableInOfficeVersion;
+            ElementType = elementType;
+            AvailableInVersion = availableInOfficeVersion;
         }
 
         /// <summary>
-        /// Get the  type of the possible child element.
+        /// Gets the type of the possible child element.
         /// </summary>
-        public Type ElementType
-        {
-            get { return _type; }
-        }
+        public Type ElementType { get; }
 
         /// <summary>
         /// Gets the Office version(s) where the child element is available.
         /// </summary>
-        public FileFormatVersions AvailableInVersion {
-            get { return format; }
-        }
+        public FileFormatVersions AvailableInVersion { get; }
     }
 }

--- a/DocumentFormat.OpenXml/DocumentTypeDetector.cs
+++ b/DocumentFormat.OpenXml/DocumentTypeDetector.cs
@@ -15,7 +15,7 @@ namespace DocumentFormat.OpenXml
         private static Dictionary<string, OpenXmlDocumentType> _mainPartContentTypes;
 
         /// <summary>
-        /// All known content types for main part in Open XML document.
+        /// Gets all known content types for main part in Open XML document.
         /// </summary>
         internal static Dictionary<string, OpenXmlDocumentType> MainPartContentTypes
         {

--- a/DocumentFormat.OpenXml/OpenXmlAttribute.cs
+++ b/DocumentFormat.OpenXml/OpenXmlAttribute.cs
@@ -100,7 +100,7 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
-        /// When overridden in a derived class, gets the qualified name of the attribute.
+        /// Gets the qualified name of the attribute.
         /// </summary>
         public XmlQualifiedName XmlQualifiedName
         {

--- a/DocumentFormat.OpenXml/OpenXmlCompositeElement.cs
+++ b/DocumentFormat.OpenXml/OpenXmlCompositeElement.cs
@@ -128,9 +128,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets a value that indicates whether the current element has any child elements.
-        /// </summary>
+        /// <inheritdoc/>
         public override bool HasChildren
         {
             get
@@ -139,9 +137,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets or sets the concatenated values of the current node and all of its children.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerText
         {
             get
@@ -155,15 +151,9 @@ namespace DocumentFormat.OpenXml
 
                 return innerText.ToString();
             }
-            //set
-            //{
-            //    throw new InvalidOperationException();
-            //}
         }
 
-        /// <summary>
-        /// Gets or sets the markup that represents only the child nodes of the current node.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerXml
         {
             set

--- a/DocumentFormat.OpenXml/OpenXmlDomReader.cs
+++ b/DocumentFormat.OpenXml/OpenXmlDomReader.cs
@@ -135,15 +135,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        ///// <summary>
-        ///// When overridden in a derived class, gets a value indicating whether the current node is an empty element (for example, <MyElement/>).
-        ///// </summary>
-        //public abstract bool IsEmptyElement { get; }
-
-        /// <summary>
-        /// Gets a value that indicates whether the current node is a miscellaneous XML node (non element).
-        /// </summary>
-        /// <remarks>IsStartElement and IsEndElement will be false when IsMiscNode==true.</remarks>
+        /// <inheritdoc/>
         public override bool IsMiscNode
         {
             get
@@ -157,17 +149,12 @@ namespace DocumentFormat.OpenXml
                     Debug.Assert(this.ElementType == typeof(OpenXmlMiscNode));
                     return true;
                 }
-                else
-                {
-                }
+
                 return false;
             }
         }
 
-        /// <summary>
-        /// Gets a value that indicates whether the current node is an element start.
-        /// </summary>
-        /// <remarks>IsStartElement and IsEndElement will be false when IsMiscNode==true.</remarks>
+        /// <inheritdoc/>
         public override bool IsStartElement
         {
             get
@@ -187,10 +174,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets a value that indicates whether the current node is an element end.
-        /// </summary>
-        /// <remarks>IsStartElement and IsEndElement will be false when IsMiscNode==true.</remarks>
+        /// <inheritdoc/>
         public override bool IsEndElement
         {
             get
@@ -210,9 +194,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets the depth of the current node in the XML document. The depth of the root element is 0.
-        /// </summary>
+        /// <inheritdoc/>
         public override int Depth
         {
             get
@@ -226,9 +208,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets a value that indicates whether the reader is positioned at the end of the stream.
-        /// </summary>
+        /// <inheritdoc/>
         public override bool EOF
         {
             get
@@ -240,9 +220,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets the local name of the current node.
-        /// </summary>
+        /// <inheritdoc/>
         public override string LocalName
         {
             get
@@ -254,9 +232,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets the namespace URI (as defined in the W3C Namespace specification) of the node on which the reader is positioned.
-        /// </summary>
+        /// <inheritdoc/>
         public override string NamespaceUri
         {
             get
@@ -268,14 +244,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        ///// <summary>
-        ///// When overridden in a derived class, gets the qualified name of the current node.
-        ///// </summary>
-        //public virtual string Name { get; }
-
-        /// <summary>
-        /// Gets the namespace prefix associated with the current node.
-        /// </summary>
+        /// <inheritdoc/>
         public override string Prefix
         {
             get
@@ -287,10 +256,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Moves to read the next element.
-        /// </summary>
-        /// <returns>Returns true if the next element was read successfully; false if there are no more elements to read. </returns>
+        /// <inheritdoc/>
         public override bool Read()
         {
             ThrowIfObjectDisposed();
@@ -308,11 +274,7 @@ namespace DocumentFormat.OpenXml
             return result;
         }
 
-        /// <summary>
-        /// Moves to read the first child element.
-        /// </summary>
-        /// <returns>Returns true if the first child element was read successfully; false if there are no child elements to read. </returns>
-        /// <remarks>This method can only be called on element start. At the current node, the reader will move to the end tag if there is no child element.</remarks>
+        /// <inheritdoc/>
         public override bool ReadFirstChild()
         {
             ThrowIfObjectDisposed();
@@ -330,11 +292,7 @@ namespace DocumentFormat.OpenXml
             return result;
         }
 
-        /// <summary>
-        /// Moves to read the next sibling element.
-        /// </summary>
-        /// <returns>Returns true if the next sibling element was read successfully; false if there are no more sibling elements to read. </returns>
-        /// <remarks>At the current node, the reader will move to the end tag of the parent if there are no more sibling elements.</remarks>
+        /// <inheritdoc/>
         public override bool ReadNextSibling()
         {
             ThrowIfObjectDisposed();
@@ -352,9 +310,7 @@ namespace DocumentFormat.OpenXml
             return result;
         }
 
-        /// <summary>
-        /// Skips the children of the current node.
-        /// </summary>
+        /// <inheritdoc/>
         public override void Skip()
         {
             ThrowIfObjectDisposed();
@@ -584,14 +540,9 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-#endregion
+        #endregion
 
-        /// <summary>
-        /// Loads the element at the current cursor.
-        /// </summary>
-        /// <returns>The OpenXmlElement object.</returns>
-        /// <exception cref="InvalidOperationException">Thrown when the current element is element end.</exception>
-        /// <remarks>The new current element is the end of the element after LoadCurrentElement().</remarks>
+        /// <inheritdoc/>
         public override OpenXmlElement LoadCurrentElement()
         {
             // TODO: should we return a clone?
@@ -624,32 +575,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        ///// <summary>
-        ///// Create an empty element of the element at current cursor.
-        ///// </summary>
-        ///// <returns>An empty ( no children, no attributes ) OpenXmlElement.</returns>
-        //public override OpenXmlElement CreateElement()
-        //{
-        //    if (this._elementState == ElementState.Start ||
-        //        this._elementState == ElementState.MiscNode)
-        //    {
-        //        OpenXmlElement element = this._elementStack.Peek();
-        //        OpenXmlElement newElement = element.CloneNode(false);
-        //        newElement.ClearAllAttributes();
-        //        return newElement;
-        //    }
-        //    else
-        //    {
-        //        throw new InvalidOperationException();
-        //    }
-        //}
-
-        /// <summary>
-        /// Gets the text of the element if the element is an OpenXmlLeafTextElement. Returns String.Empty for other elements.
-        /// </summary>
-        /// <returns>
-        /// The text of the element if the element is an OpenXmlLeafTextElement. Returns String.Empty for other elements.
-        /// </returns>
+        /// <inheritdoc/>
         public override string GetText()
         {
             ThrowIfObjectDisposed();
@@ -667,9 +593,7 @@ namespace DocumentFormat.OpenXml
             return String.Empty;
         }
 
-        /// <summary>
-        /// Closes the reader.
-        /// </summary>
+        /// <inheritdoc/>
         public override void Close()
         {
             ThrowIfObjectDisposed();

--- a/DocumentFormat.OpenXml/OpenXmlElement.cs
+++ b/DocumentFormat.OpenXml/OpenXmlElement.cs
@@ -152,7 +152,7 @@ namespace DocumentFormat.OpenXml
         #region internal properties
 
         /// <summary>
-        /// Gets the next element in the linked list.
+        /// Gets or sets the next element in the linked list.
         /// </summary>
         internal OpenXmlElement next
         {
@@ -160,14 +160,8 @@ namespace DocumentFormat.OpenXml
             set { this._next = value; }
         }
 
-        //internal bool XmlParsed
-        //{
-        //    get { return _xmlParsed; }
-        //    set { _xmlParsed = value; }
-        //}
-
         /// <summary>
-        /// Returns true if the inner raw xml is parsed.
+        /// Gets a value indicating whether the inner raw xml is parsed.
         /// </summary>
         internal bool XmlParsed
         {
@@ -175,7 +169,7 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
-        /// Gets the raw OuterXml.
+        /// Gets or sets the raw OuterXml.
         /// </summary>
         internal string RawOuterXml
         {
@@ -330,7 +324,7 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
-        /// Gets a boolean value that indicates whether the current element has any attributes.
+        /// Gets a value indicating whether the current element has any attributes.
         /// </summary>
         public bool HasAttributes
         {
@@ -379,12 +373,9 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
-        /// Gets a value that indicates whether the current element has any child elements.
+        /// Gets a value indicating whether the current element has any child elements.
         /// </summary>
-        public abstract bool HasChildren
-        {
-            get;
-        }
+        public abstract bool HasChildren { get; }
 
         /// <summary>
         /// Gets all the child nodes of the current element.
@@ -487,7 +478,7 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
-        /// Gets the concatenated values of the node and all of its children.
+        /// Gets or sets the concatenated values of the node and all of its children.
         /// </summary>
         public virtual string InnerText
         {
@@ -2705,7 +2696,7 @@ namespace DocumentFormat.OpenXml
 
         #region MC Staffs
         /// <summary>
-        /// Sets the markup compatibility attributes. Returns null if no markup compatibility attributes are defined for the current element.
+        /// Gets or sets the markup compatibility attributes. Returns null if no markup compatibility attributes are defined for the current element.
         /// </summary>
         public MarkupCompatibilityAttributes MCAttributes
         {

--- a/DocumentFormat.OpenXml/OpenXmlElementContext.cs
+++ b/DocumentFormat.OpenXml/OpenXmlElementContext.cs
@@ -65,16 +65,7 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
-        /// The XmlNameTable to be used by internal XmlReader
-        /// </summary>
-        private XmlNameTable XmlNameTable
-        {
-            get { return _xmlNameTable; }
-            // set { _xmlNameTable = value; }
-        }
-
-        /// <summary>
-        /// The XmlReaderSettings to be used by internal XmlReader
+        /// Gets or sets the XmlReaderSettings to be used by internal XmlReader
         /// </summary>
         internal XmlReaderSettings XmlReaderSettings
         {
@@ -83,7 +74,7 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
-        /// Load mode
+        /// Gets or sets load mode
         /// </summary>
         internal OpenXmlLoadMode LoadMode
         {
@@ -92,7 +83,7 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
-        /// Layers to be full populated, only effective when LoadMode==Lazy.
+        /// Gets or sets layers to be full populated, only effective when LoadMode==Lazy.
         /// Start from 0 (populate only the children layer).
         /// </summary>
         internal int LazySteps
@@ -112,18 +103,6 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        //public XmlNamespaceManager XmlNamespaceManager
-        //{
-        //    get { return _xmlNamespaceManager; }
-        //    // set { _xmlNamespaceManager = value; }
-        //}
-
-        //public XmlParserContext XmlParserContext
-        //{
-        //    get { return _xmlParserContext; }
-        //    //set { _xmlParserContext = value; }
-        //}
-
         /// <summary>
         /// Initializes a new instance of the OpenXmlElementContext class.
         /// </summary>
@@ -134,17 +113,6 @@ namespace DocumentFormat.OpenXml
             MCContext = new MCContext();
             Init();
         }
-
-        ///// <summary>
-        ///// OpenXmlElementContext constructor
-        ///// </summary>
-        //public OpenXmlElementContext(OpenXmlPart ownerPart)
-        //{
-        //    this._ownerPart = ownerPart;
-        //    // this._xmlParserContext = new XmlParserContext(
-        //    this._xmlNameTable = new NameTable();
-        //    Init();
-        //}
 
         internal static XmlReaderSettings CreateDefaultXmlReaderSettings()
         {
@@ -195,12 +163,13 @@ namespace DocumentFormat.OpenXml
             this._xmlNameTable.Add(xmlnsUri);
 
             // init XmlReaderSettings
-            this.XmlReaderSettings = new XmlReaderSettings();
-            this.XmlReaderSettings.NameTable = this.XmlNameTable;
-
             // O15:#3024890, Set IgnoreWhitespace to false for the SDK to handle the whitespace node type. We have to do this because
             // PPT does not use the preserve attribute (xml:space="preserve") for non-ignorable whitespaces. (See the bug for details.)
-            this.XmlReaderSettings.IgnoreWhitespace = false;
+            XmlReaderSettings = new XmlReaderSettings
+            {
+                NameTable = _xmlNameTable,
+                IgnoreWhitespace = false
+            };
         }
 
         #region Event mechanism

--- a/DocumentFormat.OpenXml/OpenXmlLeafElement.cs
+++ b/DocumentFormat.OpenXml/OpenXmlLeafElement.cs
@@ -13,13 +13,9 @@ namespace DocumentFormat.OpenXml
     public abstract class OpenXmlLeafElement : OpenXmlElement
     {
         /// <summary>
-        /// Represents a shadow element to hold child elements if there are any.
+        /// Gets or sets represents a shadow element to hold child elements if there are any.
         /// </summary>
-        internal OpenXmlElement ShadowElement
-        {
-            get;
-            set;
-        }
+        internal OpenXmlElement ShadowElement { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the OpenXmlLeafElement class.
@@ -29,19 +25,10 @@ namespace DocumentFormat.OpenXml
         {
         }
 
-        /// <summary>
-        /// Gets a value that indicates whether the current element has any child
-        ///  elements.
-        /// </summary>
-        public override bool HasChildren
-        {
-            get { return false; }
-        }
+        /// <inheritdoc/>
+        public override bool HasChildren => false;
 
-        /// <summary>
-        /// Gets or sets the markup that only represents child elements of the current
-        ///  element.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerXml
         {
             get
@@ -67,10 +54,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Saves all child elements of the current element to the specified XmlWriter.
-        /// </summary>
-        /// <param name="w">The XmlWriter to which to save the child elements. </param>
+        /// <inheritdoc/>
         internal override void WriteContentTo(XmlWriter w)
         {
             // Write the loaded inner xml if there are any
@@ -80,9 +64,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Removes all child elements of the current element.
-        /// </summary>
+        /// <inheritdoc/>
         public override void RemoveAllChildren()
         {
             // nothing to remove

--- a/DocumentFormat.OpenXml/OpenXmlLeafTextElement.cs
+++ b/DocumentFormat.OpenXml/OpenXmlLeafTextElement.cs
@@ -51,19 +51,13 @@ namespace DocumentFormat.OpenXml
             return null;
         }
 
-        /// <summary>
-        /// Gets a value that indicates whether the current element has any child
-        ///  elements.
-        /// </summary>
+        /// <inheritdoc/>
         public override bool HasChildren
         {
             get { return false; }
         }
 
-        /// <summary>
-        /// Gets or sets the concatenated values of the element and all of its
-        ///  child elements.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerText
         {
             get
@@ -87,10 +81,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets or sets the markup that only represents child elements of the
-        ///  current element.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerXml
         {
             get
@@ -139,10 +130,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Saves all the child elements of the current element to the specified XmlWriter.
-        /// </summary>
-        /// <param name="w">The XmlWriter to which to save the elements. </param>
+        /// <inheritdoc/>
         internal override void WriteContentTo(XmlWriter w)
         {
             // Write the loaded inner xml if there are any
@@ -157,19 +145,12 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Removes all child elements of the current element.
-        /// </summary>
+        /// <inheritdoc/>
         public override void RemoveAllChildren()
         {
             this.RawInnerText = null;
         }
 
-        //internal override void Load(XmlReader xmlReader)
-        //{
-        //    LoadAttributes(xmlReader);
-        //    this.Text = xmlReader.ReadElementString();
-        //}
         internal override void Populate(XmlReader xmlReader, OpenXmlLoadMode loadMode)
         {
             LoadAttributes(xmlReader);

--- a/DocumentFormat.OpenXml/OpenXmlNonElementNode.cs
+++ b/DocumentFormat.OpenXml/OpenXmlNonElementNode.cs
@@ -62,7 +62,7 @@ namespace DocumentFormat.OpenXml
         public OpenXmlMiscNode(XmlNodeType nodeType, string outerXml)
             : this(nodeType)
         {
-            if ( String.IsNullOrEmpty( outerXml ) )
+            if (String.IsNullOrEmpty(outerXml))
             {
                 throw new ArgumentNullException(nameof(outerXml));
             }
@@ -94,7 +94,7 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
-        /// Specifies the type of XML node.
+        /// Gets the type of XML node.
         /// </summary>
         public XmlNodeType XmlNodeType
         {
@@ -102,14 +102,13 @@ namespace DocumentFormat.OpenXml
             internal set { _nodeType = value; }
         }
 
-        /// <summary>
-        /// The type ID of the element.
-        /// </summary>
+        /// <inheritdoc/>
         internal override int ElementTypeId
         {
             get { return ReservedElementTypeIds.OpenXmlMiscNodeId; }
         }
 
+        /// <inheritdoc/>
         internal override byte NamespaceId
         {
             get
@@ -118,18 +117,13 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets a value that indicates whether the current element has any child
-        /// elements.
-        /// </summary>
+        /// <inheritdoc/>
         public override bool HasChildren
         {
             get { return false; }
         }
 
-        /// <summary>
-        /// When overridden in a derived class, gets the local name of the node.
-        /// </summary>
+        /// <inheritdoc/>
         public override string LocalName
         {
             get
@@ -200,9 +194,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets the namespace URI of the current node.
-        /// </summary>
+        /// <inheritdoc/>
         public override string NamespaceUri
         {
             get
@@ -211,9 +203,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets or sets the namespace prefix of the current node.
-        /// </summary>
+        /// <inheritdoc/>
         public override string Prefix
         {
             get
@@ -222,9 +212,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// When overridden in a derived class, gets the qualified name of the node.
-        /// </summary>
+        /// <inheritdoc/>
         public override XmlQualifiedName XmlQualifiedName
         {
             get
@@ -233,10 +221,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets or sets the markup that represents only the child nodes of the
-        /// current node.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerXml
         {
             get
@@ -250,45 +235,27 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// When overridden in a derived class, creates a duplicate of the node.
-        /// </summary>
-        /// <param name="deep">
-        /// Specify true to recursively clone the subtree under the specified
-        /// node; false to clone only the node itself.
-        /// </param>
-        /// <returns>The cloned node. </returns>
+        /// <inheritdoc/>
         public override OpenXmlElement CloneNode(bool deep)
         {
-            OpenXmlMiscNode element = new OpenXmlMiscNode(this.XmlNodeType);
-
-            element.OuterXml = this.OuterXml;
-
-            return element;
+            return new OpenXmlMiscNode(this.XmlNodeType)
+            {
+                OuterXml = this.OuterXml
+            };
         }
 
-        /// <summary>
-        /// Removes all child elements.
-        /// </summary>
+        /// <inheritdoc/>
         public override void RemoveAllChildren()
         {
         }
 
-        /// <summary>
-        /// Saves all the children of the node to the specified XmlWriter.
-        /// </summary>
-        /// <param name="w">The XmlWriter to which you want to save. </param>
+        /// <inheritdoc/>
         internal override void WriteContentTo(XmlWriter w)
         {
             throw new NotImplementedException(ExceptionMessages.NonImplemented);
         }
 
-        /// <summary>
-        /// Saves the current node to the specified XmlWriter.
-        /// </summary>
-        /// <param name="xmlWriter">
-        /// The XmlWriter at which to save the current node.
-        /// </param>
+        /// <inheritdoc/>
         public override void WriteTo(XmlWriter xmlWriter)
         {
             if (xmlWriter == null)
@@ -300,18 +267,20 @@ namespace DocumentFormat.OpenXml
             xmlWriter.WriteRaw(this.RawOuterXml);
         }
 
+        /// <inheritdoc/>
         internal override void LazyLoad(XmlReader xmlReader)
         {
             this.Populate(xmlReader, OpenXmlLoadMode.Full);
         }
 
+        /// <inheritdoc/>
         internal override void ParseXml()
         {
             // do nothing
         }
 
         /// <summary>
-        /// Holds the XmlReader.Value on loading.
+        /// Gets the XmlReader.Value on loading.
         /// </summary>
         internal string Value
         {
@@ -408,17 +377,13 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Do nothing for MiscNode.
-        /// Override this method because the MC loading algorithm try to call this method in parent's Populate.
-        /// While the OpenXmlElement.LoadAttributes() will cause the reader be moved which should not.
-        /// </summary>
-        /// <param name="xmlReader"></param>
+        /// <inheritdoc/>
         internal override void LoadAttributes(XmlReader xmlReader)
         {
             return;
         }
 
+        /// <inheritdoc/>
         internal override void Populate(XmlReader xmlReader, OpenXmlLoadMode loadMode)
         {
             this.LoadOuterXml(xmlReader);
@@ -427,14 +392,10 @@ namespace DocumentFormat.OpenXml
             // this.RawOuterXml = xmlReader.ReadOuterXml();
         }
 
-        /// <summary>
-        /// Whether this element is available in a specific version of Office Application.
-        /// For OpenXmlMiscNode, always return true, no matter what the version is.
-        /// </summary>
-        /// <param name="version">The Office file format version.</param>
-        /// <returns>Returns true if the element is defined in the specified version.</returns>
+        /// <inheritdoc/>
         internal override bool IsInVersion(FileFormatVersions version)
         {
+            // For OpenXmlMiscNode, always return true, no matter what the version is.
             return true;
         }
 

--- a/DocumentFormat.OpenXml/OpenXmlPartReader.cs
+++ b/DocumentFormat.OpenXml/OpenXmlPartReader.cs
@@ -193,9 +193,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets the type of the corresponding strong typed class of the current element.
-        /// </summary>
+        /// <inheritdoc/>
         public override Type ElementType
         {
             get
@@ -208,18 +206,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        ///// <summary>
-        ///// When overridden in a derived class, gets a value indicating whether the current node is an empty element (for example, <MyElement/>).
-        ///// </summary>
-        //public override bool IsEmptyElement
-        //{
-        //    get { return this._xmlReader.IsEmptyElement; }
-        //}
-
-        /// <summary>
-        /// Gets a value that indicates whether the current node is a miscellaneous XML node (non element).
-        /// </summary>
-        /// <remarks>IsStartElement and IsEndElement will be false when IsMiscNode==true.</remarks>
+        /// <inheritdoc/>
         public override bool IsMiscNode
         {
             get
@@ -240,10 +227,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets a value that indicates whether the current node is an element start.
-        /// </summary>
-        /// <remarks>IsStartElement and IsEndElement will be false when IsMiscNode==true.</remarks>
+        /// <inheritdoc/>
         public override bool IsStartElement
         {
             get
@@ -263,10 +247,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets a value that indicates whether the current node is an element end.
-        /// </summary>
-        /// <remarks>IsStartElement and IsEndElement will be false when IsMiscNode==true.</remarks>
+        /// <inheritdoc/>
         public override bool IsEndElement
         {
             get
@@ -287,9 +268,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets the depth of the current node in the XML document. The depth of the root element is 0.
-        /// </summary>
+        /// <inheritdoc/>
         public override int Depth
         {
             get
@@ -303,9 +282,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets a value that indicates whether the reader is positioned at the end of the stream.
-        /// </summary>
+        /// <inheritdoc/>
         public override bool EOF
         {
             get
@@ -317,9 +294,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets the local name of the current node.
-        /// </summary>
+        /// <inheritdoc/>
         public override string LocalName
         {
             get
@@ -331,9 +306,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets the namespace URI (as defined in the W3C Namespace specification) of the node on which the reader is positioned.
-        /// </summary>
+        /// <inheritdoc/>
         public override string NamespaceUri
         {
             get
@@ -345,14 +318,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        ///// <summary>
-        ///// When overridden in a derived class, gets the qualified name of the current node.
-        ///// </summary>
-        //public virtual string Name { get; }
-
-        /// <summary>
-        /// Gets the namespace prefix associated with the current node.
-        /// </summary>
+        /// <inheritdoc/>
         public override string Prefix
         {
             get
@@ -364,10 +330,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Moves to read the next element.
-        /// </summary>
-        /// <returns>Returns true if the next element was read successfully; false if there are no more elements to read. </returns>
+        /// <inheritdoc/>
         public override bool Read()
         {
             ThrowIfObjectDisposed();
@@ -385,11 +348,7 @@ namespace DocumentFormat.OpenXml
             return result;
         }
 
-        /// <summary>
-        /// Moves to read the first child element.
-        /// </summary>
-        /// <returns>Returns true if the first child element was read successfully; false if there are no child elements to read. </returns>
-        /// <remarks>This method can only be called on element start. At the current node, the reader will move to the end tag if there is no child element.</remarks>
+        /// <inheritdoc/>
         public override bool ReadFirstChild()
         {
             ThrowIfObjectDisposed();
@@ -407,11 +366,7 @@ namespace DocumentFormat.OpenXml
             return result;
         }
 
-        /// <summary>
-        /// Moves to read the next sibling element.
-        /// </summary>
-        /// <returns>Returns true if the next sibling element was read successfully; false if there are no more sibling elements to read. </returns>
-        /// <remarks>At the current node, the reader will move to the end tag of the parent if there are no more sibling elements.</remarks>
+        /// <inheritdoc/>
         public override bool ReadNextSibling()
         {
             ThrowIfObjectDisposed();
@@ -429,9 +384,7 @@ namespace DocumentFormat.OpenXml
             return result;
         }
 
-        /// <summary>
-        /// Skips the child elements of the current node.
-        /// </summary>
+        /// <inheritdoc/>
         public override void Skip()
         {
             ThrowIfObjectDisposed();
@@ -643,12 +596,7 @@ namespace DocumentFormat.OpenXml
 
         #endregion
 
-        /// <summary>
-        /// Loads the element at the current cursor.
-        /// </summary>
-        /// <returns>The OpenXmlElement object.</returns>
-        /// <exception cref="InvalidOperationException">Thrown when the current element is element end.</exception>
-        /// <remarks>The new current element is the end of the element after LoadCurrentElement().</remarks>
+        /// <inheritdoc/>
         public override OpenXmlElement LoadCurrentElement()
         {
             ThrowIfObjectDisposed();
@@ -701,40 +649,7 @@ namespace DocumentFormat.OpenXml
             return null;
         }
 
-        ///// <summary>
-        ///// Create an empty element of the element at current cursor.
-        ///// </summary>
-        ///// <returns>An empty ( no children, no attributes ) OpenXmlElement.</returns>
-        //public override OpenXmlElement CreateElement()
-        //{
-        //    switch (this._elementState)
-        //    {
-        //        case ElementState.LeafStart:
-        //        case ElementState.Start:
-        //        case ElementState.MiscNode:
-        //            {
-        //                OpenXmlElement element = this._elementStack.Peek();
-        //                OpenXmlElement newElement = element.CloneNode(false);
-        //                newElement.ClearAllAttributes();
-        //                return newElement;
-        //            }
-
-        //        case ElementState.LoadEnd:
-        //        case ElementState.End:
-        //        case ElementState.LeafEnd:
-        //        case ElementState.Null:
-        //        case ElementState.EOF:
-        //        default:
-        //            throw new InvalidOperationException();
-        //    }
-        //}
-
-        /// <summary>
-        /// Gets the text of the element if the element is an OpenXmlLeafTextElement. Returns String.Empty for other elements.
-        /// </summary>
-        /// <returns>
-        /// The text of the element if the element is an OpenXmlLeafTextElement. Returns String.Empty for other elements.
-        /// </returns>
+        /// <inheritdoc/>
         public override string GetText()
         {
             ThrowIfObjectDisposed();
@@ -752,9 +667,7 @@ namespace DocumentFormat.OpenXml
             return String.Empty;
         }
 
-        /// <summary>
-        /// Closes the reader.
-        /// </summary>
+        /// <inheritdoc/>
         public override void Close()
         {
             ThrowIfObjectDisposed();

--- a/DocumentFormat.OpenXml/OpenXmlPartRootElement.cs
+++ b/DocumentFormat.OpenXml/OpenXmlPartRootElement.cs
@@ -231,14 +231,10 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
-        /// Get / set the part that is associated with the DOM tree.
+        /// Gets or sets the part that is associated with the DOM tree.
         /// It returns null when the DOM tree is not associated with a part.
         /// </summary>
-        internal OpenXmlPart OpenXmlPart
-        {
-            get;
-            set;
-        }
+        internal OpenXmlPart OpenXmlPart { get; set; }
 
         /// <summary>
         /// Saves the data in the DOM tree back to the part. This method can
@@ -362,11 +358,8 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
-        /// If this property is true, then the Save method will try write all namespace declation on the root element.
+        /// Gets a value indicating whether the Save method will try write all namespace declation on the root element.
         /// </summary>
-        internal virtual bool WriteAllNamespaceOnRoot
-        {
-            get { return true; }
-        }
+        internal virtual bool WriteAllNamespaceOnRoot => true;
     }
 }

--- a/DocumentFormat.OpenXml/OpenXmlReader.cs
+++ b/DocumentFormat.OpenXml/OpenXmlReader.cs
@@ -100,7 +100,7 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
-        /// Gets a value that indicates whether the OpenXmlReader will read or skip all miscellaneous nodes.
+        /// Gets a value indicating whether the OpenXmlReader will read or skip all miscellaneous nodes.
         /// </summary>
         public bool ReadMiscNodes
         {
@@ -140,7 +140,7 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
-        /// Gets a value that indicates whether the current node has any attributes.
+        /// Gets a value indicating whether the current node has any attributes.
         /// </summary>
         public virtual bool HasAttributes
         {
@@ -154,10 +154,7 @@ namespace DocumentFormat.OpenXml
         /// <summary>
         /// Gets the list of attributes of the current element.
         /// </summary>
-        public abstract ReadOnlyCollection<OpenXmlAttribute> Attributes
-        {
-            get;
-        }
+        public abstract ReadOnlyCollection<OpenXmlAttribute> Attributes { get; }
 
         /// <summary>
         /// Gets the namespace declarations of the current element.
@@ -167,76 +164,46 @@ namespace DocumentFormat.OpenXml
         /// <summary>
         /// Gets the type of the corresponding strongly typed class of the current element.
         /// </summary>
-        public abstract Type ElementType
-        {
-            get;
-        }
-
-        ///// <summary>
-        ///// When overridden in a derived class, gets a value indicating whether the current node is an empty element (for example, <MyElement/>).
-        ///// </summary>
-        //public abstract bool IsEmptyElement { get; }
+        public abstract Type ElementType { get; }
 
         /// <summary>
-        /// When overridden in a derived class, gets a value that indicates whether the current node is a miscellaneous XML node (non element).
+        /// Gets a value indicating whether the current node is a miscellaneous XML node (non element).
         /// </summary>
-        /// <remarks>IsStartElement and IsEndElement will be false when IsMiscNode==true.</remarks>
-        public abstract bool IsMiscNode
-        {
-            get;
-        }
+        /// <remarks><see cref="IsStartElement"/> and <see cref="IsEndElement"/> will be false when <see cref="IsMiscNode"/> is true.</remarks>
+        public abstract bool IsMiscNode { get; }
 
         /// <summary>
-        /// When overridden in a derived class, gets a value that indicates whether the current node is an element start.
+        /// Gets a value indicating whether the current node is an element start.
         /// </summary>
-        /// <remarks>IsStartElement and IsEndElement will be false when IsMiscNode==true.</remarks>
-        public abstract bool IsStartElement
-        {
-            get;
-        }
+        public abstract bool IsStartElement { get; }
 
         /// <summary>
-        /// When overridden in a derived class, gets a value that indicates whether the current node is an element end.
+        /// Gets a value indicating whether the current node is an element end.
         /// </summary>
-        /// <remarks>IsStartElement and IsEndElement will be false when IsMiscNode==true.</remarks>
-        public abstract bool IsEndElement
-        {
-            get;
-        }
+        public abstract bool IsEndElement { get; }
 
         /// <summary>
         /// Gets the depth of the current node in the XML document. The depth of the root element is 0.
         /// </summary>
-        public abstract int Depth
-        {
-            get;
-        }
+        public abstract int Depth { get; }
 
         /// <summary>
-        /// When overridden in a derived class, gets a value that indicates whether the reader is positioned at the end of the stream.
+        /// Gets a value indicating whether the reader is positioned at the end of the stream.
         /// </summary>
-        public abstract bool EOF
-        {
-            get;
-        }
+        public abstract bool EOF { get; }
 
         /// <summary>
-        /// When overridden in a derived class, gets the local name of the current node.
+        /// Gets the local name of the current node.
         /// </summary>
         public abstract string LocalName { get; }
 
         /// <summary>
-        /// When overridden in a derived class, gets the namespace URI (as defined in the W3C Namespace specification) of the node on which the reader is positioned.
+        /// Gets the namespace URI (as defined in the W3C Namespace specification) of the node on which the reader is positioned.
         /// </summary>
         public abstract string NamespaceUri { get; }
 
-        ///// <summary>
-        ///// When overridden in a derived class, gets the qualified name of the current node.
-        ///// </summary>
-        //public virtual string Name { get; }
-
         /// <summary>
-        /// When overridden in a derived class, gets the namespace prefix associated with the current node.
+        /// Gets the namespace prefix associated with the current node.
         /// </summary>
         public abstract string Prefix { get; }
 

--- a/DocumentFormat.OpenXml/OpenXmlUnknownElement.cs
+++ b/DocumentFormat.OpenXml/OpenXmlUnknownElement.cs
@@ -134,71 +134,24 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// When overridden in a derived class, gets the local name of the node.
-        /// </summary>
-        public override string LocalName
-        {
-            get { return this._tagName; }
-        }
+        /// <inheritdoc/>
+        public override string LocalName => this._tagName;
 
-        /// <summary>
-        /// Gets the namespace URI of the current node.
-        /// </summary>
-        public override string NamespaceUri
-        {
-            get
-            {
-                return this._namespaceUri;
-            }
-        }
+        /// <inheritdoc/>
+        public override string NamespaceUri => this._namespaceUri;
 
-        /// <summary>
-        /// Gets or sets the prefix of the current node.
-        /// </summary>
-        public override string Prefix
-        {
-            get
-            {
-                return this._prefix;
-            }
-        }
+        /// <inheritdoc/>
+        public override string Prefix => this._prefix;
 
-        /// <summary>
-        /// When overridden in a derived class, gets the qualified name of the node.
-        /// </summary>
-        public override XmlQualifiedName XmlQualifiedName
-        {
-            get
-            {
-                return new XmlQualifiedName(this._tagName, this._namespaceUri);
-            }
-        }
+        /// <inheritdoc/>
+        public override XmlQualifiedName XmlQualifiedName => new XmlQualifiedName(this._tagName, this._namespaceUri);
 
-        //internal override int AttributeTotal
-        //{
-        //    get { return this._attributeTotal; }
-        //}
+        internal override byte NamespaceId => throw new InvalidOperationException();
 
-        internal override byte NamespaceId
-        {
-            get
-            {
-                throw new InvalidOperationException();
-            }
-        }
+        /// <inheritdoc/>
+        internal override int ElementTypeId => ReservedElementTypeIds.OpenXmlUnknownElementId;
 
-        /// <summary>
-        /// The type ID of the element.
-        /// </summary>
-        internal override int ElementTypeId
-        {
-            get { return ReservedElementTypeIds.OpenXmlUnknownElementId; }
-        }
-
-        /// <summary>
-        /// Gets or sets the concatenated values of the node and all of its children.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerText
         {
             get
@@ -212,10 +165,6 @@ namespace DocumentFormat.OpenXml
                     return this._text;
                 }
             }
-            //set
-            //{
-            //    throw new InvalidOperationException();
-            //}
         }
 
         /// <summary>
@@ -231,19 +180,16 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// When overridden in a derived class, creates a duplicate of the node.
-        /// </summary>
-        /// <param name="deep">
-        /// Specify true to recursively clone the subtree under the specified
-        /// node; false to clone only the node itself.
-        /// </param>
-        /// <returns>The cloned node. </returns>
+        /// <inheritdoc/>
         public override OpenXmlElement CloneNode(bool deep)
         {
-            OpenXmlUnknownElement element = new OpenXmlUnknownElement(this._prefix, this._tagName, this._namespaceUri);
-            element._text = this.Text;
+            OpenXmlUnknownElement element = new OpenXmlUnknownElement(this._prefix, this._tagName, this._namespaceUri)
+            {
+                _text = this.Text
+            };
+
             element.CopyAttributes(this);
+
             if(deep)
             {
                 element.CopyChilden(this, deep);
@@ -252,10 +198,7 @@ namespace DocumentFormat.OpenXml
             return element;
         }
 
-        /// <summary>
-        /// Saves all the children of the node to the specified XmlWriter.
-        /// </summary>
-        /// <param name="w">The XmlWriter to which you want to save. </param>
+        /// <inheritdoc/>
         internal override void WriteContentTo(XmlWriter w)
         {
             if (this.HasChildren)
@@ -271,10 +214,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Saves the current node to the specified XmlWriter.
-        /// </summary>
-        /// <param name="xmlWriter">The XmlWriter at which to save.</param>
+        /// <inheritdoc/>
         public override void WriteTo(XmlWriter xmlWriter)
         {
             if (xmlWriter == null)
@@ -295,6 +235,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
+        /// <inheritdoc/>
         internal override void LazyLoad(XmlReader xmlReader)
         {
             this._tagName = xmlReader.LocalName;
@@ -304,6 +245,7 @@ namespace DocumentFormat.OpenXml
             this.RawOuterXml = xmlReader.ReadOuterXml();
         }
 
+        /// <inheritdoc/>
         internal override void Populate(XmlReader xmlReader, OpenXmlLoadMode loadMode)
         {
             if (String.IsNullOrEmpty(this._tagName))
@@ -345,12 +287,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Whether this element is available in a specific version of Office Application.
-        /// For OpenXmlUnknownElement, always return false, no matter what the version is.
-        /// </summary>
-        /// <param name="version">The Office file format version.</param>
-        /// <returns>Returns true if the element is defined in the specified version.</returns>
+        /// <inheritdoc/>
         internal override bool IsInVersion(FileFormatVersions version)
         {
             return false;

--- a/DocumentFormat.OpenXml/Packaging/CustomUIPart.cs
+++ b/DocumentFormat.OpenXml/Packaging/CustomUIPart.cs
@@ -13,9 +13,7 @@ namespace DocumentFormat.OpenXml.Packaging
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         private DocumentFormat.OpenXml.Office.CustomUI.CustomUI _rootEle;
 
-        /// <summary>
-        /// Only for OpenXmlPart derived classes.
-        /// </summary>
+        /// <inheritdoc/>
         internal override OpenXmlPartRootElement _rootElement
         {
             get
@@ -29,9 +27,7 @@ namespace DocumentFormat.OpenXml.Packaging
             }
         }
 
-        /// <summary>
-        /// Gets the root element of this part. The DOM tree will be loaded on demand.
-        /// </summary>
+        /// <inheritdoc/>
         internal override OpenXmlPartRootElement PartRootElement
         {
             get
@@ -41,9 +37,9 @@ namespace DocumentFormat.OpenXml.Packaging
         }
 
         /// <summary>
-        /// Gets/Sets the root element of this part.
+        /// Gets or sets the root element of this part.
         /// </summary>
-        public DocumentFormat.OpenXml.Office.CustomUI.CustomUI CustomUI
+        public Office.CustomUI.CustomUI CustomUI
         {
             get
             {

--- a/DocumentFormat.OpenXml/Packaging/DataPart.cs
+++ b/DocumentFormat.OpenXml/Packaging/DataPart.cs
@@ -193,28 +193,19 @@ namespace DocumentFormat.OpenXml.Packaging
         }
 
         /// <summary>
-        /// The internal path to be used for the part name.
+        /// Gets the internal path to be used for the part name.
         /// </summary>
-        internal virtual string TargetPath
-        {
-            get { return DefaultTargetPart; }
-        }
+        internal virtual string TargetPath => DefaultTargetPart;
 
         /// <summary>
-        /// The file base name to be used for the part name in the package.
+        /// Gets the file base name to be used for the part name in the package.
         /// </summary>
-        internal virtual string TargetName
-        {
-            get { return DefaultTargetName; }
-        }
+        internal virtual string TargetName => DefaultTargetName;
 
         /// <summary>
-        /// The file extension to be used for the part in the package.
+        /// Gets the file extension to be used for the part in the package.
         /// </summary>
-        internal virtual string TargetFileExtension
-        {
-            get { return DefaultTargetExt; }
-        }
+        internal virtual string TargetFileExtension => DefaultTargetExt;
 
         internal void Load(OpenXmlPackage openXmlPackage, PackagePart packagePart)
         {

--- a/DocumentFormat.OpenXml/Packaging/ExtendedPart.cs
+++ b/DocumentFormat.OpenXml/Packaging/ExtendedPart.cs
@@ -36,9 +36,7 @@ namespace DocumentFormat.OpenXml.Packaging
             this._relationshipType = relationshipType;
         }
 
-        /// <summary>
-        /// The relationship type of the part.
-        /// </summary>
+        /// <inheritdoc/>
         public override string RelationshipType
         {
             get
@@ -47,9 +45,7 @@ namespace DocumentFormat.OpenXml.Packaging
             }
         }
 
-        /// <summary>
-        /// The file extension to be used for the part in the package.
-        /// </summary>
+        /// <inheritdoc/>
         internal override string TargetFileExtension
         {
             get
@@ -58,17 +54,13 @@ namespace DocumentFormat.OpenXml.Packaging
             }
         }
 
-        /// <summary>
-        /// The internal path to be used for the part name.
-        /// </summary>
+        /// <inheritdoc/>
         internal override string TargetPath
         {
             get { return "udata"; }
         }
 
-        /// <summary>
-        /// The file base name to be used for the part name in the package
-        /// </summary>
+        /// <inheritdoc/>
         internal override string TargetName
         {
             get { return "data"; }

--- a/DocumentFormat.OpenXml/Packaging/MailMergeRecipientDataPart.cs
+++ b/DocumentFormat.OpenXml/Packaging/MailMergeRecipientDataPart.cs
@@ -14,9 +14,7 @@ namespace DocumentFormat.OpenXml.Packaging
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         private DocumentFormat.OpenXml.OpenXmlPartRootElement _rootEle;
 
-        /// <summary>
-        /// Only for OpenXmlPart derived classes.
-        /// </summary>
+        /// <inheritdoc/>
         internal override OpenXmlPartRootElement _rootElement
         {
             get
@@ -30,9 +28,7 @@ namespace DocumentFormat.OpenXml.Packaging
             }
         }
 
-        /// <summary>
-        /// Gets the root element of this part. The DOM tree will be loaded on demand.
-        /// </summary>
+        /// <inheritdoc/>
         internal override OpenXmlPartRootElement PartRootElement
         {
             get
@@ -49,10 +45,10 @@ namespace DocumentFormat.OpenXml.Packaging
         }
 
         /// <summary>
-        /// Gets/Sets the part's root element when the part's content type is MailMergeRecipientDataPartType.OpenXmlMailMergeRecipientData.
+        /// Gets or sets the part's root element when the part's content type is MailMergeRecipientDataPartType.OpenXmlMailMergeRecipientData.
         /// Setting this property will throw InvalidOperationException if the MailMergeRecipients property is not null.
         /// </summary>
-        public DocumentFormat.OpenXml.Wordprocessing.Recipients Recipients
+        public Wordprocessing.Recipients Recipients
         {
             get
             {
@@ -75,10 +71,10 @@ namespace DocumentFormat.OpenXml.Packaging
         }
 
         /// <summary>
-        /// Gets/Sets the part's root element when the part's content type is MailMergeRecipientDataPartType.MsWordMailMergeRecipientData.
+        /// Gets or sets the part's root element when the part's content type is MailMergeRecipientDataPartType.MsWordMailMergeRecipientData.
         /// Setting this property will throw InvalidOperationException if the Recipients property is not null.
         /// </summary>
-        public DocumentFormat.OpenXml.Office.Word.MailMergeRecipients MailMergeRecipients
+        public MailMergeRecipients MailMergeRecipients
         {
             get
             {

--- a/DocumentFormat.OpenXml/Packaging/MediaDataPart.cs
+++ b/DocumentFormat.OpenXml/Packaging/MediaDataPart.cs
@@ -20,28 +20,13 @@ namespace DocumentFormat.OpenXml.Packaging
         {
         }
 
-        /// <summary>
-        /// The internal path to be used for the part name.
-        /// </summary>
-        internal override string TargetPath
-        {
-            get { return DefaultTargetPart; }
-        }
+        /// <inheritdoc/>
+        internal override string TargetPath => DefaultTargetPart;
 
-        /// <summary>
-        /// The file base name to be used for the part name in the package
-        /// </summary>
-        internal override string TargetName
-        {
-            get { return DefaultTargetName; }
-        }
+        /// <inheritdoc/>
+        internal override string TargetName => DefaultTargetName;
 
-        /// <summary>
-        /// The file extension to be used for the part in the package.
-        /// </summary>
-        internal override string TargetFileExtension
-        {
-            get { return DefaultTargetExt; }
-        }
+        /// <inheritdoc/>
+        internal override string TargetFileExtension => DefaultTargetExt;
     }
 }

--- a/DocumentFormat.OpenXml/Packaging/OpenSettings.cs
+++ b/DocumentFormat.OpenXml/Packaging/OpenSettings.cs
@@ -12,7 +12,7 @@ namespace DocumentFormat.OpenXml.Packaging
         private MarkupCompatibilityProcessSettings _mcSettings;
 
         /// <summary>
-        /// Gets or sets a value that indicates whether or not to auto save document modifications.
+        /// Gets or sets a value indicating whether to auto save document modifications.
         /// The default value is true.
         /// </summary>
         public bool AutoSave

--- a/DocumentFormat.OpenXml/Packaging/OpenXmlBasePart.cs
+++ b/DocumentFormat.OpenXml/Packaging/OpenXmlBasePart.cs
@@ -290,7 +290,7 @@ namespace DocumentFormat.OpenXml.Packaging
         #region public properties
 
         /// <summary>
-        /// Represents a part that is in the OpenXmlPackage container.
+        /// Gets a part that is in the OpenXmlPackage container.
         /// </summary>
         public OpenXmlPackage OpenXmlPackage
         {
@@ -302,7 +302,7 @@ namespace DocumentFormat.OpenXml.Packaging
         }
 
         /// <summary>
-        /// Represents the internal part path in the package.
+        /// Gets the internal part path in the package.
         /// </summary>
         public Uri Uri
         {
@@ -314,11 +314,6 @@ namespace DocumentFormat.OpenXml.Packaging
 
                 return this._uri;
             }
-            //internal set
-            //{
-            //    ThrowIfObjectDisposed();
-            //    this._uri = value;
-            //}
         }
 
         #endregion
@@ -407,7 +402,7 @@ namespace DocumentFormat.OpenXml.Packaging
         #region public virtual methods / properties
 
         /// <summary>
-        /// Represents the content type (MIME type) of the content data in the part.
+        /// Gets the content type (MIME type) of the content data in the part.
         /// </summary>
         public virtual string ContentType
         {
@@ -419,7 +414,7 @@ namespace DocumentFormat.OpenXml.Packaging
         }
 
         /// <summary>
-        /// The relationship type of the part.
+        /// Gets the relationship type of the part.
         /// </summary>
         public abstract string RelationshipType { get; }
 
@@ -510,7 +505,7 @@ namespace DocumentFormat.OpenXml.Packaging
         #region internal properties
 
         /// <summary>
-        /// The internal metro PackagePart element.
+        /// Gets the internal metro PackagePart element.
         /// </summary>
         internal PackagePart PackagePart
         {
@@ -519,7 +514,6 @@ namespace DocumentFormat.OpenXml.Packaging
                 ThrowIfObjectDisposed();
                 return this._metroPart;
             }
-            // set { this._metroPart = value; }
         }
 
         ///// <summary>
@@ -554,7 +548,7 @@ namespace DocumentFormat.OpenXml.Packaging
         #region internal virtual methods / properties
 
         /// <summary>
-        /// Indicates whether the ContentType for the current part is fixed.
+        /// Gets a value indicating whether the ContentType for the current part is fixed.
         /// </summary>
         internal virtual bool IsContentTypeFixed
         {
@@ -658,15 +652,9 @@ namespace DocumentFormat.OpenXml.Packaging
         #region internal methods
 
         /// <summary>
-        /// Returns true when the root element is loaded from the part or it has been set.
+        /// Gets a value indicating whether the root element is loaded from the part or it has been set.
         /// </summary>
-        internal bool IsRootElementLoaded
-        {
-            get
-            {
-                return this._rootElement != null;
-            }
-        }
+        internal bool IsRootElementLoaded => this._rootElement != null;
 
         /// <summary>
         /// Sets the PartRootElement to null.

--- a/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
+++ b/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
@@ -349,22 +349,12 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <remarks>
         /// This property allows you to mitigate denial of service attacks where the attacker submits a package with an extremely large Open XML part. By limiting the size of a part, you can detect the attack and recover reliably.
         /// </remarks>
-        public long MaxCharactersInPart
-        {
-            get;
-            internal set;
-        }
+        public long MaxCharactersInPart { get; internal set; }
 
         /// <summary>
-        /// Enumerates all the <see cref="DataPart"/> parts in the document package.
+        /// Gets all the <see cref="DataPart"/> parts in the document package.
         /// </summary>
-        public IEnumerable<DataPart> DataParts
-        {
-            get
-            {
-                return this._dataPartList;
-            }
-        }
+        public IEnumerable<DataPart> DataParts => this._dataPartList;
 
         #endregion
 
@@ -755,15 +745,9 @@ namespace DocumentFormat.OpenXml.Packaging
 
         #region Auto-Save functions
         /// <summary>
-        /// Gets a flag that indicates whether the parts should be saved when disposed.
+        /// Gets a value indicating whether the parts should be saved when disposed.
         /// </summary>
-        public bool AutoSave
-        {
-            get
-            {
-                return OpenSettings.AutoSave;
-            }
-        }
+        public bool AutoSave => OpenSettings.AutoSave;
 
         private void SavePartContents(bool save)
         {

--- a/DocumentFormat.OpenXml/Packaging/OpenXmlPackageValidationEventArgs.cs
+++ b/DocumentFormat.OpenXml/Packaging/OpenXmlPackageValidationEventArgs.cs
@@ -26,7 +26,7 @@ namespace DocumentFormat.OpenXml.Packaging
         }
 
         /// <summary>
-        /// Gets the message string of the event.
+        /// Gets or sets the message string of the event.
         /// </summary>
         public string Message
         {
@@ -75,19 +75,11 @@ namespace DocumentFormat.OpenXml.Packaging
             internal set { _parentPart = value; }
         }
 
-        internal string MessageId
-        {
-            get;
-            set;
-        }
+        internal string MessageId { get; set; }
 
         /// <summary>
-        /// The DataPartReferenceRelationship that caused the event.
+        /// Gets or sets the DataPartReferenceRelationship that caused the event.
         /// </summary>
-        internal DataPartReferenceRelationship DataPartReferenceRelationship
-        {
-            get;
-            set;
-        }
+        internal DataPartReferenceRelationship DataPartReferenceRelationship { get; set; }
     }
 }

--- a/DocumentFormat.OpenXml/Packaging/OpenXmlPartContainer.cs
+++ b/DocumentFormat.OpenXml/Packaging/OpenXmlPartContainer.cs
@@ -173,7 +173,7 @@ namespace DocumentFormat.OpenXml.Packaging
         #region methods to operate ExternalRelationship
 
         /// <summary>
-        /// Enumerates all external relationships.
+        /// Gets all external relationships.
         /// Hyperlink relationships are not included, use HyperlinkRelationship property to enumerate hyperlink relationships.
         /// </summary>
         public IEnumerable<ExternalRelationship> ExternalRelationships
@@ -351,7 +351,7 @@ namespace DocumentFormat.OpenXml.Packaging
         #region methods to operate HyperlinkRelationship
 
         /// <summary>
-        /// Enumerates all hyperlink relationships.
+        /// Gets all hyperlink relationships.
         /// </summary>
         public IEnumerable<HyperlinkRelationship> HyperlinkRelationships
         {
@@ -422,7 +422,7 @@ namespace DocumentFormat.OpenXml.Packaging
         #region methods to operate DataPartReferenceRelationship
 
         /// <summary>
-        /// Enumerates all <see cref="DataPartReferenceRelationship"/> relationships.
+        /// Gets all <see cref="DataPartReferenceRelationship"/> relationships.
         /// </summary>
         public IEnumerable<DataPartReferenceRelationship> DataPartReferenceRelationships
         {
@@ -525,7 +525,7 @@ namespace DocumentFormat.OpenXml.Packaging
         #region methods to operate parts
 
         /// <summary>
-        /// Enumerates all parts which are relationship targets of this part.
+        /// Gets all parts which are relationship targets of this part.
         /// </summary>
         public IEnumerable<IdPartPair> Parts
         {
@@ -2254,7 +2254,7 @@ namespace DocumentFormat.OpenXml.Packaging
         #region abstract / virtual internal methods to be implemented by derived classes.
 
         /// <summary>
-        /// Internal OpenXmlPackage instance
+        /// Gets the internal OpenXmlPackage instance
         /// </summary>
         abstract internal OpenXmlPackage InternalOpenXmlPackage { get; }
 

--- a/DocumentFormat.OpenXml/Packaging/ReferenceRelationship.cs
+++ b/DocumentFormat.OpenXml/Packaging/ReferenceRelationship.cs
@@ -58,47 +58,27 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Gets the owner <see cref="OpenXmlPartContainer"/> that holds the <see cref="ReferenceRelationship"/>.
         /// </summary>
-        public OpenXmlPartContainer Container
-        {
-            get;
-            internal set;
-        }
+        public OpenXmlPartContainer Container { get; internal set; }
 
         /// <summary>
         /// Gets the relationship type.
         /// </summary>
-        public virtual string RelationshipType
-        {
-            get;
-            private set;
-        }
+        public virtual string RelationshipType { get; private set; }
 
         /// <summary>
-        /// Gets a value that indicates whether the target of the relationship is Internal or External to the <see cref="OpenXmlPackage"/>.
+        /// Gets a value indicating whether the target of the relationship is Internal or External to the <see cref="OpenXmlPackage"/>.
         /// </summary>
-        public virtual bool IsExternal
-        {
-            get;
-            private set;
-        }
+        public virtual bool IsExternal { get; private set; }
 
         /// <summary>
         /// Gets the relationship ID.
         /// </summary>
-        public virtual string Id
-        {
-            get;
-            private set;
-        }
+        public virtual string Id { get; private set; }
 
         /// <summary>
         /// Gets the target URI of the relationship.
         /// </summary>
-        public virtual Uri Uri
-        {
-            get;
-            private set;
-        }
+        public virtual Uri Uri { get; private set; }
 
         /// <summary>
         /// Initializes this instance of the ReferenceRelationship.

--- a/DocumentFormat.OpenXml/Packaging/StylesPart.cs
+++ b/DocumentFormat.OpenXml/Packaging/StylesPart.cs
@@ -11,11 +11,9 @@ namespace DocumentFormat.OpenXml.Packaging
     public abstract partial class StylesPart : OpenXmlPart
     {
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
-        private DocumentFormat.OpenXml.Wordprocessing.Styles _rootEle;
+        private Wordprocessing.Styles _rootEle;
 
-        /// <summary>
-        /// Only for OpenXmlPart derived classes.
-        /// </summary>
+        /// <inheritdoc/>
         internal override OpenXmlPartRootElement _rootElement
         {
             get
@@ -41,9 +39,9 @@ namespace DocumentFormat.OpenXml.Packaging
         }
 
         /// <summary>
-        /// Gets/Sets the root element of this part.
+        /// Gets or sets the root element of this part.
         /// </summary>
-        public DocumentFormat.OpenXml.Wordprocessing.Styles Styles
+        public Wordprocessing.Styles Styles
         {
             get
             {

--- a/DocumentFormat.OpenXml/SimpleTypes/Base64BinaryValue.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/Base64BinaryValue.cs
@@ -50,7 +50,7 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
-        /// Gets the base64Binary string value.
+        /// Gets or sets the Base64 binary string value.
         /// </summary>
         public string Value
         {

--- a/DocumentFormat.OpenXml/SimpleTypes/BooleanValue.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/BooleanValue.cs
@@ -46,9 +46,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets or sets the inner XML text.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerText
         {
             get
@@ -62,18 +60,13 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Convert the text to meaningful value.
-        /// </summary>
+        /// <inheritdoc/>
         internal override void Parse()
         {
             this.InnerValue = XmlConvert.ToBoolean(this.TextValue);
         }
 
-        /// <summary>
-        /// Convert the text to meaningful value.
-        /// </summary>
-        /// <returns></returns>
+        /// <inheritdoc/>
         internal override bool TryParse()
         {
             Boolean value;

--- a/DocumentFormat.OpenXml/SimpleTypes/ByteValue.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/ByteValue.cs
@@ -47,9 +47,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets or sets the inner XML text.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerText
         {
             get

--- a/DocumentFormat.OpenXml/SimpleTypes/DateTimeValue.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/DateTimeValue.cs
@@ -68,9 +68,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets or sets the inner XML text.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerText
         {
             get

--- a/DocumentFormat.OpenXml/SimpleTypes/DecimalValue.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/DecimalValue.cs
@@ -47,9 +47,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// The inner XML text.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerText
         {
             get

--- a/DocumentFormat.OpenXml/SimpleTypes/DoubleValue.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/DoubleValue.cs
@@ -47,9 +47,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets or sets the inner XML text.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerText
         {
             get

--- a/DocumentFormat.OpenXml/SimpleTypes/EnumValue.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/EnumValue.cs
@@ -78,9 +78,7 @@ namespace DocumentFormat.OpenXml
             this._enumValue = source._enumValue;
         }
 
-        /// <summary>
-        /// Gets a value that indicates whether the underneath text value is a valid value.
-        /// </summary>
+        /// <inheritdoc/>
         public override bool HasValue
         {
             get
@@ -131,9 +129,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets or sets the inner XML text.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerText
         {
             get

--- a/DocumentFormat.OpenXml/SimpleTypes/HexBinaryValue.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/HexBinaryValue.cs
@@ -44,7 +44,7 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
-        /// Gets the hexBinary string value.
+        /// Gets or sets the hex binary value
         /// </summary>
         public string Value
         {

--- a/DocumentFormat.OpenXml/SimpleTypes/Int16Value.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/Int16Value.cs
@@ -43,9 +43,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets or sets the inner XML text.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerText
         {
             get
@@ -67,18 +65,13 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Convert the text to meaningful value.
-        /// </summary>
+        /// <inheritdoc/>
         internal override void Parse()
         {
             this.InnerValue = XmlConvert.ToInt16(this.TextValue);
         }
 
-        /// <summary>
-        /// Convert the text to meaningful value.
-        /// </summary>
-        /// <returns></returns>
+        /// <inheritdoc/>
         internal override bool TryParse()
         {
             Int16 value;

--- a/DocumentFormat.OpenXml/SimpleTypes/Int32Value.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/Int32Value.cs
@@ -43,9 +43,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets or sets the inner XML text.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerText
         {
             get
@@ -85,18 +83,13 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Convert the text to meaningful value.
-        /// </summary>
+        /// <inheritdoc/>
         internal override void Parse()
         {
             this.InnerValue = XmlConvert.ToInt32(this.TextValue);
         }
 
-        /// <summary>
-        /// Convert the text to meaningful value.
-        /// </summary>
-        /// <returns></returns>
+        /// <inheritdoc/>
         internal override bool TryParse()
         {
             Int32 value;

--- a/DocumentFormat.OpenXml/SimpleTypes/Int64Value.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/Int64Value.cs
@@ -43,9 +43,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets or sets the inner XML text.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerText
         {
             get
@@ -67,18 +65,13 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Convert the text to meaningful value.
-        /// </summary>
+        /// <inheritdoc/>
         internal override void Parse()
         {
             this.InnerValue = XmlConvert.ToInt64(this.TextValue);
         }
 
-        /// <summary>
-        /// Convert the text to meaningful value.
-        /// </summary>
-        /// <returns></returns>
+        /// <inheritdoc/>
         internal override bool TryParse()
         {
             Int64 value;

--- a/DocumentFormat.OpenXml/SimpleTypes/IntegerValue.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/IntegerValue.cs
@@ -50,9 +50,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets or sets the inner XML text.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerText
         {
             get
@@ -74,18 +72,13 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Convert the text to meaningful value.
-        /// </summary>
+        /// <inheritdoc/>
         internal override void Parse()
         {
             this.InnerValue = XmlConvert.ToInt64(this.TextValue);
         }
 
-        /// <summary>
-        /// Convert the text to meaningful value.
-        /// </summary>
-        /// <returns></returns>
+        /// <inheritdoc/>
         internal override bool TryParse()
         {
             Int64 value;

--- a/DocumentFormat.OpenXml/SimpleTypes/ListValue.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/ListValue.cs
@@ -64,10 +64,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets a value that indicates whether the underneath text value is
-        /// a valid value.
-        /// </summary>
+        /// <inheritdoc/>
         public override bool HasValue
         {
             get

--- a/DocumentFormat.OpenXml/SimpleTypes/OnOffValue.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/OnOffValue.cs
@@ -56,9 +56,7 @@ namespace DocumentFormat.OpenXml
                 GetDefaultTextValue);
         }
 
-        /// <summary>
-        /// Gets a value that indicates whether the underneath text value is a valid value.
-        /// </summary>
+        /// <inheritdoc/>
         public override bool HasValue
         {
             get
@@ -67,10 +65,12 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets or sets the value.
-        /// </summary>
+#pragma warning disable SA1623 // Property summary documentation should match accessor
+                              /// <summary>
+                              /// Gets or sets the value.
+                              /// </summary>
         public bool Value
+#pragma warning restore SA1623 // Property summary documentation should match accessors
         {
             get
             {
@@ -83,9 +83,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets or sets the inner XML text.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerText
         {
             get

--- a/DocumentFormat.OpenXml/SimpleTypes/OpenXmlSimpleType.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/OpenXmlSimpleType.cs
@@ -37,8 +37,8 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
-        /// DON'T use this property. Only for OpenXmlSimpleType.cs internal use.
-        /// The internal raw text value.
+        /// Gets or sets the internal raw text value.
+        /// DO NOT use this property. Only for OpenXmlSimpleType.cs internal use.
         /// </summary>
         protected string TextValue
         {
@@ -70,7 +70,7 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
-        /// Gets a value that indicates whether the underneath text value is a valid value.
+        /// Gets a value indicating whether the underneath text value is a valid value.
         /// </summary>
         public virtual bool HasValue
         {

--- a/DocumentFormat.OpenXml/SimpleTypes/OpenXmlSimpleValue.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/OpenXmlSimpleValue.cs
@@ -57,9 +57,7 @@ namespace DocumentFormat.OpenXml
             this.InnerText = source.InnerText;
         }
 
-        /// <summary>
-        /// Gets a value that indicates whether the underneath text value is a valid value.
-        /// </summary>
+        /// <inheritdoc/>
         public override bool HasValue
         {
             get
@@ -104,9 +102,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets or sets the inner XML text.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerText
         {
             get

--- a/DocumentFormat.OpenXml/SimpleTypes/SByteValue.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/SByteValue.cs
@@ -44,9 +44,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets or sets the inner XML text.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerText
         {
             get
@@ -68,18 +66,13 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Convert the text to meaningful value.
-        /// </summary>
+        /// <inheritdoc/>
         internal override void Parse()
         {
             this.InnerValue = XmlConvert.ToSByte(this.TextValue);
         }
 
-        /// <summary>
-        /// Convert the text to meaningful value.
-        /// </summary>
-        /// <returns></returns>
+        /// <inheritdoc/>
         internal override bool TryParse()
         {
             SByte value;

--- a/DocumentFormat.OpenXml/SimpleTypes/SingleValue.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/SingleValue.cs
@@ -43,9 +43,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets or sets the inner XML text.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerText
         {
             get
@@ -86,19 +84,14 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Convert the text to meaningful value.
-        /// </summary>
+        /// <inheritdoc/>
         internal override void Parse()
         {
             float value = XmlConvert.ToSingle(this.TextValue);
             this.InnerValue = value;
         }
 
-        /// <summary>
-        /// Convert the text to meaningful value.
-        /// </summary>
-        /// <returns></returns>
+        /// <inheritdoc/>
         internal override bool TryParse()
         {
             this.InnerValue = null;

--- a/DocumentFormat.OpenXml/SimpleTypes/StringValue.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/StringValue.cs
@@ -44,7 +44,7 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
-        /// Gets the string value.
+        /// Gets or sets the string value.
         /// </summary>
         public string Value
         {

--- a/DocumentFormat.OpenXml/SimpleTypes/TrueFalseBlankValue.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/TrueFalseBlankValue.cs
@@ -55,21 +55,15 @@ namespace DocumentFormat.OpenXml
                 GetDefaultTextValue);
         }
 
-        /// <summary>
-        /// Gets a value that indicates whether the underneath text value is valid value.
-        /// </summary>
-        public override bool HasValue
-        {
-            get
-            {
-                return _impl.HasValue;
-            }
-        }
+        /// <inheritdoc/>
+        public override bool HasValue => _impl.HasValue;
 
-        /// <summary>
-        /// Gets or sets the value.
-        /// </summary>
+#pragma warning disable SA1623 // Property summary documentation should match accessors
+                              /// <summary>
+                              /// Gets or sets the value.
+                              /// </summary>
         public bool Value
+#pragma warning restore SA1623 // Property summary documentation should match accessors
         {
             get
             {
@@ -82,9 +76,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets or sets the inner XML text.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerText
         {
             get

--- a/DocumentFormat.OpenXml/SimpleTypes/TrueFalseValue.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/TrueFalseValue.cs
@@ -56,21 +56,15 @@ namespace DocumentFormat.OpenXml
                 GetDefaultTextValue);
         }
 
-        /// <summary>
-        /// Gets a value that indicates whether the underneath text value is a valid value.
-        /// </summary>
-        public override bool HasValue
-        {
-            get
-            {
-                return _impl.HasValue;
-            }
-        }
+        /// <inheritdoc/>
+        public override bool HasValue => _impl.HasValue;
 
-        /// <summary>
-        /// Gets or sets the value.
-        /// </summary>
+#pragma warning disable SA1623 // Property summary documentation should match accessors
+                              /// <summary>
+                              /// Gets or sets the value.
+                              /// </summary>
         public Boolean Value
+#pragma warning restore SA1623 // Property summary documentation should match accessors
         {
             get
             {
@@ -83,9 +77,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets or sets the inner XML text.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerText
         {
             get

--- a/DocumentFormat.OpenXml/SimpleTypes/TrueFalseValueImpl.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/TrueFalseValueImpl.cs
@@ -36,9 +36,7 @@ namespace DocumentFormat.OpenXml
             this._getDefaultTextValueMethod = getDefaultTextMethod;
         }
 
-        /// <summary>
-        /// Gets and sets the inner XML text.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerText
         {
             get
@@ -59,9 +57,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets a value that indicates whether the underneath text value is a valid value.
-        /// </summary>
+        /// <inheritdoc/>
         public override bool HasValue
         {
             get
@@ -81,10 +77,12 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets and sets the boolean value of the <see cref="TrueFalseValueImpl"/> type.
-        /// </summary>
+#pragma warning disable SA1623 // Property summary documentation should match accessors
+                              /// <summary>
+                              /// Gets or sets the boolean value
+                              /// </summary>
         public bool Value
+#pragma warning restore SA1623 // Property summary documentation should match accessors
         {
             get
             {

--- a/DocumentFormat.OpenXml/SimpleTypes/UInt16Value.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/UInt16Value.cs
@@ -44,9 +44,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets or sets the inner XML text.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerText
         {
             get
@@ -66,18 +64,13 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Convert the text to meaningful value.
-        /// </summary>
+        /// <inheritdoc/>
         internal override void Parse()
         {
             this.InnerValue = XmlConvert.ToUInt16(this.TextValue);
         }
 
-        /// <summary>
-        /// Convert the text to meaningful value.
-        /// </summary>
-        /// <returns></returns>
+        /// <inheritdoc/>
         internal override bool TryParse()
         {
             UInt16 value;

--- a/DocumentFormat.OpenXml/SimpleTypes/UInt32Value.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/UInt32Value.cs
@@ -44,9 +44,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets or sets the inner XML text.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerText
         {
             get

--- a/DocumentFormat.OpenXml/SimpleTypes/UInt64Value.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/UInt64Value.cs
@@ -44,9 +44,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Gets or sets the inner XML text.
-        /// </summary>
+        /// <inheritdoc/>
         public override string InnerText
         {
             get

--- a/DocumentFormat.OpenXml/Validation/DocumentValidator.cs
+++ b/DocumentFormat.OpenXml/Validation/DocumentValidator.cs
@@ -19,29 +19,17 @@ namespace DocumentFormat.OpenXml.Validation
         /// <summary>
         /// Gets the schema validator for schema validation.
         /// </summary>
-        internal SchemaValidator SchemaValidator
-        {
-            get;
-            private set;
-        }
+        internal SchemaValidator SchemaValidator { get; private set; }
 
         /// <summary>
         /// Gets the semantic validator for semantic validation.
         /// </summary>
-        internal SemanticValidator SemanticValidator
-        {
-            get;
-            private set;
-        }
+        internal SemanticValidator SemanticValidator { get; private set; }
 
         /// <summary>
-        /// The validation settings.
+        /// Gets the validation settings.
         /// </summary>
-        protected ValidationSettings ValidationSettings
-        {
-            get;
-            private set;
-        }
+        protected ValidationSettings ValidationSettings { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the DocumentValidator.
@@ -165,7 +153,7 @@ namespace DocumentFormat.OpenXml.Validation
         protected ValidationContext ValidationContext { get; set; }
 
         /// <summary>
-        /// Gets or set the validtion result.
+        /// Gets or sets or set the validtion result.
         /// </summary>
         protected ValidationResult ValidationResult { get; set; }
 
@@ -175,7 +163,7 @@ namespace DocumentFormat.OpenXml.Validation
         protected abstract OpenXmlPackage TargetDocument { get; set; }
 
         /// <summary>
-        /// Returns all the parts needs to be validated.
+        /// Gets all the parts needs to be validated.
         /// </summary>
         protected abstract IEnumerable<OpenXmlPart> PartsToBeValidated { get; }
 

--- a/DocumentFormat.OpenXml/Validation/OpenXmlValidator.cs
+++ b/DocumentFormat.OpenXml/Validation/OpenXmlValidator.cs
@@ -47,9 +47,6 @@ namespace DocumentFormat.OpenXml.Validation
 
         #region private properties
 
-        /// <summary>
-        /// Schema validator
-        /// </summary>
         private SchemaValidator SchemaValidator
         {
             get

--- a/DocumentFormat.OpenXml/Validation/PresentationDocumentValidator.cs
+++ b/DocumentFormat.OpenXml/Validation/PresentationDocumentValidator.cs
@@ -42,9 +42,7 @@ namespace DocumentFormat.OpenXml.Validation
             }
         }
 
-        /// <summary>
-        /// Returns all the parts needs to be validated.
-        /// </summary>
+        /// <inheritdoc/>
         protected override IEnumerable<OpenXmlPart> PartsToBeValidated
         {
             get

--- a/DocumentFormat.OpenXml/Validation/Schema/AnyParticle.cs
+++ b/DocumentFormat.OpenXml/Validation/Schema/AnyParticle.cs
@@ -28,18 +28,14 @@ namespace DocumentFormat.OpenXml.Validation.Schema
             _particleValidator = new AnyParticleValidator(this);
         }
 
-        /// <summary>
-        /// Gets the type of the particle.
-        /// </summary>
+        /// <inheritdoc/>
         internal override ParticleType ParticleType
         {
             get { return ParticleType.Any; }
             set { Debug.Assert(value == ParticleType.Any); }
         }
 
-        /// <summary>
-        /// This field is actually the value of the xsd:any.
-        /// </summary>
+        /// <inheritdoc/>
         internal override int ElementId
         {
             set
@@ -54,65 +50,11 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         }
 
         /// <summary>
-        /// The value of the xsd:any@namespace.
+        /// Gets the value of the xsd:any@namespace.
         /// </summary>
-        internal ushort NamespaceValue
-        {
-            get { return this._xsdAnyValue; }
-        }
+        internal ushort NamespaceValue => this._xsdAnyValue;
 
-        /// <summary>
-        /// Gets a ParticleValidator for this particle constraint.
-        /// </summary>
-        internal override IParticleValidator ParticleValidator
-        {
-            get { return this._particleValidator; }
-        }
+        /// <inheritdoc/>
+        internal override IParticleValidator ParticleValidator => this._particleValidator;
     }
-
-#if false
-    /// <summary>
-    /// Particle constraint data for particle which type is ParticleType.All
-    /// </summary>
-    internal class AllParticle : CompositeParticle
-    {
-        internal AllParticle() : base()
-        {
-        }
-    }
-
-    /// <summary>
-    /// Particle constraint data for particle which type is ParticleType.Choice
-    /// </summary>
-    internal class ChoiceParticle : CompositeParticle
-    {
-        internal ChoiceParticle()
-            : base()
-        {
-        }
-    }
-
-    /// <summary>
-    /// Particle constraint data for particle which type is ParticleType.Sequence
-    /// </summary>
-    internal class SequenceParticle : CompositeParticle
-    {
-        internal SequenceParticle()
-            : base()
-        {
-        }
-    }
-
-    /// <summary>
-    /// Particle constraint data for particle which type is ParticleType.Group
-    /// </summary>
-    internal class GroupParticle : CompositeParticle
-    {
-        internal GroupParticle()
-            : base()
-        {
-        }
-    }
-#endif
-
 }

--- a/DocumentFormat.OpenXml/Validation/Schema/AttributeConstraint.cs
+++ b/DocumentFormat.OpenXml/Validation/Schema/AttributeConstraint.cs
@@ -11,7 +11,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema
     /// </summary>
     internal class AttributeConstraint
     {
-        internal AttributeConstraint(XsdAttributeUse xsdAttributeUse, SimpleTypeRestriction simpleTypeConstraint)
+        public AttributeConstraint(XsdAttributeUse xsdAttributeUse, SimpleTypeRestriction simpleTypeConstraint)
         {
             Debug.Assert(simpleTypeConstraint != null);
 
@@ -19,7 +19,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema
             this.SimpleTypeConstraint = simpleTypeConstraint;
         }
 
-        internal AttributeConstraint(XsdAttributeUse xsdAttributeUse, SimpleTypeRestriction simpleTypeConstraint, FileFormatVersions supportedVersion)
+        public AttributeConstraint(XsdAttributeUse xsdAttributeUse, SimpleTypeRestriction simpleTypeConstraint, FileFormatVersions supportedVersion)
         {
             Debug.Assert(simpleTypeConstraint != null);
 
@@ -29,33 +29,18 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         }
 
         /// <summary>
-        /// The "use" attribute on xsd:attribute [ use = (optional | prohibited | required): optional ]
+        /// Gets the "use" attribute on xsd:attribute [ use = (optional | prohibited | required): optional ]
         /// </summary>
-        internal XsdAttributeUse XsdAttributeUse
-        {
-            get;
-            private set;
-        }
-
-        // the name of the attribute will be gotten from the CodeGen info.
-        // public string PropertyName { get; set; } // the Property name of the xsd:attribute.
+        public XsdAttributeUse XsdAttributeUse { get; }
 
         /// <summary>
-        /// The simple type constraint for this attribute.
+        /// Gets the simple type constraint for this attribute.
         /// </summary>
-        internal SimpleTypeRestriction SimpleTypeConstraint
-        {
-            get;
-            private set;
-        }
+        public SimpleTypeRestriction SimpleTypeConstraint { get; }
 
         /// <summary>
-        /// In which file format version this attribute is allowed.
+        /// Gets in which file format version this attribute is allowed.
         /// </summary>
-        internal FileFormatVersions SupportedVersion
-        {
-            get;
-            private set;
-        }
+        public FileFormatVersions SupportedVersion { get; }
     }
 }

--- a/DocumentFormat.OpenXml/Validation/Schema/CompositeParticle.cs
+++ b/DocumentFormat.OpenXml/Validation/Schema/CompositeParticle.cs
@@ -29,27 +29,21 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         {
         }
 
-        /// <summary>
-        /// Gets the type of the particle.
-        /// </summary>
+        /// <inheritdoc/>
         internal override ParticleType ParticleType
         {
             get { return this._particleType; }
             set { this._particleType = value; }
         }
 
-        /// <summary>
-        /// Gets the children particles.
-        /// </summary>
+        /// <inheritdoc/>
         internal override ParticleConstraint[] ChildrenParticles
         {
             get { return this._childrenParticles; }
             set { this._childrenParticles = value; }
         }
 
-        /// <summary>
-        /// Gets a ParticleValidator for this particle constraint.
-        /// </summary>
+        /// <inheritdoc/>
         internal override IParticleValidator ParticleValidator
         {
             get
@@ -71,50 +65,4 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         //    throw new NotImplementedException();
         //}
     }
-
-#if false
-    /// <summary>
-    /// Particle constraint data for particle which type is ParticleType.All
-    /// </summary>
-    internal class AllParticle : CompositeParticle
-    {
-        internal AllParticle() : base()
-        {
-        }
-    }
-
-    /// <summary>
-    /// Particle constraint data for particle which type is ParticleType.Choice
-    /// </summary>
-    internal class ChoiceParticle : CompositeParticle
-    {
-        internal ChoiceParticle()
-            : base()
-        {
-        }
-    }
-
-    /// <summary>
-    /// Particle constraint data for particle which type is ParticleType.Sequence
-    /// </summary>
-    internal class SequenceParticle : CompositeParticle
-    {
-        internal SequenceParticle()
-            : base()
-        {
-        }
-    }
-
-    /// <summary>
-    /// Particle constraint data for particle which type is ParticleType.Group
-    /// </summary>
-    internal class GroupParticle : CompositeParticle
-    {
-        internal GroupParticle()
-            : base()
-        {
-        }
-    }
-#endif
-
 }

--- a/DocumentFormat.OpenXml/Validation/Schema/CompositeParticleValidator.cs
+++ b/DocumentFormat.OpenXml/Validation/Schema/CompositeParticleValidator.cs
@@ -25,7 +25,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         private ParticleMatchInfo _childMatchInfo = new ParticleMatchInfo();
 
         /// <summary>
-        /// The constraint to be validated.
+        /// Gets the constraint to be validated.
         /// </summary>
         protected ParticleConstraint ParticleConstraint { get { return this._particleConstraint; } }
 

--- a/DocumentFormat.OpenXml/Validation/Schema/ElementParticle.cs
+++ b/DocumentFormat.OpenXml/Validation/Schema/ElementParticle.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using DocumentFormat.OpenXml.Validation;
 using System.Diagnostics;
 
 namespace DocumentFormat.OpenXml.Validation.Schema
@@ -23,39 +22,27 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         {
         }
 
-        /// <summary>
-        /// Gets the type of the particle.
-        /// </summary>
+        /// <inheritdoc/>
         internal override ParticleType ParticleType
         {
             get { return ParticleType.Element; }
             set { Debug.Assert(value == ParticleType.Element); }
         }
 
-        /// <summary>
-        /// Gets or sets the type ID of the OpenXmlElement if the ParticleType == ParticleType.Element.
-        /// </summary>
+        /// <inheritdoc/>
         internal override int ElementId
         {
             get { return this._elementId; }
             set { this._elementId = value; }
         }
 
-        /// <summary>
-        /// Gets a ParticleValidator for this particle constraint.
-        /// </summary>
+        /// <inheritdoc/>
         internal override IParticleValidator ParticleValidator
         {
             get { return this; }
         }
 
-        #region IParticleValidator Members
-
-        /// <summary>
-        /// Try match this element once.
-        /// </summary>
-        /// <param name="particleMatchInfo"></param>
-        /// <param name="validationContext"></param>
+        /// <inheritdoc/>
         public void TryMatchOnce(ParticleMatchInfo particleMatchInfo, ValidationContext validationContext)
         {
             Debug.Assert(particleMatchInfo != null);
@@ -73,11 +60,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema
             return;
         }
 
-        /// <summary>
-        /// Try match this element.
-        /// </summary>
-        /// <param name="particleMatchInfo"></param>
-        /// <param name="validationContext"></param>
+        /// <inheritdoc/>
         public void TryMatch(ParticleMatchInfo particleMatchInfo, ValidationContext validationContext)
         {
             Debug.Assert(particleMatchInfo != null);
@@ -128,11 +111,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema
             return;
         }
 
-        /// <summary>
-        /// Get the required elements - elements which minOccurs > 0.
-        /// </summary>
-        /// <param name="result"></param>
-        /// <returns>True if there are required elements in this particle.</returns>
+        /// <inheritdoc/>
         public bool GetRequiredElements(ExpectedChildren result)
         {
             if (this.MinOccurs > 0)
@@ -146,10 +125,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema
             return false;
         }
 
-        /// <summary>
-        /// Get the required elements - elements which minOccurs > 0.
-        /// </summary>
-        /// <returns>Required elements in this particle.</returns>
+        /// <inheritdoc/>
         public ExpectedChildren GetRequiredElements()
         {
             ExpectedChildren requiredElements = new ExpectedChildren();
@@ -162,21 +138,14 @@ namespace DocumentFormat.OpenXml.Validation.Schema
             return requiredElements;
         }
 
-        /// <summary>
-        /// Get the expected elements - elements which minOccurs >= 0.
-        /// </summary>
-        /// <param name="result"></param>
-        /// <returns>True if there are expected elements in this particle.</returns>
+        /// <inheritdoc/>
         public bool GetExpectedElements(ExpectedChildren result)
         {
             result.Add(this.ElementId);
             return true;
         }
 
-        /// <summary>
-        /// Get the expected elements - elements which minOccurs >= 0.
-        /// </summary>
-        /// <returns>Expected elements in this particle.</returns>
+        /// <inheritdoc/>
         public ExpectedChildren GetExpectedElements()
         {
             ExpectedChildren expectedElements = new ExpectedChildren();
@@ -185,53 +154,5 @@ namespace DocumentFormat.OpenXml.Validation.Schema
 
             return expectedElements;
         }
-
-        #endregion
     }
-
-#if false
-    /// <summary>
-    /// Particle constraint data for particle which type is ParticleType.All
-    /// </summary>
-    internal class AllParticle : CompositeParticle
-    {
-        internal AllParticle() : base()
-        {
-        }
-    }
-
-    /// <summary>
-    /// Particle constraint data for particle which type is ParticleType.Choice
-    /// </summary>
-    internal class ChoiceParticle : CompositeParticle
-    {
-        internal ChoiceParticle()
-            : base()
-        {
-        }
-    }
-
-    /// <summary>
-    /// Particle constraint data for particle which type is ParticleType.Sequence
-    /// </summary>
-    internal class SequenceParticle : CompositeParticle
-    {
-        internal SequenceParticle()
-            : base()
-        {
-        }
-    }
-
-    /// <summary>
-    /// Particle constraint data for particle which type is ParticleType.Group
-    /// </summary>
-    internal class GroupParticle : CompositeParticle
-    {
-        internal GroupParticle()
-            : base()
-        {
-        }
-    }
-#endif
-
 }

--- a/DocumentFormat.OpenXml/Validation/Schema/ExpectedChildren.cs
+++ b/DocumentFormat.OpenXml/Validation/Schema/ExpectedChildren.cs
@@ -95,7 +95,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         }
 
         /// <summary>
-        /// Returns the count of required children elements.
+        /// Gets the count of required children elements.
         /// </summary>
         internal int Count
         {

--- a/DocumentFormat.OpenXml/Validation/Schema/NsAnyParticle.cs
+++ b/DocumentFormat.OpenXml/Validation/Schema/NsAnyParticle.cs
@@ -28,18 +28,14 @@ namespace DocumentFormat.OpenXml.Validation.Schema
             _particleValidator = new NsAnyParticleValidator(this);
         }
 
-        /// <summary>
-        /// Gets the type of the particle.
-        /// </summary>
+        /// <inheritdoc/>
         internal override ParticleType ParticleType
         {
             get { return ParticleType.AnyWithUri; }
             set { Debug.Assert(value == ParticleType.AnyWithUri); }
         }
 
-        /// <summary>
-        /// This field is actually the namespace ID of the xsd:any.
-        /// </summary>
+        /// <inheritdoc/>
         internal override int ElementId
         {
             set
@@ -49,7 +45,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         }
 
         /// <summary>
-        /// The namespace ID of the the namespace in the xsd:any@namespace.
+        /// Gets the namespace ID of the the namespace in the xsd:any@namespace.
         /// </summary>
         internal byte NamespaceId
         {
@@ -59,55 +55,6 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         /// <summary>
         /// Gets a ParticleValidator for this particle constraint.
         /// </summary>
-        internal override IParticleValidator ParticleValidator
-        {
-            get { return this._particleValidator;  }
-        }
+        internal override IParticleValidator ParticleValidator => this._particleValidator;
     }
-
-#if false
-    /// <summary>
-    /// Particle constraint data for particle which type is ParticleType.All
-    /// </summary>
-    internal class AllParticle : CompositeParticle
-    {
-        internal AllParticle() : base()
-        {
-        }
-    }
-
-    /// <summary>
-    /// Particle constraint data for particle which type is ParticleType.Choice
-    /// </summary>
-    internal class ChoiceParticle : CompositeParticle
-    {
-        internal ChoiceParticle()
-            : base()
-        {
-        }
-    }
-
-    /// <summary>
-    /// Particle constraint data for particle which type is ParticleType.Sequence
-    /// </summary>
-    internal class SequenceParticle : CompositeParticle
-    {
-        internal SequenceParticle()
-            : base()
-        {
-        }
-    }
-
-    /// <summary>
-    /// Particle constraint data for particle which type is ParticleType.Group
-    /// </summary>
-    internal class GroupParticle : CompositeParticle
-    {
-        internal GroupParticle()
-            : base()
-        {
-        }
-    }
-#endif
-
 }

--- a/DocumentFormat.OpenXml/Validation/Schema/ParticleConstraint.cs
+++ b/DocumentFormat.OpenXml/Validation/Schema/ParticleConstraint.cs
@@ -25,7 +25,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         }
 
         /// <summary>
-        /// Gets the type of the particle.
+        /// Gets or sets the type of the particle.
         /// </summary>
         internal virtual ParticleType ParticleType
         {
@@ -45,7 +45,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         internal int MaxOccurs { get; set; }
 
         /// <summary>
-        /// Gets whether the maxOccurs="unbounded".
+        /// Gets a value indicating whether the maxOccurs is unbounded.
         /// </summary>
         internal bool UnboundedMaxOccurs
         {
@@ -53,7 +53,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         }
 
         /// <summary>
-        /// Return true if maxOccurs="unbounded" or maxOccurs > 1
+        /// Gets a value indicating whether maxOccurs is unbounded or maxOccurs > 1
         /// </summary>
         internal bool CanOccursMoreThanOne
         {
@@ -83,7 +83,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         }
 
         /// <summary>
-        /// Gets the children particles.
+        /// Gets or sets the children particles.
         /// </summary>
         /// <remarks>
         /// be null if the ParticleType == ParticleType.Element || ParticleType=ParticleType.Any

--- a/DocumentFormat.OpenXml/Validation/Schema/ParticleMatchInfo.cs
+++ b/DocumentFormat.OpenXml/Validation/Schema/ParticleMatchInfo.cs
@@ -36,22 +36,22 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         }
 
         /// <summary>
-        /// Particle match result.
+        /// Gets or sets particle match result.
         /// </summary>
         internal ParticleMatch Match { get; set; }
 
         /// <summary>
-        /// The start element to be matched by a particle rule.
+        /// Gets the start element to be matched by a particle rule.
         /// </summary>
         internal OpenXmlElement StartElement { get; private set; }
 
         /// <summary>
-        /// The last element matched by the particle match.
+        /// Gets or sets the last element matched by the particle match.
         /// </summary>
         internal OpenXmlElement LastMatchedElement { get; set; }
 
         /// <summary>
-        /// On Partial match, return the errors.
+        /// Gets or sets message on match error
         /// </summary>
         /// <remarks>
         /// TODO: how can this be decopled from the validator?
@@ -59,7 +59,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         internal string ErrorMessage { get; set; }
 
         /// <summary>
-        /// The element type ids of expected children.
+        /// Gets the element type ids of expected children.
         /// Fill this field on partial match.
         /// </summary>
         /// <remarks>
@@ -109,17 +109,6 @@ namespace DocumentFormat.OpenXml.Validation.Schema
                 this.ExpectedChildren.Add(expectedChildren);
             }
         }
-
-        ///// <summary>
-        ///// Returns a flag which indicate whether the ExpectedChildren is empty.
-        ///// </summary>
-        //internal bool HasExpectedChildren
-        //{
-        //    get
-        //    {
-        //        return this.ExpectedChildren != null && this.ExpectedChildren.Count > 0;
-        //    }
-        //}
 
         internal void Reset(OpenXmlElement startElement)
         {

--- a/DocumentFormat.OpenXml/Validation/Schema/ParticleValidator.cs
+++ b/DocumentFormat.OpenXml/Validation/Schema/ParticleValidator.cs
@@ -14,12 +14,12 @@ namespace DocumentFormat.OpenXml.Validation.Schema
     public static class InstanceCounter
     {
         /// <summary>
-        /// Count of ParticleMatchInfo instance.
+        /// Gets or sets count of ParticleMatchInfo instance.
         /// </summary>
         public static long ParticleMatchInfo { get; set; }
 
         /// <summary>
-        /// Count of ExpectedChildren instance.
+        /// Gets or sets count of ExpectedChildren instance.
         /// </summary>
         public static long ExpectedChildren { get; set; }
     }

--- a/DocumentFormat.OpenXml/Validation/Schema/Restrictions/RedirectedRestriction.cs
+++ b/DocumentFormat.OpenXml/Validation/Schema/Restrictions/RedirectedRestriction.cs
@@ -17,7 +17,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema.Restrictions
         public SimpleTypeRestriction TargetRestriction { get; set; }
 
         /// <summary>
-        /// An ID for this type.
+        /// Gets or sets an ID for this type.
         /// </summary>
         [DataMember]
         public int AttributeId { get; set; }

--- a/DocumentFormat.OpenXml/Validation/Schema/Restrictions/SimpleTypeRestriction.cs
+++ b/DocumentFormat.OpenXml/Validation/Schema/Restrictions/SimpleTypeRestriction.cs
@@ -16,7 +16,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema.Restrictions
     internal abstract class SimpleTypeRestriction
     {
         /// <summary>
-        /// The FileFormat version of this restriction.
+        /// Gets or sets the FileFormat version of this restriction.
         /// </summary>
         internal FileFormatVersions FileFormat { get; set; }
 
@@ -31,12 +31,12 @@ namespace DocumentFormat.OpenXml.Validation.Schema.Restrictions
         public virtual string ClrTypeName => throw new NotImplementedException();
 
         /// <summary>
-        /// Gets if this simple type is an enum
+        /// Gets a value indicating whether this simple type is an enum
         /// </summary>
         public virtual bool IsEnum => false;
 
         /// <summary>
-        /// Gets if this simple type is a list
+        /// Gets a value indicating whether this simple type is a list
         /// </summary>
         public virtual bool IsList => false;
 

--- a/DocumentFormat.OpenXml/Validation/Schema/Restrictions/SimpleValueRestriction.cs
+++ b/DocumentFormat.OpenXml/Validation/Schema/Restrictions/SimpleValueRestriction.cs
@@ -31,25 +31,25 @@ namespace DocumentFormat.OpenXml.Validation.Schema.Restrictions
         public override string ClrTypeName => typeof(T).Name;
 
         /// <summary>
-        /// Gets the minInclusive facets.
+        /// Gets or sets the minInclusive facets.
         /// </summary>
         [DataMember]
         public T MinInclusive { get; set; }
 
         /// <summary>
-        /// Gets the maxInclusive facets.
+        /// Gets or sets the maxInclusive facets.
         /// </summary>
         [DataMember]
         public T MaxInclusive { get; set; }
 
         /// <summary>
-        /// Gets the minExclusive facets.
+        /// Gets or sets the minExclusive facets.
         /// </summary>
         [DataMember]
         public T MinExclusive { get; set; }
 
         /// <summary>
-        /// Gets the maxExclusive facets.
+        /// Gets or sets the maxExclusive facets.
         /// </summary>
         [DataMember]
         public T MaxExclusive { get; set; }

--- a/DocumentFormat.OpenXml/Validation/Schema/Restrictions/UnionValueRestriction.cs
+++ b/DocumentFormat.OpenXml/Validation/Schema/Restrictions/UnionValueRestriction.cs
@@ -9,8 +9,6 @@ namespace DocumentFormat.OpenXml.Validation.Schema.Restrictions
     /// <summary>
     /// Class for all union simple types.
     /// </summary>
-    /// <remarks>
-    /// </remarks>
     [DataContract]
     internal class UnionValueRestriction : SimpleTypeRestriction
     {
@@ -18,7 +16,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema.Restrictions
         public SimpleTypeRestriction[] UnionTypes { get; set; }
 
         /// <summary>
-        /// An ID for union.
+        /// Gets or sets an ID for union.
         /// </summary>
         [DataMember]
         public int UnionId { get; set; }

--- a/DocumentFormat.OpenXml/Validation/Schema/SchemaTypeData.cs
+++ b/DocumentFormat.OpenXml/Validation/Schema/SchemaTypeData.cs
@@ -65,13 +65,9 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         }
 
         /// <summary>
-        /// The type ID of the OpenXmlElement class for this schema type.
+        /// Gets the type ID of the OpenXmlElement class for this schema type.
         /// </summary>
-        internal int OpenXmlTypeId
-        {
-            get;
-            private set;
-        }
+        internal int OpenXmlTypeId { get; private set; }
 
         /// <summary>
         /// Gets or sets the particle constraint of this schema type.
@@ -80,11 +76,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         /// Valid for complex types which are composite types - aka. has children particles.
         /// Otherwise, it should be null.
         /// </remarks>
-        internal ParticleConstraint ParticleConstraint
-        {
-            get;
-            private set;
-        }
+        internal ParticleConstraint ParticleConstraint { get; private set; }
 
         /// <summary>
         /// Gets or sets the simple type constraint when this type is simple content.
@@ -93,11 +85,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         /// The simple type constraint if it is a simple content complex type or a simple type.
         /// null for complex types which are composite types - aka. has children particles.
         /// </remarks>
-        internal SimpleTypeRestriction SimpleTypeConstraint
-        {
-            get;
-            private set;
-        }
+        internal SimpleTypeRestriction SimpleTypeConstraint { get; private set; }
 
         /// <summary>
         /// Gets or sets the constraints for all the attributes of this type.
@@ -107,11 +95,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         /// The attributes value are saved in a fixed array in the OpenXmlElement class.
         /// So the attribute constraint in this array has same order (has a 1:1 map relation to the fixed array in the class).
         /// </remarks>
-        internal IList<AttributeConstraint> AttributeConstraints
-        {
-            get;
-            private set;
-        }
+        internal IList<AttributeConstraint> AttributeConstraints { get; private set; }
 
         internal bool HasAttributeConstraints
         {
@@ -134,25 +118,13 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         }
 
         /// <summary>
-        /// Returns true if the schema type is a schema type which contains particles.
+        /// Gets a value indicating whether the schema type is a schema type which contains particles.
         /// </summary>
-        internal bool IsCompositeType
-        {
-            get
-            {
-                return this.ParticleConstraint != null;
-            }
-        }
+        internal bool IsCompositeType => this.ParticleConstraint != null;
 
         /// <summary>
-        /// Returns true if the schema type contains simple content only.
+        /// Gets a value indicating whether the schema type contains simple content only.
         /// </summary>
-        internal bool IsSimpleContent
-        {
-            get
-            {
-                return this.SimpleTypeConstraint != null;
-            }
-        }
+        internal bool IsSimpleContent => this.SimpleTypeConstraint != null;
     }
  }

--- a/DocumentFormat.OpenXml/Validation/Schema/SdbAttributeConstraint.cs
+++ b/DocumentFormat.OpenXml/Validation/Schema/SdbAttributeConstraint.cs
@@ -17,17 +17,17 @@ namespace DocumentFormat.OpenXml.Validation.Schema
     internal class SdbAttributeConstraint : SdbData
     {
         /// <summary>
-        /// The xsd:use value.
+        /// Gets or sets the xsd:use value.
         /// </summary>
         public XsdAttributeUse AttributeUse { get; set; }
 
         /// <summary>
-        /// The index of the simple data in the SdbSimpleTypeRestriction data array.
+        /// Gets or sets the index of the simple data in the SdbSimpleTypeRestriction data array.
         /// </summary>
         public SdbIndex SimpleTypeIndex { get; set; }
 
         /// <summary>
-        /// In which file format version this attribute is allowed.
+        /// Gets or sets in which file format version this attribute is allowed.
         /// </summary>
         public byte FileFormatVersion { get; set; }
 
@@ -43,7 +43,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         }
 
         /// <summary>
-        /// The size in bytes of this data structure.
+        /// Gets the size in bytes of this data structure.
         /// </summary>
         public static int TypeSize
         {
@@ -57,12 +57,9 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         #region Override SdbData Members
 
         /// <summary>
-        /// The size in bytes of this data structure.
+        /// Gets the size in bytes of this data structure.
         /// </summary>
-        public override int DataSize
-        {
-            get { return TypeSize; }
-        }
+        public override int DataSize => TypeSize;
 
         /// <summary>
         /// Serialize the data into byte data.

--- a/DocumentFormat.OpenXml/Validation/Schema/SdbClassIdToSchemaTypeIndex.cs
+++ b/DocumentFormat.OpenXml/Validation/Schema/SdbClassIdToSchemaTypeIndex.cs
@@ -25,12 +25,12 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         public const SdbIndex InvalidSchemaTypeIndex = SdbIndex.MaxValue;
 
         /// <summary>
-        /// Class ID - Element Type ID.
+        /// Gets or sets class ID (Element Type ID).
         /// </summary>
         public SdbIndex ClassId { get; set; }
 
         /// <summary>
-        /// The index of the schema type in the SdbSchemaType data array.
+        /// Gets or sets the index of the schema type in the SdbSchemaType data array.
         /// </summary>
         public SdbIndex SchemaTypeIndex { get; set; }
 
@@ -64,25 +64,16 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         }
 
         /// <summary>
-        /// The size in bytes of this data structure.
+        /// Gets the size in bytes of this data structure.
         /// </summary>
-        public static int TypeSize
-        {
-            get
-            {
-                return sizeof(SdbIndex) * 2;
-            }
-        }
+        public static int TypeSize => sizeof(SdbIndex) * 2;
 
         #region Override SdbData Members
 
         /// <summary>
-        /// The size in bytes of this data structure.
+        /// Gets the size in bytes of this data structure.
         /// </summary>
-        public override int DataSize
-        {
-            get { return TypeSize; }
-        }
+        public override int DataSize => TypeSize;
 
         /// <summary>
         /// Serialize the data into byte data.

--- a/DocumentFormat.OpenXml/Validation/Schema/SdbData.cs
+++ b/DocumentFormat.OpenXml/Validation/Schema/SdbData.cs
@@ -22,7 +22,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         #region abstract methods
 
         /// <summary>
-        /// The size in bytes of this data structure.
+        /// Gets the size in bytes of this data structure.
         /// </summary>
         public abstract int DataSize { get; }
 

--- a/DocumentFormat.OpenXml/Validation/Schema/SdbDataHead.cs
+++ b/DocumentFormat.OpenXml/Validation/Schema/SdbDataHead.cs
@@ -32,12 +32,12 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         public int DataVersion { get; set; }
 
         /// <summary>
-        /// size in byte of the schema constraint datas, exclude the DataHead.
+        /// Gets or sets size in byte of the schema constraint datas, exclude the DataHead.
         /// </summary>
         public int DataByteCount { get; set; }
 
         /// <summary>
-        /// The first class ID.
+        /// Gets or sets the first class ID.
         /// </summary>
         public int StartClassId { get; set; }
 

--- a/DocumentFormat.OpenXml/Validation/Schema/SdbParticleChildrenIndex.cs
+++ b/DocumentFormat.OpenXml/Validation/Schema/SdbParticleChildrenIndex.cs
@@ -19,7 +19,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema
     internal class SdbParticleChildrenIndex : SdbData
     {
         /// <summary>
-        /// The index of the particle in the SdbParticleConstraint data array.
+        /// Gets or sets the index of the particle in the SdbParticleConstraint data array.
         /// </summary>
         public SdbIndex ParticleIndex { get; set; }
 
@@ -44,22 +44,16 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         }
 
         /// <summary>
-        /// The size in bytes of this data structure.
+        /// Gets the size in bytes of this data structure.
         /// </summary>
-        public static int TypeSize
-        {
-            get { return sizeof(SdbIndex); }
-        }
+        public static int TypeSize => sizeof(SdbIndex);
 
         #region Override SdbData Members
 
         /// <summary>
-        /// The size in bytes of this data structure.
+        /// Gets the size in bytes of this data structure.
         /// </summary>
-        public override int DataSize
-        {
-            get { return TypeSize; }
-        }
+        public override int DataSize => TypeSize;
 
         /// <summary>
         /// Serialize the data into byte data.

--- a/DocumentFormat.OpenXml/Validation/Schema/SdbParticleConstraint.cs
+++ b/DocumentFormat.OpenXml/Validation/Schema/SdbParticleConstraint.cs
@@ -23,39 +23,39 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         public const ushort UnboundedMaxOccurs = 0;
 
         /// <summary>
-        /// The particle type of this particle.
+        /// Gets or sets the particle type of this particle.
         /// </summary>
         public ParticleType ParticleType { get; set; }
 
         /// <summary>
-        /// When this is an element, save the element type ID (class ID).
+        /// Gets or sets the element type ID (class ID).
         /// </summary>
         public SdbIndex ElementTypeId { get; set; }
 
         /// <summary>
-        /// The xsd:minOccurs value of this particle.
+        /// Gets or sets the xsd:minOccurs value of this particle.
         /// Just use ushort at now. throw exceptions if thera are numbers > ushort.MaxValue.
         /// </summary>
         public ushort MinOccurs { get; set; }
 
         /// <summary>
-        /// The xsd:maxOccurs value of this particle.
+        /// Gets or sets the xsd:maxOccurs value of this particle.
         /// ushort is not enough.
         /// </summary>
         public int MaxOccurs { get; set; }
 
         /// <summary>
-        /// Count of children particles.
+        /// Gets or sets count of children particles.
         /// </summary>
         public SdbIndex ChildrenCount { get; set; }
 
         /// <summary>
-        /// The index of the first child particle index in the SdbParticleChildrenIndex data array.
+        /// Gets or sets the index of the first child particle index in the SdbParticleChildrenIndex data array.
         /// </summary>
         public SdbIndex ChildrenStartIndex { get; set; }
 
         /// <summary>
-        /// Returns the namespace ID defiend in "xsd:any" when the particle type is ParticleType.Any or ParticleType.AnyWithUri
+        /// Gets the namespace ID defiend in "xsd:any" when the particle type is ParticleType.Any or ParticleType.AnyWithUri
         /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         public SdbIndex XsdAnyNamespaceId
@@ -71,7 +71,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         }
 
         /// <summary>
-        /// The size in bytes of this data structure.
+        /// Gets the size in bytes of this data structure.
         /// </summary>
         public static int TypeSize
         {
@@ -86,20 +86,10 @@ namespace DocumentFormat.OpenXml.Validation.Schema
             }
         }
 
-        #region Override SdbData Members
+        /// <inheritdoc/>
+        public override int DataSize => TypeSize;
 
-        /// <summary>
-        /// The size in bytes of this data structure.
-        /// </summary>
-        public override int DataSize
-        {
-            get { return TypeSize; }
-        }
-
-        /// <summary>
-        /// Serialize the data into byte data.
-        /// </summary>
-        /// <returns>Byte data.</returns>
+        /// <inheritdoc/>
         public override byte[] GetBytes()
         {
             // !!!!Caution: keep the order of the following code lines!!!!
@@ -111,11 +101,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema
                 this.ChildrenStartIndex.Bytes());
         }
 
-        /// <summary>
-        /// Deserialize the data from byte data.
-        /// </summary>
-        /// <param name="value">The byte data.</param>
-        /// <param name="startIndex">The offset the data begins at.</param>
+        /// <inheritdoc/>
         public override void LoadFromBytes(byte[] value, int startIndex)
         {
             // !!!!Caution: keep the order of the following code lines!!!!
@@ -126,7 +112,5 @@ namespace DocumentFormat.OpenXml.Validation.Schema
             this.ChildrenCount = LoadSdbIndex(value, ref startIndex);
             this.ChildrenStartIndex = LoadSdbIndex(value, ref startIndex);
         }
-
-        #endregion
     }
 }

--- a/DocumentFormat.OpenXml/Validation/Schema/SdbSchemaType.cs
+++ b/DocumentFormat.OpenXml/Validation/Schema/SdbSchemaType.cs
@@ -13,25 +13,25 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         // TODO: the ParticleIndex and SimpleTypeIndex can share one field.
 
         /// <summary>
-        /// The index of the particle in the SdbParticleConstraint data array.
+        /// Gets or sets the index of the particle in the SdbParticleConstraint data array.
         /// Will be "SdbData.InvalidId" if the schema type is NOT composite type.
         /// </summary>
         /// <remarks>This field can be eliminated.</remarks>
         public SdbIndex ParticleIndex { get; set; }
 
         /// <summary>
-        /// The index of the simple data in the SdbSimpleTypeRestriction data array.
+        /// Gets or sets the index of the simple data in the SdbSimpleTypeRestriction data array.
         /// Will be "SdbData.InvalidId" if the schema type is NOT simple content only.
         /// </summary>
         public SdbIndex SimpleTypeIndex { get; set; }
 
         /// <summary>
-        /// The count of attributes.
+        /// Gets or sets the count of attributes.
         /// </summary>
         public SdbIndex AttributesCount { get; set; }
 
         /// <summary>
-        /// The index of the first attribute data in the SdbAttributeConstraint data array.
+        /// Gets or sets the index of the first attribute data in the SdbAttributeConstraint data array.
         /// </summary>
         public SdbIndex StartIndexOfAttributes { get; set; }
 
@@ -58,43 +58,24 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         }
 
         /// <summary>
-        /// Returns true if the schema type is a schema type which contains particles.
+        /// Gets a value indicating whether the schema type is a schema type which contains particles.
         /// </summary>
-        public bool IsCompositeType
-        {
-            get { return this.ParticleIndex != SdbData.InvalidId; }
-        }
+        public bool IsCompositeType => this.ParticleIndex != SdbData.InvalidId;
 
         /// <summary>
-        /// Returns true if the schema type contains simple content only.
+        /// Gets a value indicating whether the schema type contains simple content only.
         /// </summary>
-        public bool IsSimpleContent
-        {
-            get { return this.SimpleTypeIndex != SdbData.InvalidId; }
-        }
+        public bool IsSimpleContent => this.SimpleTypeIndex != SdbData.InvalidId;
 
         /// <summary>
-        /// The size in bytes of this data structure
+        /// Gets the size in bytes of this data structure
         /// </summary>
-        public static int TypeSize
-        {
-            get { return sizeof(SdbIndex) * 4; }
-        }
+        public static int TypeSize => sizeof(SdbIndex) * 4;
 
-        #region Override SdbData Members
+        /// <inheritdoc/>
+        public override int DataSize => TypeSize;
 
-        /// <summary>
-        /// The size in bytes of this data structure
-        /// </summary>
-        public override int DataSize
-        {
-            get { return TypeSize; }
-        }
-
-        /// <summary>
-        /// Serialize the data into byte data.
-        /// </summary>
-        /// <returns>Byte data.</returns>
+        /// <inheritdoc/>
         public override byte[] GetBytes()
         {
             // !!!!Caution: keep the order of the following code lines!!!!
@@ -104,11 +85,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema
                                 this.StartIndexOfAttributes.Bytes());
         }
 
-        /// <summary>
-        /// Deserialize the data from byte data.
-        /// </summary>
-        /// <param name="value">The byte data.</param>
-        /// <param name="startIndex">The offset the data begins at.</param>
+        /// <inheritdoc/>
         public override void LoadFromBytes(byte[] value, int startIndex)
         {
             // !!!!Caution: keep the order of the following code lines!!!!
@@ -117,7 +94,5 @@ namespace DocumentFormat.OpenXml.Validation.Schema
             this.AttributesCount = LoadSdbIndex(value, ref startIndex);
             this.StartIndexOfAttributes = LoadSdbIndex(value, ref startIndex);
         }
-
-        #endregion
     }
 }

--- a/DocumentFormat.OpenXml/Validation/SpreadsheetDocumentValidator.cs
+++ b/DocumentFormat.OpenXml/Validation/SpreadsheetDocumentValidator.cs
@@ -42,9 +42,7 @@ namespace DocumentFormat.OpenXml.Validation
             }
         }
 
-        /// <summary>
-        /// Returns all the parts needs to be validated.
-        /// </summary>
+        /// <inheritdoc/>
         protected override IEnumerable<OpenXmlPart> PartsToBeValidated
         {
             get

--- a/DocumentFormat.OpenXml/Validation/ValidationContext.cs
+++ b/DocumentFormat.OpenXml/Validation/ValidationContext.cs
@@ -28,51 +28,32 @@ namespace DocumentFormat.OpenXml.Validation
         }
 
         /// <summary>
-        /// Target file format.
+        /// Gets or sets target file format.
         /// </summary>
         internal FileFormatVersions FileFormat { get; set; }
 
-        //internal MCMode McMode
-        //{
-        //    get
-        //    {
-        //        switch (this.FileFormat)
-        //        {
-        //            case FileFormat.Office2007:
-        //                return MCMode.Office2007;
-
-        //            case FileFormat.Office2010:
-        //                return MCMode.Office2010;
-
-        //            default:
-        //                Debug.Assert(false);
-        //                return MCMode.Office2007;
-        //        }
-        //    }
-        //}
-
         /// <summary>
-        /// The target OpenXmlPackage.
+        /// Gets or sets the target OpenXmlPackage.
         /// </summary>
         internal OpenXmlPackage Package { get; set; }
 
         /// <summary>
-        /// The target OpenXmlPart
+        /// Gets or sets the target OpenXmlPart
         /// </summary>
         internal OpenXmlPart Part { get; set; }
 
         /// <summary>
-        /// The target element.
+        /// Gets or sets the target element.
         /// </summary>
         internal OpenXmlElement Element { get; set; }
 
         /// <summary>
-        /// Used to track MC context.
+        /// Gets or sets used to track MC context.
         /// </summary>
         internal MCContext McContext { get; set; }
 
         /// <summary>
-        /// Collect ExpectedChildren or not.
+        /// Gets or sets a value indicating whether collect ExpectedChildren or not.
         /// </summary>
         internal bool CollectExpectedChildren { get; set; }
 

--- a/DocumentFormat.OpenXml/Validation/ValidationErrorEventArgs.cs
+++ b/DocumentFormat.OpenXml/Validation/ValidationErrorEventArgs.cs
@@ -16,7 +16,7 @@ namespace DocumentFormat.OpenXml.Validation
         }
 
         /// <summary>
-        /// The validation error.
+        /// Gets or sets the validation error.
         /// </summary>
         internal ValidationErrorInfo ValidationErrorInfo { get; set; }
     }

--- a/DocumentFormat.OpenXml/Validation/ValidationErrorInfo.cs
+++ b/DocumentFormat.OpenXml/Validation/ValidationErrorInfo.cs
@@ -21,36 +21,25 @@ namespace DocumentFormat.OpenXml.Validation
 
 #if DEBUG
         /// <summary>
-        /// The semantic constraint ID in internal tool.
+        /// Gets the semantic constraint ID in internal tool.
         /// </summary>
         /// <remarks>
         /// This is for debug only.
         /// </remarks>
-        public string SemanticConstraintId
-        {
-            get;
-            internal set;
-        }
+        public string SemanticConstraintId { get; internal set; }
 
         /// <summary>
-        /// Returns the XML qualified name for the attribute.
+        /// Gets the XML qualified name for the attribute.
         /// Returns null if the error is not for attribute.
         /// </summary>
-        public string AttributeQualifiedName
-        {
-            get;
-            internal set;
-        }
+        public string AttributeQualifiedName { get; internal set; }
 
         /// <summary>
-        /// Returns schema validation error category.
+        /// Gets schema validation error category.
         /// </summary>
-        public string ValidationErrorCategory
-        {
-            get;
-            internal set;
-        }
+        public string ValidationErrorCategory { get; internal set; }
 #endif
+
         /// <summary>
         /// Sets the two fields (AttributeQualifiedName, ValidationErrorCategory) in debug build only.
         /// </summary>
@@ -68,47 +57,22 @@ namespace DocumentFormat.OpenXml.Validation
         /// <summary>
         /// Gets the unique identifier of this error.
         /// </summary>
-        public string Id
-        {
-            get;
-            internal set;
-        }
+        public string Id { get; internal set; }
 
         /// <summary>
         /// Gets the type of this error.
         /// </summary>
-        public ValidationErrorType ErrorType
-        {
-            get;
-            internal set;
-        }
-
-        ///// <summary>
-        ///// Gets the category of this error.
-        ///// </summary>
-        //public string Category
-        //{
-        //    get;
-        //    internal set;
-        //}
+        public ValidationErrorType ErrorType { get; internal set; }
 
         /// <summary>
         /// Gets the description and the suggestion on how to resolve the errors.
         /// </summary>
-        public string Description
-        {
-            get;
-            internal set;
-        }
+        public string Description { get; internal set; }
 
         /// <summary>
         /// Gets the XmlPath information of this error.
         /// </summary>
-        public XmlPath Path
-        {
-            get;
-            internal set;
-        }
+        public XmlPath Path { get; internal set; }
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private OpenXmlElement _element;
@@ -141,28 +105,16 @@ namespace DocumentFormat.OpenXml.Validation
         /// <summary>
         /// Gets the part which the invalid element is in.
         /// </summary>
-        public OpenXmlPart Part
-        {
-            get;
-            internal set;
-        }
+        public OpenXmlPart Part { get; internal set; }
 
         /// <summary>
         /// Gets elements related with the invalid node.
         /// </summary>
-        public OpenXmlElement RelatedNode
-        {
-            get;
-            internal set;
-        }
+        public OpenXmlElement RelatedNode { get; internal set; }
 
         /// <summary>
         /// Gets parts related with the invalid node.
         /// </summary>
-        public OpenXmlPart RelatedPart
-        {
-            get;
-            internal set;
-        }
+        public OpenXmlPart RelatedPart { get; internal set; }
     }
 }

--- a/DocumentFormat.OpenXml/Validation/ValidationResult.cs
+++ b/DocumentFormat.OpenXml/Validation/ValidationResult.cs
@@ -21,12 +21,12 @@ namespace DocumentFormat.OpenXml.Validation
         }
 
         /// <summary>
-        /// Gets a value indicating whether the validation is canceled.
+        /// Gets or sets a value indicating whether the validation is canceled.
         /// </summary>
         internal bool Canceled { get; set; }
 
         /// <summary>
-        /// Gets a value indicating whether the validation returns ok.
+        /// Gets or sets a value indicating whether the validation returns ok.
         /// </summary>
         internal bool Valid { get; set; }
 

--- a/DocumentFormat.OpenXml/Validation/ValidationSettings.cs
+++ b/DocumentFormat.OpenXml/Validation/ValidationSettings.cs
@@ -32,7 +32,7 @@ namespace DocumentFormat.OpenXml.Validation
         }
 
         /// <summary>
-        /// The target file format.
+        /// Gets or sets the target file format.
         /// </summary>
         internal FileFormatVersions FileFormat { get; set; }
 
@@ -40,10 +40,6 @@ namespace DocumentFormat.OpenXml.Validation
         /// Gets or sets the maximum number of errors the OpenXmlValidator will return.
         /// Default is 1000.  A zero (0) value means no limitation.
         /// </summary>
-        internal int MaxNumberOfErrors
-        {
-            get;
-            set;
-        }
+        internal int MaxNumberOfErrors { get; set; }
    }
 }

--- a/DocumentFormat.OpenXml/Validation/WordprocessingDocumentValidator.cs
+++ b/DocumentFormat.OpenXml/Validation/WordprocessingDocumentValidator.cs
@@ -42,9 +42,7 @@ namespace DocumentFormat.OpenXml.Validation
             }
         }
 
-        /// <summary>
-        /// Returns all the parts needs to be validated.
-        /// </summary>
+        /// <inheritdoc/>
         protected override IEnumerable<OpenXmlPart> PartsToBeValidated
         {
             get

--- a/DocumentFormat.OpenXml/Wordprocessing/CustomXmlElement.cs
+++ b/DocumentFormat.OpenXml/Wordprocessing/CustomXmlElement.cs
@@ -36,10 +36,10 @@ namespace DocumentFormat.OpenXml.Wordprocessing
         }
 
         /// <summary>
-        /// <para>Custom XML Markup Namespace. </para>
-        /// <para>Represents the attribte in schema: w:uri.</para>
+        /// Gets or sets the custom XML Markup Namespace.
         /// </summary>
         /// <remark>
+        /// Represents the attribte in schema: w:uri.
         /// xmlns:w=http://schemas.openxmlformats.org/wordprocessingml/2006/main.
         /// </remark>
         [SchemaAttr(23, "uri")]
@@ -50,10 +50,10 @@ namespace DocumentFormat.OpenXml.Wordprocessing
         }
 
         /// <summary>
-        /// <para>Element name. </para>
-        /// <para>Represents the attribte in schema: w:element.</para>
+        /// Gets or sets the element name.
         /// </summary>
         /// <remark>
+        /// Represents the attribte in schema: w:element.
         /// xmlns:w=http://schemas.openxmlformats.org/wordprocessingml/2006/main.
         /// </remark>
         [SchemaAttr(23, "element")]
@@ -75,8 +75,7 @@ namespace DocumentFormat.OpenXml.Wordprocessing
         }
 
         /// <summary>
-        /// <para>CustomXmlProperties.</para>
-        /// <para>Represents the element tag in schema: w:customXmlPr.</para>
+        /// Gets or sets the CustomXmlProperties which represents the element tag in schema: w:customXmlPr.
         /// </summary>
         /// <remark>
         /// xmlns:w = http://schemas.openxmlformats.org/wordprocessingml/2006/main.

--- a/DocumentFormat.OpenXml/Wordprocessing/SdtElement.cs
+++ b/DocumentFormat.OpenXml/Wordprocessing/SdtElement.cs
@@ -35,7 +35,7 @@ namespace DocumentFormat.OpenXml.Wordprocessing
         }
 
         /// <summary>
-        /// Gets/Sets the SdtProperties.
+        /// Gets or sets the SdtProperties.
         /// </summary>
         public SdtProperties SdtProperties
         {
@@ -51,7 +51,7 @@ namespace DocumentFormat.OpenXml.Wordprocessing
         }
 
         /// <summary>
-        /// Gets/Sets the SdtEndCharProperties.
+        /// Gets or sets the SdtEndCharProperties.
         /// </summary>
         public SdtEndCharProperties SdtEndCharProperties
         {

--- a/DocumentFormat.OpenXml/XmlConvertingReader.cs
+++ b/DocumentFormat.OpenXml/XmlConvertingReader.cs
@@ -34,26 +34,19 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
-        /// Return true if strictTranslation is enabled.
+        /// Gets a value indicating whether strictTranslation is enabled.
         /// </summary>
-        internal bool StrictTranslation
-        {
-            get { return this._strictTranslation; }
-        }
+        internal bool StrictTranslation => this._strictTranslation;
 
 #if FEATURE_CLOSE
-        /// <summary>
-        /// Override the method defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override void Close()
         {
             this.BaseReader.Close();
         }
 #endif
 
-        /// <summary>
-        /// Override the method defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {
 #if FEATURE_CLOSE
@@ -68,121 +61,91 @@ namespace DocumentFormat.OpenXml
 #endif
         }
 
-        /// <summary>
-        /// Override the method defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override bool Read()
         {
             return this.BaseReader.Read();
         }
 
-        /// <summary>
-        /// Override the method defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override string GetAttribute(int index)
         {
             return this.BaseReader.GetAttribute(index);
         }
 
-        /// <summary>
-        /// Override the method defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override string GetAttribute(string name)
         {
             return this.BaseReader.GetAttribute(name);
         }
 
-        /// <summary>
-        /// Override the method defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override string GetAttribute(string localName, string namespaceURI)
         {
             return this.BaseReader.GetAttribute(localName, namespaceURI);
         }
 
-        /// <summary>
-        /// Override the method defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override string LookupNamespace(string prefix)
         {
             return this.BaseReader.LookupNamespace(prefix);
         }
 
-        /// <summary>
-        /// Override the method defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override void MoveToAttribute(int index)
         {
             this.BaseReader.MoveToAttribute(index);
         }
 
-        /// <summary>
-        /// Override the method defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override bool MoveToAttribute(string name)
         {
             return this.BaseReader.MoveToAttribute(name);
         }
 
-        /// <summary>
-        /// Override the method defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override bool MoveToAttribute(string localName, string namespaceURI)
         {
             return this.BaseReader.MoveToAttribute(localName, namespaceURI);
         }
 
-        /// <summary>
-        /// Override the method defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override bool MoveToElement()
         {
             return this.BaseReader.MoveToElement();
         }
 
-        /// <summary>
-        /// Override the method defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override bool MoveToFirstAttribute()
         {
             return this.BaseReader.MoveToFirstAttribute();
         }
 
-        /// <summary>
-        /// Override the method defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override bool MoveToNextAttribute()
         {
             return this.BaseReader.MoveToNextAttribute();
         }
 
-        /// <summary>
-        /// Override the method defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override bool ReadAttributeValue()
         {
             return this.BaseReader.ReadAttributeValue();
         }
 
-        /// <summary>
-        /// Override the method defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override void ResolveEntity()
         {
             this.BaseReader.ResolveEntity();
         }
 
-        /// <summary>
-        /// Override the method defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override int ReadValueChunk(char[] buffer, int index, int count)
         {
             return this.BaseReader.ReadValueChunk(buffer, index, count);
         }
 
-        /// <summary>
-        /// Override the property defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override int AttributeCount
         {
             get
@@ -191,9 +154,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Override the property defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override string BaseURI
         {
             get
@@ -202,9 +163,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Override the property defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override bool CanReadBinaryContent
         {
             get
@@ -213,9 +172,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Override the property defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override bool CanReadValueChunk
         {
             get
@@ -224,9 +181,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Override the property defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override bool CanResolveEntity
         {
             get
@@ -235,9 +190,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Override the property defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override int Depth
         {
             get
@@ -246,9 +199,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Override the property defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override bool EOF
         {
             get
@@ -257,9 +208,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Override the property defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override bool HasValue
         {
             get
@@ -268,9 +217,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Override the property defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override bool IsDefault
         {
             get
@@ -279,9 +226,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Override the property defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override bool IsEmptyElement
         {
             get
@@ -290,9 +235,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Override the property defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override string this[int index]
         {
             get
@@ -301,9 +244,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Override the property defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override string this[string name]
         {
             get
@@ -312,9 +253,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Override the property defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override string this[string name, string namespaceURI]
         {
             get
@@ -323,9 +262,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Override the property defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override string LocalName
         {
             get
@@ -334,9 +271,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Override the property defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override string Name
         {
             get
@@ -345,9 +280,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Override the property defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override string NamespaceURI
         {
             get
@@ -374,9 +307,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Override the property defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override XmlNameTable NameTable
         {
             get
@@ -385,9 +316,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Override the property defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override XmlNodeType NodeType
         {
             get
@@ -396,9 +325,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Override the property defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override string Prefix
         {
             get
@@ -408,9 +335,7 @@ namespace DocumentFormat.OpenXml
         }
 
 #if FEATURE_XML_QUOTECHAR
-        /// <summary>
-        /// Override the property defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override char QuoteChar
         {
             get
@@ -420,9 +345,7 @@ namespace DocumentFormat.OpenXml
         }
 #endif
 
-        /// <summary>
-        /// Override the property defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override ReadState ReadState
         {
             get
@@ -431,9 +354,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Override the property defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override string Value
         {
             get
@@ -464,9 +385,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Override the property defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override string XmlLang
         {
             get
@@ -475,9 +394,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        /// <summary>
-        /// Override the property defined in XmlReader
-        /// </summary>
+        /// <inheritdoc/>
         public override XmlSpace XmlSpace
         {
             get

--- a/rules.ruleset
+++ b/rules.ruleset
@@ -162,7 +162,7 @@
     <Rule Id="SA1620" Action="None" />
     <Rule Id="SA1621" Action="None" />
     <Rule Id="SA1622" Action="None" />
-    <Rule Id="SA1623" Action="None" />
+    <Rule Id="SA1623" Action="Warning" />
     <Rule Id="SA1624" Action="None" />
     <Rule Id="SA1625" Action="None" />
     <Rule Id="SA1626" Action="None" />
@@ -187,7 +187,7 @@
     <Rule Id="SA1645" Action="None" />
     <Rule Id="SA1646" Action="None" />
     <Rule Id="SA1647" Action="None" />
-    <Rule Id="SA1648" Action="None" />
+    <Rule Id="SA1648" Action="Warning" />
     <Rule Id="SA1649" Action="None" />
     <Rule Id="SA1650" Action="None" />
     <Rule Id="SA1651" Action="None" />


### PR DESCRIPTION
This enforces appropriate Gets/Sets nomenclature, and uses `<inheritdoc/>` when used in an overridden property to minimize need of duplicated items. This enables a StyleCop rule to enforce this for future properties.

Fixes #305 