### PR TITLE
Add IEnumerable<T> to ListValue

### DIFF
--- a/DocumentFormat.OpenXml/SimpleTypes/OpenXmlSimpleType.cs
+++ b/DocumentFormat.OpenXml/SimpleTypes/OpenXmlSimpleType.cs
@@ -131,17 +131,6 @@ namespace DocumentFormat.OpenXml
             return xmlAttribute.InnerText;
         }
 
-        #region internal methods to be used by validation
-
-        /// <summary>
-        /// When overridden in the derived ListValue class, this method returns items in the list.
-        /// </summary>
-        /// <returns>Returns items in the list.</returns>
-        internal virtual IEnumerable<OpenXmlSimpleType> GetListItems()
-        {
-            throw new NotImplementedException();
-        }
-
         /// <summary>
         /// Test whether the value is allowed in the specified file format version. Only for EnumValue.
         /// </summary>
@@ -154,7 +143,5 @@ namespace DocumentFormat.OpenXml
         {
             throw new NotImplementedException();
         }
-
-        #endregion
     }
 }

--- a/DocumentFormat.OpenXml/Validation/Schema/Restrictions/ListValueRestriction.cs
+++ b/DocumentFormat.OpenXml/Validation/Schema/Restrictions/ListValueRestriction.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace DocumentFormat.OpenXml.Validation.Schema.Restrictions
@@ -26,9 +27,9 @@ namespace DocumentFormat.OpenXml.Validation.Schema.Restrictions
         /// <inheritdoc />
         public override bool ValidateValueType(OpenXmlSimpleType attributeValue)
         {
-            if (attributeValue.HasValue)
+            if (attributeValue.HasValue && attributeValue is IEnumerable<OpenXmlSimpleType> value)
             {
-                foreach (var itemValue in attributeValue.GetListItems())
+                foreach (var itemValue in value)
                 {
                     if (!this.ListItemType.ValidateValueType(itemValue) ||
                         this.ListItemType.Validate(itemValue) != RestrictionField.None)
@@ -41,96 +42,5 @@ namespace DocumentFormat.OpenXml.Validation.Schema.Restrictions
             }
             return false;
         }
-
-        // ************* No length, maxLength, minLength, pattern constraint on list type in current Ecma376.
-
-#if false
-        /// <summary>
-        /// Gets the maxLength facets.
-        /// </summary>
-        public int MaxLength
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets the minLength facets.
-        /// </summary>
-        public int MinLength
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets the length facets.
-        /// </summary>
-        public int Length
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Get the lenght of the attribute value according to the xsd type.
-        /// </summary>
-        /// <param name="attributeValue"></param>
-        /// <returns></returns>
-        /// <remarks>
-        /// A value in a ·value space· is facet-valid with respect to ·length·, determined as follows:
-        /// 2 if the {variety} is ·list·, then the length of the value, as measured in list items, ·must· be equal to {value}
-        /// </remarks>
-        internal int GetValueLength(OpenXmlSimpleType attributeValue)
-        {
-            Debug.Assert(false);
-            return 0;
-        }
-
-        /// <summary>
-        /// Validate whether the "length" constraint is ok.
-        /// </summary>
-        /// <param name="attributeValue"></param>
-        /// <returns>True if the length of the value is same as defined.</returns>
-        /// <remarks>
-        /// A value in a ·value space· is facet-valid with respect to ·length·, determined as follows:
-        /// 2 if the {variety} is ·list·, then the length of the value, as measured in list items, ·must· be equal to {value}
-        /// </remarks>
-        public bool IsLengthValid(OpenXmlSimpleType attributeValue)
-        {
-            Debug.Assert(false);
-            return true;
-        }
-
-        /// <summary>
-        /// Validate whether the "length" constraint is ok.
-        /// </summary>
-        /// <param name="attributeValue"></param>
-        /// <returns>True if the length of the value is same as defined.</returns>
-        /// <remarks>
-        /// A value in a ·value space· is facet-valid with respect to ·length·, determined as follows:
-        /// 2 if the {variety} is ·list·, then the length of the value, as measured in list items, ·must· be equal to {value}
-        /// </remarks>
-        public bool IsMinLengthValid(OpenXmlSimpleType attributeValue)
-        {
-            Debug.Assert(false);
-            return true;
-        }
-
-        /// <summary>
-        /// Validate whether the "length" constraint is ok.
-        /// </summary>
-        /// <param name="attributeValue"></param>
-        /// <returns>True if the length of the value is same as defined.</returns>
-        /// <remarks>
-        /// A value in a ·value space· is facet-valid with respect to ·length·, determined as follows:
-        /// 2 if the {variety} is ·list·, then the length of the value, as measured in list items, ·must· be equal to {value}
-        /// </remarks>
-        public bool IsMaxLengthValid(OpenXmlSimpleType attributeValue)
-        {
-            Debug.Assert(false);
-            return true;
-        }
-#endif
     }
 }


### PR DESCRIPTION
`OpenXmlSimpleType` only has a single implementation that needs list access, so this switches it to use an interface implementation rather than an abstract method.