### PR TITLE
Use single property for OpenXmlPackage.ChildrenParts and PartDictionary

### DIFF
--- a/src/DocumentFormat.OpenXml/Packaging/ExtendedPart.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/ExtendedPart.cs
@@ -145,7 +145,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             string relationshipId = AttachChild(newPart, id);
 
-            ChildrenParts.Add(relationshipId, newPart);
+            ChildrenRelationshipParts.Add(relationshipId, newPart);
 
             return;
         }

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlBasePart.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlBasePart.cs
@@ -715,7 +715,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             OpenXmlPackage.Package.DeletePart(Uri);
 
-            PartDictionary = null;
+            ChildrenParts.Clear(); 
             ReferenceRelationshipList.Clear();
             _openXmlPackage = null;
             _packagePart = null;

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlBasePart.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlBasePart.cs
@@ -715,7 +715,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             OpenXmlPackage.Package.DeletePart(Uri);
 
-            ChildrenRelationshipParts.Clear(); 
+            ChildrenRelationshipParts.Clear();
             ReferenceRelationshipList.Clear();
             _openXmlPackage = null;
             _packagePart = null;

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlBasePart.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlBasePart.cs
@@ -121,7 +121,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 // add it and get the id
                 string relationshipId = AttachChild(child);
 
-                ChildrenParts.Add(relationshipId, child);
+                ChildrenRelationshipParts.Add(relationshipId, child);
 
                 return child;
             }
@@ -538,7 +538,7 @@ namespace DocumentFormat.OpenXml.Packaging
             }
 
             reachableParts.Add(this, false);
-            foreach (OpenXmlPart part in ChildrenParts.Values)
+            foreach (OpenXmlPart part in ChildrenRelationshipParts.Values)
             {
                 if (!reachableParts.ContainsKey(part))
                 {
@@ -715,7 +715,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             OpenXmlPackage.Package.DeletePart(Uri);
 
-            ChildrenParts.Clear(); 
+            ChildrenRelationshipParts.Clear(); 
             ReferenceRelationshipList.Clear();
             _openXmlPackage = null;
             _packagePart = null;

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
@@ -609,7 +609,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 // TODO: Close resources
                 _package.Close();
                 _package = null;
-                PartDictionary = null;
+                ChildrenParts.Clear();
                 ReferenceRelationshipList.Clear();
                 _partUriHelper = null;
             }

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
@@ -908,7 +908,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 {
                     // just call AttachChild( ) is OK. No need to call AddPart( ... )
                     newMainPart.AttachChild(idPartPair.Value, idPartPair.Key);
-                    newMainPart.ChildrenRelationshipParts.Add(idPartPair);
+                    newMainPart.ChildrenRelationshipParts.Add(idPartPair.Key, idPartPair.Value);
                 }
 
                 foreach (ExternalRelationship externalRel in referenceRelationships.OfType<ExternalRelationship>())

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
@@ -609,7 +609,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 // TODO: Close resources
                 _package.Close();
                 _package = null;
-                ChildrenParts.Clear();
+                ChildrenRelationshipParts.Clear();
                 ReferenceRelationshipList.Clear();
                 _partUriHelper = null;
             }
@@ -859,7 +859,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 //
                 tempPart = AddExtendedPart(@"http://temp", MainPartContentType, @".xml");
 
-                foreach (KeyValuePair<string, OpenXmlPart> idPartPair in mainPart.ChildrenParts)
+                foreach (KeyValuePair<string, OpenXmlPart> idPartPair in mainPart.ChildrenRelationshipParts)
                 {
                     childParts.Add(idPartPair.Key, idPartPair.Value);
                 }
@@ -883,7 +883,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 string id = GetIdOfPart(mainPart);
 
                 // remove the old part
-                ChildrenParts.Remove(id);
+                ChildrenRelationshipParts.Remove(id);
                 DeleteRelationship(id);
                 mainPart.Destroy();
 
@@ -897,7 +897,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 // add it and get the id
                 string relationshipId = AttachChild(newMainPart, id);
 
-                ChildrenParts.Add(relationshipId, newMainPart);
+                ChildrenRelationshipParts.Add(relationshipId, newMainPart);
 
                 // copy the stream back
                 memoryStream.Position = 0;
@@ -908,7 +908,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 {
                     // just call AttachChild( ) is OK. No need to call AddPart( ... )
                     newMainPart.AttachChild(idPartPair.Value, idPartPair.Key);
-                    newMainPart.ChildrenParts.Add(idPartPair);
+                    newMainPart.ChildrenRelationshipParts.Add(idPartPair);
                 }
 
                 foreach (ExternalRelationship externalRel in referenceRelationships.OfType<ExternalRelationship>())
@@ -928,7 +928,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
                 // delete the temp part
                 id = GetIdOfPart(tempPart);
-                ChildrenParts.Remove(id);
+                ChildrenRelationshipParts.Remove(id);
                 DeleteRelationship(id);
                 tempPart.Destroy();
             }
@@ -981,7 +981,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 // add it and get the id
                 string relationshipId = AttachChild(child);
 
-                ChildrenParts.Add(relationshipId, child);
+                ChildrenRelationshipParts.Add(relationshipId, child);
 
                 return child;
             }
@@ -1008,7 +1008,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 throw new ArgumentNullException(nameof(reachableParts));
             }
 
-            foreach (OpenXmlPart part in ChildrenParts.Values)
+            foreach (OpenXmlPart part in ChildrenRelationshipParts.Values)
             {
                 if (!reachableParts.ContainsKey(part))
                 {

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPartContainer.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPartContainer.cs
@@ -32,7 +32,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Gets the children parts IDictionary.
         /// </summary>
-        internal Dictionary<string, OpenXmlPart> ChildrenParts
+        internal Dictionary<string, OpenXmlPart> ChildrenRelationshipParts
         {
             get
             {
@@ -510,7 +510,7 @@ namespace DocumentFormat.OpenXml.Packaging
             {
                 ThrowIfObjectDisposed();
 
-                foreach (KeyValuePair<string, OpenXmlPart> item in ChildrenParts)
+                foreach (KeyValuePair<string, OpenXmlPart> item in ChildrenRelationshipParts)
                 {
                     yield return new IdPartPair(item.Key, item.Value);
                 }
@@ -534,7 +534,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             OpenXmlPart part = null;
 
-            if (ChildrenParts.TryGetValue(id, out part))
+            if (ChildrenRelationshipParts.TryGetValue(id, out part))
             {
                 return part;
             }
@@ -561,9 +561,9 @@ namespace DocumentFormat.OpenXml.Packaging
                 throw new ArgumentNullException(nameof(part));
             }
 
-            if (ChildrenParts.ContainsValue(part))
+            if (ChildrenRelationshipParts.ContainsValue(part))
             {
-                foreach (KeyValuePair<string, OpenXmlPart> idPartPair in ChildrenParts)
+                foreach (KeyValuePair<string, OpenXmlPart> idPartPair in ChildrenRelationshipParts)
                 {
                     if (part == idPartPair.Value)
                     {
@@ -599,7 +599,7 @@ namespace DocumentFormat.OpenXml.Packaging
             }
 
             string oldId = null;
-            foreach (var idPartPair in ChildrenParts)
+            foreach (var idPartPair in ChildrenRelationshipParts)
             {
                 if (idPartPair.Key == newRelationshipId)
                 {
@@ -629,10 +629,10 @@ namespace DocumentFormat.OpenXml.Packaging
 
             // Add a new relationship, and then remove the old relationship
             CreateRelationship(part.Uri, TargetMode.Internal, part.RelationshipType, newRelationshipId);
-            ChildrenParts.Add(newRelationshipId, part);
+            ChildrenRelationshipParts.Add(newRelationshipId, part);
 
             DeleteRelationship(oldId);
-            ChildrenParts.Remove(oldId);
+            ChildrenRelationshipParts.Remove(oldId);
 
             return oldId;
         }
@@ -821,7 +821,7 @@ namespace DocumentFormat.OpenXml.Packaging
             // add it
             string relationshipId = AttachChild(child, rId);
 
-            ChildrenParts.Add(relationshipId, child);
+            ChildrenRelationshipParts.Add(relationshipId, child);
 
             return child;
         }
@@ -864,7 +864,7 @@ namespace DocumentFormat.OpenXml.Packaging
             }
 
             if (part.OpenXmlPackage != InternalOpenXmlPackage ||
-                !ChildrenParts.ContainsValue(part))
+                !ChildrenRelationshipParts.ContainsValue(part))
             {
                 throw new InvalidOperationException(ExceptionMessages.ForeignOpenXmlPart);
             }
@@ -1225,7 +1225,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             ThrowIfObjectDisposed();
 
-            return ChildrenParts.Values.OfType<T>();
+            return ChildrenRelationshipParts.Values.OfType<T>();
         }
 
         /// <summary>
@@ -1311,7 +1311,7 @@ namespace DocumentFormat.OpenXml.Packaging
                     throw new ArgumentException(ExceptionMessages.InvalidXmlIDStringException, nameof(id));
                 }
 
-                if (ChildrenParts.ContainsKey(id))
+                if (ChildrenRelationshipParts.ContainsKey(id))
                 {
                     throw new ArgumentException(ExceptionMessages.RelationshipIdConflict, nameof(id));
                 }
@@ -1405,7 +1405,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
                 string relationshipId = AttachChild(newPart, id);
 
-                ChildrenParts.Add(relationshipId, newPart);
+                ChildrenRelationshipParts.Add(relationshipId, newPart);
 
                 return;
             }
@@ -1548,7 +1548,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 // it is a part shared in the same package
                 string relationshipId = AttachChild(part, rId);
 
-                ChildrenParts.Add(relationshipId, part);
+                ChildrenRelationshipParts.Add(relationshipId, part);
 
                 return part;
             }
@@ -1591,7 +1591,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
                 relationshipId = AttachChild(child, rId);
 
-                ChildrenParts.Add(relationshipId, child);
+                ChildrenRelationshipParts.Add(relationshipId, child);
 
                 return child;
             }
@@ -1622,7 +1622,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
                 string relationshipId = AttachChild(child, rId);
 
-                ChildrenParts.Add(relationshipId, child);
+                ChildrenRelationshipParts.Add(relationshipId, child);
 
                 // add to processed node list
                 partDictionary.Add(part, child);
@@ -1742,7 +1742,7 @@ namespace DocumentFormat.OpenXml.Packaging
             child.FindAllReachableParts(processedParts);
 
             // remove from the collection
-            ChildrenParts.Remove(id);
+            ChildrenRelationshipParts.Remove(id);
 
             // find all live parts
             InternalOpenXmlPackage.FindAllReachableParts(liveParts);
@@ -1794,7 +1794,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             List<string> relationshipIds = new List<string>();
 
-            foreach (KeyValuePair<string, OpenXmlPart> idPartPair in ChildrenParts)
+            foreach (KeyValuePair<string, OpenXmlPart> idPartPair in ChildrenRelationshipParts)
             {
                 if (idPartPair.Value is T)
                 {
@@ -1818,7 +1818,7 @@ namespace DocumentFormat.OpenXml.Packaging
             DeletePartsOfType<T>();
 
             // remove recursively
-            foreach (OpenXmlPart child in ChildrenParts.Values)
+            foreach (OpenXmlPart child in ChildrenRelationshipParts.Values)
             {
                 child.DeletePartsRecursivelyOfTypeBase<T>();
             }
@@ -1831,11 +1831,11 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             ThrowIfObjectDisposed();
 
-            if (ChildrenParts.Count > 0)
+            if (ChildrenRelationshipParts.Count > 0)
             {
                 Collection<OpenXmlPart> subPartsShouldBeDeleted = new Collection<OpenXmlPart>();
 
-                foreach (KeyValuePair<string, OpenXmlPart> idPartPair in ChildrenParts)
+                foreach (KeyValuePair<string, OpenXmlPart> idPartPair in ChildrenRelationshipParts)
                 {
                     bool isDeleted;
 
@@ -1858,7 +1858,7 @@ namespace DocumentFormat.OpenXml.Packaging
                     // TODO: is this necessary? Will Package.DeletePart also delete it's .rels?
                     DeleteRelationship(idPartPair.Key);
                 }
-                ChildrenParts.Clear();
+                ChildrenRelationshipParts.Clear();
 
                 foreach (OpenXmlPart child in subPartsShouldBeDeleted)
                 {
@@ -1885,7 +1885,7 @@ namespace DocumentFormat.OpenXml.Packaging
             }
 
             // there should be only one part of this type
-            foreach (OpenXmlPart part in ChildrenParts.Values)
+            foreach (OpenXmlPart part in ChildrenRelationshipParts.Values)
             {
                 if (part.RelationshipType == relationshipType)
                 {
@@ -1921,7 +1921,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 throw new ArgumentOutOfRangeException(nameof(part));
             }
 
-            return ChildrenParts.ContainsValue(part);
+            return ChildrenRelationshipParts.ContainsValue(part);
         }
 
         /// <summary>
@@ -1992,7 +1992,7 @@ namespace DocumentFormat.OpenXml.Packaging
                                 {
                                     throw new OpenXmlPackageException(ExceptionMessages.SamePartWithDifferentRelationshipType);
                                 }
-                                ChildrenParts.Add(relationship.Id, child);
+                                ChildrenRelationshipParts.Add(relationship.Id, child);
                             }
                             else if (DataPartReferenceRelationship.IsDataPartReferenceRelationship(relationship.RelationshipType))
                             {
@@ -2018,7 +2018,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
                                 child.Load(openXmlPackage, sourcePart, uriTarget, relationship.Id, loadedParts);
 
-                                ChildrenParts.Add(relationship.Id, child);
+                                ChildrenRelationshipParts.Add(relationship.Id, child);
                             }
                         }
                     }

--- a/src/DocumentFormat.OpenXml/Validation/PackageValidator.cs
+++ b/src/DocumentFormat.OpenXml/Validation/PackageValidator.cs
@@ -80,7 +80,7 @@ namespace DocumentFormat.OpenXml.Validation
             // count all parts of same type
             var partOccurs = new Dictionary<string, int>(StringComparer.Ordinal);
 
-            foreach (var part in container.ChildrenParts.Values)
+            foreach (var part in container.ChildrenRelationshipParts.Values)
             {
                 if (partOccurs.TryGetValue(part.RelationshipType, out int occurs))
                 {
@@ -152,7 +152,7 @@ namespace DocumentFormat.OpenXml.Validation
                 }
             }
 
-            foreach (var part in container.ChildrenParts.Values)
+            foreach (var part in container.ChildrenRelationshipParts.Values)
             {
                 if (!processedParts.ContainsKey(part))
                 {

--- a/test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlPartTest.cs
+++ b/test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlPartTest.cs
@@ -181,9 +181,9 @@ namespace DocumentFormat.OpenXml.Tests
                     mainDocPart.ChangeIdOfPart(commentsPart, "rId3");
                     mainDocPart.ChangeIdOfPart(headerPart, "rId1");
 
-                    Assert.Equal(2, mainDocPart.ChildrenParts.Count());
-                    Assert.False(mainDocPart.ChildrenParts.ContainsKey("rId2"));
-                    Assert.True(mainDocPart.ChildrenParts.ContainsKey("rId3"));
+                    Assert.Equal(2, mainDocPart.ChildrenRelationshipParts.Count());
+                    Assert.False(mainDocPart.ChildrenRelationshipParts.ContainsKey("rId2"));
+                    Assert.True(mainDocPart.ChildrenRelationshipParts.ContainsKey("rId3"));
 
                     var rId = mainDocPart.GetIdOfPart(mainDocPart.WordprocessingCommentsPart);
                     Assert.Equal("rId3", rId);
@@ -197,7 +197,7 @@ namespace DocumentFormat.OpenXml.Tests
                 using (WordprocessingDocument loadedDoc = WordprocessingDocument.Open(stream, false))
                 {
                     var mainDocPart = loadedDoc.MainDocumentPart;
-                    Assert.Equal(2, mainDocPart.ChildrenParts.Count());
+                    Assert.Equal(2, mainDocPart.ChildrenRelationshipParts.Count());
 
                     var rId = mainDocPart.GetIdOfPart(mainDocPart.WordprocessingCommentsPart);
                     Assert.Equal("rId3", rId);


### PR DESCRIPTION
There are two properties that point to the same instance of data. This also obsoletes a couple of methods that are redundant with simple LINQ operators that we don't need to maintain in the long run. With the next major version, we'll remove them, but for now they are marked with the ObsoleteAttribute.