### PR TITLE
Simplify enum parsing utilities

### DIFF
--- a/src/DocumentFormat.OpenXml/SimpleTypes/EnumStringAttribute.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/EnumStringAttribute.cs
@@ -8,8 +8,8 @@ namespace DocumentFormat.OpenXml
     /// <summary>
     /// Represents the custom attribute for fields in a generated enum.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field, Inherited=false, AllowMultiple=false)]
-    public sealed class EnumStringAttribute : System.Attribute
+    [AttributeUsage(AttributeTargets.Field, Inherited = false, AllowMultiple = false)]
+    public sealed class EnumStringAttribute : Attribute
     {
         /// <summary>
         /// Initializes a new instance of the EnumStringAttribute class using
@@ -18,16 +18,12 @@ namespace DocumentFormat.OpenXml
         /// <param name="value">The text string.</param>
         public EnumStringAttribute(string value)
         {
-            this.Value = value;
+            Value = value;
         }
 
         /// <summary>
         /// Gets the text string in the custom attribute.
         /// </summary>
-        public string Value
-        {
-            get;
-            private set;
-        }
+        public string Value { get; }
     }
 }

--- a/src/DocumentFormat.OpenXml/SimpleTypes/EnumStringLookup.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/EnumStringLookup.cs
@@ -1,0 +1,157 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace DocumentFormat.OpenXml
+{
+    /// <summary>
+    /// A utility to parse the <see cref="EnumStringAttribute"/> and <see cref="OfficeAvailabilityAttribute"/>
+    /// attributes on schema related enums. Performance profiling shows that iterating through each of the types
+    /// every time this is needed is very detrimental for performance. This creates an instance of a lookup table
+    /// and caches it on the initial call
+    /// </summary>
+    /// <typeparam name="TEnum">The type of the enum</typeparam>
+    /// <remarks>
+    /// Calls will throw <see cref="ArgumentOutOfRangeException"/> when <typeparamref name="TEnum"/> has the following
+    /// characteristics:
+    ///   - Does not have <see cref="int"/> as an underlying type
+    ///   - Has custom values that are not in the range of [0, {EnumSize}]
+    ///   - Does not have an <see cref="EnumStringAttribute"/> for each member
+    ///   - Has no members
+    /// </remarks>
+    internal static class EnumStringLookup<TEnum>
+        where TEnum : struct
+    {
+        private static EnumStringLookupImpl Instance { get; } = new EnumStringLookupImpl();
+
+        public static bool TryParse(string name, out TEnum value) => Instance.TryParse(name, out value);
+
+        public static string ToString(TEnum value) => Instance.ToString(value);
+
+        public static FileFormatVersions GetVersion(TEnum value) => Instance.GetVersion(value);
+
+        public static bool IsDefined(TEnum value) => Instance.IsDefined(value);
+
+        private sealed class EnumStringLookupImpl
+        {
+            private readonly Dictionary<string, TEnum> _nameLookup;
+            private readonly EnumStringInfo[] _enumInfo;
+
+            public bool TryParse(string name, out TEnum value)
+            {
+                if (_nameLookup == null)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(TEnum));
+                }
+
+                if (name == null)
+                {
+                    value = default;
+                    return false;
+                }
+
+                return _nameLookup.TryGetValue(name, out value);
+            }
+
+            public string ToString(TEnum value) => Lookup(value).Name;
+
+            public FileFormatVersions GetVersion(TEnum value) => Lookup(value).Versions;
+
+            /// <summary>
+            /// Custom implementation of IsDefined to minimize performance impact on many calls
+            /// </summary>
+            public bool IsDefined(TEnum value) => IsDefined(value, out _);
+
+            private bool IsDefined(TEnum value, out int index)
+            {
+                if (_enumInfo == null)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(TEnum));
+                }
+
+                index = Convert.ToInt32(value);
+
+                return index >= 0 && index < _enumInfo.Length;
+            }
+
+            private EnumStringInfo Lookup(TEnum value)
+            {
+                if (!IsDefined(value, out var index))
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                return _enumInfo[index];
+            }
+
+            public EnumStringLookupImpl()
+            {
+                var enumType = typeof(TEnum).GetTypeInfo();
+
+                if (!enumType.IsEnum)
+                {
+                    return;
+                }
+
+                if (Enum.GetUnderlyingType(typeof(TEnum)) != typeof(int))
+                {
+                    return;
+                }
+
+                var values = Enum.GetValues(typeof(TEnum));
+
+                if (values.Length == 0)
+                {
+                    return;
+                }
+
+                var nameLookup = new Dictionary<string, TEnum>(values.Length, StringComparer.Ordinal);
+                var enumInfo = new EnumStringInfo[values.Length];
+
+                foreach (var enumVal in values)
+                {
+                    var field = enumType.GetDeclaredField(enumVal.ToString());
+                    var enumString = field.GetCustomAttribute<EnumStringAttribute>();
+                    var officeAvailability = field.GetCustomAttribute<OfficeAvailabilityAttribute>();
+
+                    if (enumString == null)
+                    {
+                        return;
+                    }
+
+                    nameLookup.Add(enumString.Value, (TEnum)enumVal);
+
+                    var versions = officeAvailability?.OfficeVersion ?? FileFormatVersions.Office2007.AndLater();
+
+                    var index = Convert.ToInt32(enumVal);
+
+                    if (index < 0 || index >= enumInfo.Length)
+                    {
+                        return;
+                    }
+
+                    enumInfo[index] = new EnumStringInfo(versions, enumString.Value);
+                }
+
+                _nameLookup = nameLookup;
+                _enumInfo = enumInfo;
+            }
+        }
+
+        private struct EnumStringInfo
+        {
+            public EnumStringInfo(FileFormatVersions versions, string name)
+            {
+                Versions = versions;
+                Name = name;
+            }
+
+            public FileFormatVersions Versions { get; }
+
+            public string Name { get; }
+        }
+    }
+}

--- a/src/DocumentFormat.OpenXml/SimpleTypes/OpenXmlSimpleValue.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/OpenXmlSimpleValue.cs
@@ -46,6 +46,10 @@ namespace DocumentFormat.OpenXml
 
         private protected virtual bool ShouldParse(string value) => !string.IsNullOrEmpty(value);
 
+        private protected virtual void ValidateSet(T value)
+        {
+        }
+
         /// <inheritdoc/>
         public override bool HasValue
         {
@@ -101,6 +105,8 @@ namespace DocumentFormat.OpenXml
 
             set
             {
+                ValidateSet(value);
+
                 this.InnerValue = value;
                 this.TextValue = null;
             }

--- a/test/DocumentFormat.OpenXml.Tests/SimpleTypes/EnumStringLookupTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/SimpleTypes/EnumStringLookupTests.cs
@@ -1,0 +1,154 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace DocumentFormat.OpenXml.Packaging.Tests
+{
+    public class EnumStringLookupTests
+    {
+        private enum EmptyEnum { }
+
+        [Fact]
+        public void EmptyEnumTest() => ArgumentOutOfRangeTest(default(EmptyEnum));
+
+        private enum SingleItemWithName
+        {
+            [EnumString("name")]
+            Item
+        }
+
+        [Fact]
+        public void SingleItemWithNameTest()
+        {
+            const string Name = "name";
+
+            Assert.True(EnumStringLookup<SingleItemWithName>.TryParse(Name, out var item));
+            Assert.Equal(SingleItemWithName.Item, item);
+
+            Assert.Equal(Name, EnumStringLookup<SingleItemWithName>.ToString(SingleItemWithName.Item));
+            Assert.Equal(FileFormatVersions.Office2007.AndLater(), EnumStringLookup<SingleItemWithName>.GetVersion(SingleItemWithName.Item));
+        }
+
+        [Fact]
+        public void TryParseNullNameSetsValueDefault()
+        {
+            Assert.False(EnumStringLookup<SingleItemWithName>.TryParse(null, out var value));
+            Assert.Equal(default, value);
+        }
+
+        private enum SingleItemWithoutName
+        {
+            Item
+        }
+
+        [Fact]
+        public void SingleItemWithoutNameTest() => ArgumentOutOfRangeTest(SingleItemWithoutName.Item);
+
+        public enum MultipleItemsWithNamesAndVersion
+        {
+            [EnumString("name1")]
+            Item1 = 0,
+            [EnumString("name2")]
+            Item2 = 1,
+            [EnumString("name3")]
+            [OfficeAvailability(FileFormatVersions.Office2010)]
+            Item3 = 3,
+            [EnumString("name4")]
+            Item4 = 2,
+            [EnumString("NAME4")]
+            Item5 = 4
+        }
+
+        public static IEnumerable<object[]> GetMultipleItemsWithNamesAndVersionsTestData()
+        {
+            yield return new object[] { MultipleItemsWithNamesAndVersion.Item1, "name1", FileFormatVersions.Office2007.AndLater() };
+            yield return new object[] { MultipleItemsWithNamesAndVersion.Item2, "name2", FileFormatVersions.Office2007.AndLater() };
+            yield return new object[] { MultipleItemsWithNamesAndVersion.Item3, "name3", FileFormatVersions.Office2010 };
+            yield return new object[] { MultipleItemsWithNamesAndVersion.Item4, "name4", FileFormatVersions.Office2007.AndLater() };
+            yield return new object[] { MultipleItemsWithNamesAndVersion.Item5, "NAME4", FileFormatVersions.Office2007.AndLater() };
+        }
+
+        [MemberData(nameof(GetMultipleItemsWithNamesAndVersionsTestData))]
+        [Theory]
+        public void MultipleItemsWithNamesAndVersionsTests(MultipleItemsWithNamesAndVersion value, string name, FileFormatVersions version)
+        {
+            Assert.True(EnumStringLookup<MultipleItemsWithNamesAndVersion>.TryParse(name, out var result));
+            Assert.Equal(value, result);
+            Assert.Equal(name, EnumStringLookup<MultipleItemsWithNamesAndVersion>.ToString(value));
+            Assert.Equal(version, EnumStringLookup<MultipleItemsWithNamesAndVersion>.GetVersion(value));
+        }
+
+        private enum ValueHigherThanItems
+        {
+            [EnumString("a")]
+            Item1 = 0,
+            [EnumString("b")]
+            Item2 = 2
+        }
+
+        [Fact]
+        public void ValueHigherThanItemsTest() => ArgumentOutOfRangeTest(ValueHigherThanItems.Item1);
+
+        private enum ValueLessThan0
+        {
+            [EnumString("a")]
+            Item = -1
+        }
+
+        [Fact]
+        public void ValueLessThan0Test() => ArgumentOutOfRangeTest(ValueLessThan0.Item);
+
+        private enum NonInt32 : byte
+        {
+            Item
+        }
+
+        [Fact]
+        public void NonInt32Test() => ArgumentOutOfRangeTest(NonInt32.Item);
+
+        [Fact]
+        public void NonEnumTest() => ArgumentOutOfRangeTest(1);
+
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [Theory]
+        public void IsDefinedTests(int entry)
+        {
+            var enumEntry = (SingleItemWithName)entry;
+
+            Assert.Equal(Enum.IsDefined(typeof(SingleItemWithName), enumEntry), EnumStringLookup<SingleItemWithName>.IsDefined(enumEntry));
+        }
+
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [Theory]
+        public void OutOfRange(int entry)
+        {
+            var enumEntry = (SingleItemWithName)entry;
+
+            if (Enum.IsDefined(typeof(SingleItemWithName), enumEntry))
+            {
+                Assert.NotNull(EnumStringLookup<SingleItemWithName>.ToString(enumEntry));
+            }
+            else
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("value", () => EnumStringLookup<SingleItemWithName>.ToString(enumEntry));
+            }
+        }
+
+        private void ArgumentOutOfRangeTest<TEnum>(TEnum item)
+            where TEnum : struct
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(nameof(TEnum), () => EnumStringLookup<TEnum>.ToString(item));
+            Assert.Throws<ArgumentOutOfRangeException>(nameof(TEnum), () => EnumStringLookup<TEnum>.TryParse("a", out _));
+            Assert.Throws<ArgumentOutOfRangeException>(nameof(TEnum), () => EnumStringLookup<TEnum>.GetVersion(item));
+        }
+    }
+}

--- a/test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlSimpleValueTest2.cs
+++ b/test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlSimpleValueTest2.cs
@@ -62,6 +62,18 @@ namespace DocumentFormat.OpenXml.Tests
             Assert.Equal("0", target.ToString());
         }
 
+        [Fact]
+        public void EnumValueOutOfRangeTest()
+        {
+            var value = (M.BooleanValues)10;
+            Assert.False(Enum.IsDefined(typeof(M.BooleanValues), value));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => new EnumValue<M.BooleanValues>(value));
+
+            var onOffEnum = new EnumValue<M.BooleanValues>();
+            Assert.Throws<ArgumentOutOfRangeException>(() => onOffEnum.Value = value);
+        }
+
         /// <summary>
         ///A test for EnumValue
         ///</summary>


### PR DESCRIPTION
The current parsing logic has a caching mechanism that duplicates a lot of code and allocates a number of unneeded objects. This cleans up the parsing mechanism to cache at the onset with minimal allocations. By moving to its own type (EnumStringLookup), the EnumValue itself can more easily inherit from OpenXmlValueType and get a lot of the error checking for free.