### PR TITLE
tests for #380

### DIFF
--- a/DocumentFormat.OpenXml.Tests/FlatOpcFixture.cs
+++ b/DocumentFormat.OpenXml.Tests/FlatOpcFixture.cs
@@ -24,6 +24,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Packaging;
 using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using DocumentFormat.OpenXml.Wordprocessing;
 using OxTest;
 using Xunit;
 
@@ -123,6 +125,19 @@ namespace DocumentFormat.OpenXml.Tests
             }
         }
 
+        [Fact(Skip = "#380")]
+        public void CanCreateFlatOpcPresentationDocumentsDynamically()
+        {
+            using (MemoryStream stream = new MemoryStream())
+            using (PresentationDocument presentation = PresentationDocument.Create(stream, PresentationDocumentType.Presentation))
+            {
+                PresentationPart presentationPart = presentation.AddPresentationPart();
+                presentationPart.Presentation = new Presentation.Presentation();
+
+                string opc = presentation.ToFlatOpcString();
+            }
+        }
+
         [Fact]
         public void CanCreateFlatOpcSpreadsheetDocuments()
         {
@@ -176,6 +191,19 @@ namespace DocumentFormat.OpenXml.Tests
             }
         }
 
+        [Fact(Skip = "#380")]
+        public void CanCreateFlatOpcSpreadsheetDocumentsDynamically()
+        {
+            using (MemoryStream stream = new MemoryStream())
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook))
+            {
+                WorkbookPart workbookPart = spreadsheet.AddWorkbookPart();
+                workbookPart.Workbook = new Workbook();
+
+                string opc = spreadsheet.ToFlatOpcString();
+            }
+        }
+
         [Fact]
         public void CanCreateFlatOpcWordprocessingDocuments()
         {
@@ -226,6 +254,19 @@ namespace DocumentFormat.OpenXml.Tests
                 using (var package = Package.Open(stream, FileMode.Create, FileAccess.ReadWrite))
                 using (var dest = WordprocessingDocument.FromFlatOpcString(flatOpcString, package))
                     AssertThatPackagesAreEqual(source, dest);
+            }
+        }
+
+        [Fact(Skip = "#380")]
+        public void CanCreateFlatOpcWordprocessingDocumentsDynamically()
+        {
+            using (MemoryStream stream = new MemoryStream())
+            using (WordprocessingDocument document = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document))
+            {
+                MainDocumentPart mainDocumentPart = document.AddMainDocumentPart();
+                mainDocumentPart.Document = new Document();
+
+                string opc = document.ToFlatOpcString();
             }
         }
     }


### PR DESCRIPTION
a few skipped tests for #380 to illustrate the problem and have some coverage when the document is dynamically generated.