### PR TITLE
Organize fields in OpenXmlBasePart

### DIFF
--- a/src/DocumentFormat.OpenXml/GeneratedCode/PartParitalDef.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/PartParitalDef.g.cs
@@ -9,7 +9,7 @@ public partial class ThemePart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -61,7 +61,7 @@ public partial class ThemeOverridePart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -113,7 +113,7 @@ public partial class TableStylesPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -165,7 +165,7 @@ public partial class ChartPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -217,7 +217,7 @@ public partial class ChartDrawingPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -269,7 +269,7 @@ public partial class DiagramColorsPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -321,7 +321,7 @@ public partial class DiagramDataPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -373,7 +373,7 @@ public partial class DiagramLayoutDefinitionPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -425,7 +425,7 @@ public partial class DiagramStylePart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -477,7 +477,7 @@ public partial class DrawingsPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -529,7 +529,7 @@ public partial class CustomXmlPropertiesPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -581,7 +581,7 @@ public partial class CustomFilePropertiesPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -633,7 +633,7 @@ public partial class ExtendedFilePropertiesPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -685,7 +685,7 @@ public partial class CalculationChainPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -737,7 +737,7 @@ public partial class WorksheetCommentsPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -789,7 +789,7 @@ public partial class CustomXmlMappingsPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -841,7 +841,7 @@ public partial class ConnectionsPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -893,7 +893,7 @@ public partial class PivotTableCacheDefinitionPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -945,7 +945,7 @@ public partial class PivotTableCacheRecordsPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -997,7 +997,7 @@ public partial class PivotTablePart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -1049,7 +1049,7 @@ public partial class QueryTablePart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -1101,7 +1101,7 @@ public partial class SharedStringTablePart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -1153,7 +1153,7 @@ public partial class WorkbookRevisionHeaderPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -1205,7 +1205,7 @@ public partial class WorkbookRevisionLogPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -1257,7 +1257,7 @@ public partial class WorkbookUserDataPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -1309,7 +1309,7 @@ public partial class WorksheetPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -1361,7 +1361,7 @@ public partial class ChartsheetPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -1413,7 +1413,7 @@ public partial class DialogsheetPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -1465,7 +1465,7 @@ public partial class CellMetadataPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -1517,7 +1517,7 @@ public partial class SingleCellTablePart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -1569,7 +1569,7 @@ public partial class WorkbookStylesPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -1621,7 +1621,7 @@ public partial class ExternalWorkbookPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -1673,7 +1673,7 @@ public partial class TableDefinitionPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -1725,7 +1725,7 @@ public partial class VolatileDependenciesPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -1777,7 +1777,7 @@ public partial class WorkbookPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -1829,7 +1829,7 @@ public partial class WordprocessingCommentsPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -1881,7 +1881,7 @@ public partial class FootnotesPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -1933,7 +1933,7 @@ public partial class EndnotesPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -1985,7 +1985,7 @@ public partial class HeaderPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -2037,7 +2037,7 @@ public partial class FooterPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -2089,7 +2089,7 @@ public partial class DocumentSettingsPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -2141,7 +2141,7 @@ public partial class WebSettingsPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -2193,7 +2193,7 @@ public partial class FontTablePart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -2245,7 +2245,7 @@ public partial class NumberingDefinitionsPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -2297,7 +2297,7 @@ public partial class MainDocumentPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -2349,7 +2349,7 @@ public partial class GlossaryDocumentPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -2401,7 +2401,7 @@ public partial class CommentAuthorsPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -2453,7 +2453,7 @@ public partial class SlideCommentsPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -2505,7 +2505,7 @@ public partial class PresentationPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -2557,7 +2557,7 @@ public partial class PresentationPropertiesPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -2609,7 +2609,7 @@ public partial class SlidePart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -2661,7 +2661,7 @@ public partial class SlideLayoutPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -2713,7 +2713,7 @@ public partial class SlideMasterPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -2765,7 +2765,7 @@ public partial class HandoutMasterPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -2817,7 +2817,7 @@ public partial class NotesMasterPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -2869,7 +2869,7 @@ public partial class NotesSlidePart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -2921,7 +2921,7 @@ public partial class SlideSyncDataPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -2973,7 +2973,7 @@ public partial class UserDefinedTagsPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -3025,7 +3025,7 @@ public partial class ViewPropertiesPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -3077,7 +3077,7 @@ public partial class MacroSheetPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -3129,7 +3129,7 @@ public partial class WorksheetSortMapPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -3181,7 +3181,7 @@ public partial class CustomizationPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -3233,7 +3233,7 @@ public partial class VbaDataPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -3285,7 +3285,7 @@ public partial class CustomDataPropertiesPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -3337,7 +3337,7 @@ public partial class ControlPropertiesPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -3389,7 +3389,7 @@ public partial class SlicersPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -3441,7 +3441,7 @@ public partial class SlicerCachePart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -3493,7 +3493,7 @@ public partial class DiagramPersistLayoutPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -3545,7 +3545,7 @@ public partial class RibbonAndBackstageCustomizationsPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -3597,7 +3597,7 @@ public partial class ChartColorStylePart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -3649,7 +3649,7 @@ public partial class ChartStylePart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -3701,7 +3701,7 @@ public partial class WebExtensionPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -3753,7 +3753,7 @@ public partial class WordprocessingCommentsExPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -3805,7 +3805,7 @@ public partial class WordprocessingPeoplePart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -3857,7 +3857,7 @@ public partial class WebExTaskpanesPart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -3909,7 +3909,7 @@ public partial class TimeLinePart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{
@@ -3961,7 +3961,7 @@ public partial class TimeLineCachePart
 	/// <summary>
     /// Only for OpenXmlPart derived classes.
     /// </summary>
-	internal override OpenXmlPartRootElement _rootElement
+	private protected override OpenXmlPartRootElement InternalRootElement
 	{
 		get
 		{

--- a/src/DocumentFormat.OpenXml/Packaging/CustomUIPart.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/CustomUIPart.cs
@@ -11,10 +11,10 @@ namespace DocumentFormat.OpenXml.Packaging
     public abstract partial class CustomUIPart : OpenXmlPart
     {
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
-        private DocumentFormat.OpenXml.Office.CustomUI.CustomUI _rootEle;
+        private Office.CustomUI.CustomUI _rootEle;
 
         /// <inheritdoc/>
-        internal override OpenXmlPartRootElement _rootElement
+        private protected override OpenXmlPartRootElement InternalRootElement
         {
             get
             {
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             set
             {
-                _rootEle = value as DocumentFormat.OpenXml.Office.CustomUI.CustomUI;
+                _rootEle = value as Office.CustomUI.CustomUI;
             }
         }
 
@@ -45,7 +45,7 @@ namespace DocumentFormat.OpenXml.Packaging
             {
                 if (_rootEle == null)
                 {
-                    LoadDomTree<DocumentFormat.OpenXml.Office.CustomUI.CustomUI>();
+                    LoadDomTree<Office.CustomUI.CustomUI>();
                 }
                 return _rootEle;
             }

--- a/src/DocumentFormat.OpenXml/Packaging/MailMergeRecipientDataPart.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/MailMergeRecipientDataPart.cs
@@ -15,7 +15,7 @@ namespace DocumentFormat.OpenXml.Packaging
         private DocumentFormat.OpenXml.OpenXmlPartRootElement _rootEle;
 
         /// <inheritdoc/>
-        internal override OpenXmlPartRootElement _rootElement
+        private protected override OpenXmlPartRootElement InternalRootElement
         {
             get
             {

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlBasePart.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlBasePart.cs
@@ -24,7 +24,10 @@ namespace DocumentFormat.OpenXml.Packaging
         private PackagePart _packagePart;
         private Uri _uri;
 
-        internal protected OpenXmlPart()
+        /// <summary>
+        /// Create an instance of <see cref="OpenXmlPart"/>
+        /// </summary>
+        protected internal OpenXmlPart()
             : base()
         {
         }

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlBasePart.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlBasePart.cs
@@ -8,6 +8,11 @@ using System.Globalization;
 using System.IO;
 using System.IO.Packaging;
 
+#if FEATURE_XML_SCHEMA
+using System.Xml;
+using System.Xml.Schema;
+#endif
+
 namespace DocumentFormat.OpenXml.Packaging
 {
     /// <summary>
@@ -406,24 +411,19 @@ namespace DocumentFormat.OpenXml.Packaging
 #else
                 DtdProcessing = DtdProcessing.Prohibit, // set to prohibit explicitly for security fix
 #endif
-                MaxCharactersInDocument = MaxCharactersInPart
+                MaxCharactersInDocument = MaxCharactersInPart,
+                Schemas = schemas,
+                ValidationType = ValidationType.Schema
             };
-            XmlReader xmlReader = null;
 
-            // XML validator object
-
-            using (Stream partStream = GetStream())
+            using (var partStream = GetStream())
             {
-                //xmlReaderSettings.Schemas.Add(null, schemaFile);
-                xmlReaderSettings.Schemas = schemas;
-                xmlReaderSettings.ValidationType = ValidationType.Schema;
-                // Add validation event handler
                 if (validationEventHandler != null)
                 {
                     xmlReaderSettings.ValidationEventHandler += validationEventHandler;
                 }
 
-                using (xmlReader = XmlConvertingReaderFactory.Create(partStream, xmlReaderSettings))
+                using (var xmlReader = XmlConvertingReaderFactory.Create(partStream, xmlReaderSettings))
                 {
                     // Validate XML data
                     while (xmlReader.Read()) ;

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlBasePart.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlBasePart.cs
@@ -7,8 +7,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.IO.Packaging;
-using System.Xml;
-using System.Xml.Schema;
 
 namespace DocumentFormat.OpenXml.Packaging
 {
@@ -17,28 +15,14 @@ namespace DocumentFormat.OpenXml.Packaging
     /// </summary>
     public abstract class OpenXmlPart : OpenXmlPartContainer
     {
-        #region private data members
-
         private OpenXmlPackage _openXmlPackage;
-        private PackagePart _metroPart;
+        private PackagePart _packagePart;
         private Uri _uri;
 
-        // parent part, for internal use only
-        //private OpenXmlPart _ownerPart;
-
-        #endregion
-
-        #region constructors
-
-        /// <summary>
-        /// OpenXmlPart constructor
-        /// </summary>
         internal protected OpenXmlPart()
             : base()
         {
         }
-
-        #endregion
 
         #region methods for LoadPart(), NewPart( ), AddPartFrom( )
 
@@ -69,7 +53,6 @@ namespace DocumentFormat.OpenXml.Packaging
             }
 
             _openXmlPackage = openXmlPackage;
-            //this._ownerPart = parent;
 
             Debug.Assert(loadedParts.ContainsKey(uriTarget));
 
@@ -89,7 +72,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 throw new OpenXmlPackageException(errorMessage);
             }
 
-            _metroPart = metroPart;
+            _packagePart = metroPart;
 
             // add the _uri to be reserved
             OpenXmlPackage.ReserveUri(ContentType, Uri);
@@ -175,7 +158,7 @@ namespace DocumentFormat.OpenXml.Packaging
             }
 
             // throw exception to catch error in our code
-            if (_metroPart != null)
+            if (_packagePart != null)
             {
                 throw new InvalidOperationException();
             }
@@ -221,7 +204,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             _uri = _openXmlPackage.GetUniquePartUri(contentType, parentUri, targetPath, TargetName, targetFileExt);
 
-            _metroPart = _openXmlPackage.CreateMetroPart(_uri, contentType);
+            _packagePart = _openXmlPackage.CreateMetroPart(_uri, contentType);
         }
 
         // create a new part in this package
@@ -243,7 +226,7 @@ namespace DocumentFormat.OpenXml.Packaging
             }
 
             // throw exception to catch error in our code
-            if (_metroPart != null)
+            if (_packagePart != null)
             {
                 throw new InvalidOperationException();
             }
@@ -264,7 +247,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             _uri = _openXmlPackage.GetUniquePartUri(contentType, parentUri, partUri);
 
-            _metroPart = _openXmlPackage.CreateMetroPart(_uri, contentType);
+            _packagePart = _openXmlPackage.CreateMetroPart(_uri, contentType);
         }
 
         #endregion
@@ -292,7 +275,7 @@ namespace DocumentFormat.OpenXml.Packaging
             {
                 ThrowIfObjectDisposed();
 
-                Debug.Assert(_uri.OriginalString.Equals(_metroPart.Uri.OriginalString, StringComparison.OrdinalIgnoreCase));
+                Debug.Assert(_uri.OriginalString.Equals(_packagePart.Uri.OriginalString, StringComparison.OrdinalIgnoreCase));
 
                 return _uri;
             }
@@ -494,7 +477,7 @@ namespace DocumentFormat.OpenXml.Packaging
             get
             {
                 ThrowIfObjectDisposed();
-                return _metroPart;
+                return _packagePart;
             }
         }
 
@@ -601,10 +584,9 @@ namespace DocumentFormat.OpenXml.Packaging
 
         /// <summary>
         /// Gets or sets the root element field.
-        /// Do not call this property outside of OpenXmlPart.
         /// </summary>
         /// <exception cref="InvalidOperationException">If the part does not have root element defined.</exception>
-        internal virtual OpenXmlPartRootElement _rootElement
+        private protected virtual OpenXmlPartRootElement InternalRootElement
         {
             get { return null; }
             set { throw new InvalidOperationException(); }
@@ -636,7 +618,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Gets a value indicating whether the root element is loaded from the part or it has been set.
         /// </summary>
-        internal bool IsRootElementLoaded => _rootElement != null;
+        internal bool IsRootElementLoaded => InternalRootElement != null;
 
         /// <summary>
         /// Sets the PartRootElement to null.
@@ -647,10 +629,10 @@ namespace DocumentFormat.OpenXml.Packaging
         /// </remarks>
         internal OpenXmlPartRootElement SetPartRootElementToNull()
         {
-            var rootElement = _rootElement;
-            if (_rootElement != null)
+            var rootElement = InternalRootElement;
+            if (InternalRootElement != null)
             {
-                _rootElement = null;
+                InternalRootElement = null;
             }
             return rootElement;
         }
@@ -663,47 +645,36 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <remarks>
         /// The ._rootElement will be assigned if the DOM is loaded.
         /// </remarks>
-        internal void LoadDomTree<T>() where T : OpenXmlPartRootElement, new()
+        internal void LoadDomTree<T>()
+            where T : OpenXmlPartRootElement, new()
         {
-            Debug.Assert(_rootElement == null);
-
-            bool streamIsEmpty = true;
+            Debug.Assert(InternalRootElement == null);
 
             using (Stream stream = GetStream(FileMode.OpenOrCreate, FileAccess.Read))
             {
-                if (stream.Length > 0)
+                if (stream.Length == 0)
                 {
-                    streamIsEmpty = false;
+                    return;
                 }
 
-                if (!streamIsEmpty)
+                try
                 {
-                    T rootElement = new T();
+                    var rootElement = new T();
 
-                    try
+                    if (rootElement.LoadFromPart(this, stream))
                     {
-                        if (rootElement.LoadFromPart(this, stream))
-                        {
-                            // set this part to the root Element
-                            rootElement.OpenXmlPart = this;
+                        // set this part to the root Element
+                        rootElement.OpenXmlPart = this;
 
-                            // associate the root element with this part.
-                            _rootElement = rootElement;
-                        }
-                        else
-                        {
-                            // the part stream does not contain a XML root element.
-                            // jus leave the .RootElement as null.
-                        }
+                        // associate the root element with this part.
+                        InternalRootElement = rootElement;
                     }
-                    catch (InvalidDataException e)
-                    {
-                        throw new InvalidDataException(ExceptionMessages.CannotLoadRootElement, e);
-                    }
+                }
+                catch (InvalidDataException e)
+                {
+                    throw new InvalidDataException(ExceptionMessages.CannotLoadRootElement, e);
                 }
             }
-
-            return;
         }
 
         /// <summary>
@@ -718,19 +689,6 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             Debug.Assert(partRootElement != null);
 
-            //if (partRootElement == null)
-            //{
-            //    if (this.RootElement != null)
-            //    {
-            //        // clear the association from the previous root element.
-            //        this.RootElement.OpenXmlPart = null;
-            //    }
-
-            //    this.RootElement = null;
-
-            //    return;
-            //}
-
             if (partRootElement.OpenXmlPart != null)
             {
                 throw new ArgumentException(ExceptionMessages.PartRootAlreadyHasAssociation, nameof(partRootElement));
@@ -738,13 +696,13 @@ namespace DocumentFormat.OpenXml.Packaging
 
             partRootElement.OpenXmlPart = this;
 
-            if (_rootElement != null)
+            if (InternalRootElement != null)
             {
                 // clear the association from the previous root element.
-                _rootElement.OpenXmlPart = null;
+                InternalRootElement.OpenXmlPart = null;
             }
 
-            _rootElement = partRootElement;
+            InternalRootElement = partRootElement;
 
             return;
         }
@@ -757,13 +715,13 @@ namespace DocumentFormat.OpenXml.Packaging
             PartDictionary = null;
             ReferenceRelationshipList.Clear();
             _openXmlPackage = null;
-            _metroPart = null;
+            _packagePart = null;
             _uri = null;
             //this._ownerPart = null;
-            if (_rootElement != null)
+            if (InternalRootElement != null)
             {
-                _rootElement.OpenXmlPart = null;
-                _rootElement = null;
+                InternalRootElement.OpenXmlPart = null;
+                InternalRootElement = null;
             }
         }
 
@@ -803,14 +761,14 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             ThrowIfObjectDisposed();
 
-            return _metroPart.CreateRelationship(targetUri, targetMode, relationshipType);
+            return _packagePart.CreateRelationship(targetUri, targetMode, relationshipType);
         }
 
         internal sealed override PackageRelationship CreateRelationship(Uri targetUri, TargetMode targetMode, string relationshipType, string id)
         {
             ThrowIfObjectDisposed();
 
-            return _metroPart.CreateRelationship(targetUri, targetMode, relationshipType, id);
+            return _packagePart.CreateRelationship(targetUri, targetMode, relationshipType, id);
         }
 
         #endregion

--- a/src/DocumentFormat.OpenXml/Packaging/StylesPart.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/StylesPart.cs
@@ -14,7 +14,7 @@ namespace DocumentFormat.OpenXml.Packaging
         private Wordprocessing.Styles _rootEle;
 
         /// <inheritdoc/>
-        internal override OpenXmlPartRootElement _rootElement
+        private protected override OpenXmlPartRootElement InternalRootElement
         {
             get
             {


### PR DESCRIPTION
- Uses `private protected` for `_rootElement`
- Renames `_metroPackage` to `_package`