### PR TITLE
Extract validator from OpenXmlContainer

### DIFF
--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
@@ -537,50 +537,45 @@ namespace DocumentFormat.OpenXml.Packaging
         [Obsolete(ObsoleteAttributeMessages.ObsoleteV1ValidationFunctionality, false)]
         public void Validate(OpenXmlPackageValidationSettings validationSettings)
         {
-            this.ThrowIfObjectDisposed();
+            ThrowIfObjectDisposed();
 
-            OpenXmlPackageValidationSettings actualValidationSettings;
+            void DefaultValidationEventHandler(Object sender, OpenXmlPackageValidationEventArgs e)
+            {
+                var exception = new OpenXmlPackageException(ExceptionMessages.ValidationException);
 
-            if (validationSettings != null && validationSettings.GetEventHandler() != null)
-            {
-                actualValidationSettings = validationSettings;
-            }
-            else
-            {
-                // use default DefaultValidationEventHandler( ) which throw an exception
-                actualValidationSettings = new OpenXmlPackageValidationSettings();
-                actualValidationSettings.EventHandler += new EventHandler<OpenXmlPackageValidationEventArgs>(DefaultValidationEventHandler);
+                exception.Data.Add("OpenXmlPackageValidationEventArgs", e);
+
+                throw exception;
             }
 
-            // TODO: what's expected behavior?
-            actualValidationSettings.FileFormat = FileFormatVersions.Office2007;
+            OpenXmlPackageValidationSettings ValidateSettings(OpenXmlPackageValidationSettings settings)
+            {
+                if (settings.GetEventHandler() == null)
+                {
+                    // use default DefaultValidationEventHandler( ) which throw an exception
+                    settings.EventHandler += DefaultValidationEventHandler;
+                }
 
-            // for cycle defense
-            Dictionary<OpenXmlPart, bool> processedParts = new Dictionary<OpenXmlPart, bool>();
+                if (!settings.FileFormat.Any())
+                {
+                    settings.FileFormat = FileFormatVersions.Office2007;
+                }
 
-            ValidateInternal(actualValidationSettings, processedParts);
+                return settings;
+            }
+
+            new Validation.PackageValidator(this).Validate(ValidateSettings(validationSettings ?? new OpenXmlPackageValidationSettings()));
         }
 
-#pragma warning disable 0618 // CS0618: A class member was marked with the Obsolete attribute, such that a warning will be issued when the class member is referenced.
-
-        /// <summary>
-        /// Validates the package. This method does not validate the XML content in each part.
-        /// </summary>
-        /// <param name="validationSettings">The OpenXmlPackageValidationSettings for validation events.</param>
-        /// <param name="fileFormatVersion">The target file format version.</param>
-        /// <remarks>If validationSettings is null or no EventHandler is set, the default behavior is to throw an OpenXmlPackageException on the validation error. </remarks>
-        internal void Validate(OpenXmlPackageValidationSettings validationSettings, FileFormatVersions fileFormatVersion)
+        [Obsolete(ObsoleteAttributeMessages.ObsoleteV1ValidationFunctionality, false)]
+        internal void Validate(OpenXmlPackageValidationSettings validationSettings, FileFormatVersions fileFormatVersions)
         {
-            this.ThrowIfObjectDisposed();
             Debug.Assert(validationSettings != null);
-            Debug.Assert(fileFormatVersion.Any());
+            Debug.Assert(fileFormatVersions.Any());
 
-            validationSettings.FileFormat = fileFormatVersion;
+            validationSettings.FileFormat = fileFormatVersions;
 
-            // for cycle defense
-            Dictionary<OpenXmlPart, bool> processedParts = new Dictionary<OpenXmlPart, bool>();
-
-            ValidateInternal(validationSettings, processedParts);
+            Validate(validationSettings);
         }
 
         #endregion
@@ -1043,9 +1038,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 throw new ArgumentNullException(nameof(contentType));
             }
 
-            PartConstraintRule partConstraintRule;
-
-            if (GetPartConstraint().TryGetValue(relationshipType, out partConstraintRule))
+            if (GetPartConstraint().TryGetValue(relationshipType, out var partConstraintRule))
             {
                 if (!partConstraintRule.MaxOccursGreatThanOne)
                 {
@@ -1124,16 +1117,6 @@ namespace DocumentFormat.OpenXml.Packaging
         internal PackagePart CreateMetroPart(Uri partUri, string contentType)
         {
             return this.Package.CreatePart(partUri, contentType, this.CompressionOption);
-        }
-
-        // default package validation event handler
-        private static void DefaultValidationEventHandler(Object sender, OpenXmlPackageValidationEventArgs e)
-        {
-            OpenXmlPackageException exception = new OpenXmlPackageException(ExceptionMessages.ValidationException);
-
-            exception.Data.Add("OpenXmlPackageValidationEventArgs", e);
-
-            throw exception;
         }
 
         #endregion

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackageValidationEventArgs.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackageValidationEventArgs.cs
@@ -13,17 +13,22 @@ namespace DocumentFormat.OpenXml.Packaging
     public sealed class OpenXmlPackageValidationEventArgs : EventArgs
     {
         private string _message;
-        private string _partClassName;
 
         [NonSerialized]
-        private OpenXmlPart _childPart;
+        private object _sender;
 
         [NonSerialized]
-        private OpenXmlPart _parentPart;
+        private OpenXmlPart _subPart;
 
-        internal OpenXmlPackageValidationEventArgs()
+        [NonSerialized]
+        private OpenXmlPart _part;
+
+        internal OpenXmlPackageValidationEventArgs(object sender)
         {
+            _sender = sender;
         }
+
+        internal object Sender => _sender;
 
         /// <summary>
         /// Gets or sets the message string of the event.
@@ -32,38 +37,34 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             get
             {
-                if (this._message == null && this.MessageId != null)
+                if (_message == null && MessageId != null)
                 {
-                    return ExceptionMessages.ResourceManager.GetString(this.MessageId);
+                    return ExceptionMessages.ResourceManager.GetString(MessageId);
                 }
                 else
                 {
-                    return this._message;
+                    return _message;
                 }
             }
 
             set
             {
-                this._message = value;
+                _message = value;
             }
         }
 
         /// <summary>
         /// Gets the class name of the part.
         /// </summary>
-        public string PartClassName
-        {
-            get { return _partClassName; }
-            internal set { _partClassName = value; }
-        }
+        public string PartClassName { get; internal set; }
 
         /// <summary>
         /// Gets the part that caused the event.
         /// </summary>
         public OpenXmlPart SubPart
         {
-            get { return _childPart; }
-            internal set { _childPart = value; }
+            get { return _subPart; }
+            internal set { _subPart = value; }
         }
 
         /// <summary>
@@ -71,8 +72,8 @@ namespace DocumentFormat.OpenXml.Packaging
         /// </summary>
         public OpenXmlPart Part
         {
-            get { return _parentPart; }
-            internal set { _parentPart = value; }
+            get { return _part; }
+            internal set { _part = value; }
         }
 
         internal string MessageId { get; set; }

--- a/src/DocumentFormat.OpenXml/Validation/PackageValidator.cs
+++ b/src/DocumentFormat.OpenXml/Validation/PackageValidator.cs
@@ -1,0 +1,229 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Packaging;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+#pragma warning disable 0618 // CS0618: A class member was marked with the Obsolete attribute, such that a warning will be issued when the class member is referenced.
+
+namespace DocumentFormat.OpenXml.Validation
+{
+    /// <summary>
+    /// Defines the base class for OpenXmlPackage and OpenXmlPart.
+    /// </summary>
+    internal struct PackageValidator
+    {
+        private readonly OpenXmlPackage _package;
+
+        public PackageValidator(OpenXmlPackage package)
+        {
+            _package = package;
+        }
+
+        /// <summary>
+        /// Validates the package. This method does not validate the XML content in each part.
+        /// </summary>
+        /// <param name="validationSettings">The OpenXmlPackageValidationSettings for validation events.</param>
+        public void Validate(OpenXmlPackageValidationSettings validationSettings)
+        {
+            if (validationSettings == null)
+            {
+                throw new ArgumentNullException(nameof(validationSettings));
+            }
+
+            if (validationSettings.GetEventHandler() == null)
+            {
+                throw new ArgumentNullException(nameof(validationSettings.EventHandler));
+            }
+
+            if (!validationSettings.FileFormat.Any())
+            {
+                throw new ArgumentOutOfRangeException(nameof(validationSettings.FileFormat));
+            }
+
+            var handler = validationSettings.GetEventHandler();
+
+            foreach (var result in Validate(validationSettings.FileFormat))
+            {
+                handler(result.Sender, result);
+            }
+        }
+
+        /// <summary>
+        /// Validate against a given version
+        /// </summary>
+        /// <param name="version">Version to validate against</param>
+        /// <returns>The validation errors</returns>
+        public IEnumerable<OpenXmlPackageValidationEventArgs> Validate(FileFormatVersions version)
+        {
+            // for cycle defense
+            var processedParts = new Dictionary<OpenXmlPart, bool>();
+
+            return ValidateInternal(_package, version, processedParts);
+        }
+
+        /// <summary>
+        /// Validates the package (do not validate the xml content in each part).
+        /// </summary>
+        /// <param name="container">The Open XML container to validate</param>
+        /// <param name="version">Version to validate against</param>
+        /// <param name="processedParts">Parts already processed.</param>
+        private IEnumerable<OpenXmlPackageValidationEventArgs> ValidateInternal(OpenXmlPartContainer container, FileFormatVersions version, Dictionary<OpenXmlPart, bool> processedParts)
+        {
+            foreach (var result in ValidateDataPartReferenceRelationships(container, version))
+            {
+                yield return result;
+            }
+
+            // count all parts of same type
+            var partOccurs = new Dictionary<string, int>(StringComparer.Ordinal);
+
+            foreach (var part in container.ChildrenParts.Values)
+            {
+                if (partOccurs.TryGetValue(part.RelationshipType, out int occurs))
+                {
+                    partOccurs[part.RelationshipType] = occurs + 1;
+                }
+                else
+                {
+                    partOccurs.Add(part.RelationshipType, 1);
+                }
+
+                if (!(container is ExtendedPart) &&
+                    !container.GetPartConstraint().Keys.Contains(part.RelationshipType) &&
+                    part.IsInVersion(version))
+                {
+                    yield return new OpenXmlPackageValidationEventArgs(container)
+                    {
+                        MessageId = "PartIsNotAllowed",
+                        PartClassName = part.RelationshipType,
+                        Part = container.ThisOpenXmlPart,
+                        SubPart = part
+                    };
+                }
+
+                // if the part is not defined in this version, then should not report error, just treat it as ExtendedPart.
+            }
+
+            foreach (var constraintRulePair in container.GetPartConstraint())
+            {
+                var relatinshipType = constraintRulePair.Key;
+                var constraintRule = constraintRulePair.Value;
+
+                // validate the required parts
+                if (constraintRule.MinOccursIsNonZero
+                    // only check rules apply to the specified version.
+                    && constraintRule.FileFormat.Includes(version))
+                {
+                    // must have one
+                    if (null == container.GetSubPart(relatinshipType))
+                    {
+                        yield return new OpenXmlPackageValidationEventArgs(container)
+                        {
+                            MessageId = "RequiredPartDoNotExist",
+                            PartClassName = constraintRule.PartClassName,
+                            Part = container.ThisOpenXmlPart
+                        };
+                    }
+                }
+
+                // check for parts MaxOccursGreatThanOne=false, but do have multiple instance
+                if (!constraintRule.MaxOccursGreatThanOne
+                    // only check rules apply to the specified version.
+                    && constraintRule.FileFormat.Includes(version))
+                {
+                    if (partOccurs.TryGetValue(relatinshipType, out int occurs))
+                    {
+                        if (occurs > 1)
+                        {
+                            yield return new OpenXmlPackageValidationEventArgs(container)
+                            {
+                                MessageId = "OnlyOnePartAllowed",
+                                PartClassName = constraintRule.PartClassName,
+                                Part = container.ThisOpenXmlPart,
+#if DEBUG
+                                SubPart = container.GetSubPart(relatinshipType)
+#endif
+                            };
+                        }
+                    }
+                }
+            }
+
+            foreach (var part in container.ChildrenParts.Values)
+            {
+                if (!processedParts.ContainsKey(part))
+                {
+                    if (!(part is ExtendedPart))
+                    {
+                        if (container.GetPartConstraint().TryGetValue(part.RelationshipType, out var rule))
+                        {
+                            if (rule.FileFormat.Includes(version))
+                            {
+                                // validate content type
+                                if (rule.PartContentType != null && part.ContentType != rule.PartContentType)
+                                {
+                                    var message = String.Format(CultureInfo.CurrentUICulture, ExceptionMessages.InvalidContentTypePart, rule.PartContentType);
+                                    yield return new OpenXmlPackageValidationEventArgs(container)
+                                    {
+                                        Message = message,
+                                        MessageId = "InvalidContentTypePart",
+                                        SubPart = part,
+                                        Part = container.ThisOpenXmlPart
+                                    };
+                                }
+                            }
+                            else
+                            {
+                                // if the part is not defined in this version, then should not report error, just treat it as ExtendedPart.
+                            }
+                        }
+                    }
+#if DEBUG
+                    else
+                    {
+                        // check the relationship type
+                        if (part.RelationshipType.StartsWith(@"http://schemas.openxmlformats.org", StringComparison.OrdinalIgnoreCase))
+                        {
+                            yield return new OpenXmlPackageValidationEventArgs(container)
+                            {
+                                MessageId = "ExtendedPartIsOpenXmlPart",
+                                SubPart = part,
+                                Part = container.ThisOpenXmlPart
+                            };
+                        }
+                    }
+#endif
+                    processedParts.Add(part, true);
+
+                    foreach (var result in ValidateInternal(part, version, processedParts))
+                    {
+                        yield return result;
+                    }
+                }
+            }
+        }
+
+        private IEnumerable<OpenXmlPackageValidationEventArgs> ValidateDataPartReferenceRelationships(OpenXmlPartContainer container, FileFormatVersions version)
+        {
+            // At current, only media / audio / video reference. There are all [0, unbounded].
+            // So just check whether the reference is allowed.
+            foreach (var dataPartReference in container.DataPartReferenceRelationships)
+            {
+                if (!container.GetDataPartReferenceConstraint().TryGetValue(dataPartReference.RelationshipType, out var constraintRule))
+                {
+                    yield return new OpenXmlPackageValidationEventArgs(container)
+                    {
+                        MessageId = "DataPartReferenceIsNotAllowed",
+                        PartClassName = dataPartReference.RelationshipType,
+                        Part = container.ThisOpenXmlPart,
+                        SubPart = null,
+                        DataPartReferenceRelationship = dataPartReference
+                    };
+                }
+            }
+        }
+    }
+}

--- a/src/DocumentFormat.OpenXml/Validation/ValidationErrorInfo.cs
+++ b/src/DocumentFormat.OpenXml/Validation/ValidationErrorInfo.cs
@@ -12,13 +12,6 @@ namespace DocumentFormat.OpenXml.Validation
     [DebuggerDisplay("Description={Description}")]
     public class ValidationErrorInfo
     {
-        /// <summary>
-        /// Initializes a new instance of the ValidationErrorInfo.
-        /// </summary>
-        public ValidationErrorInfo()
-        {
-        }
-
 #if DEBUG
         /// <summary>
         /// Gets the XML qualified name for the attribute.


### PR DESCRIPTION
The current validation logic uses obsolete APIs. This is the first step to update to the newer validation system by extracting the validation information from OpenXmlContainer 