### PR TITLE
adding strongly typed methods to OpenXmlReader fixes #398

### DIFF
--- a/src/DocumentFormat.OpenXml/OpenXmlReader.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlReader.cs
@@ -242,6 +242,47 @@ namespace DocumentFormat.OpenXml
         public abstract OpenXmlElement LoadCurrentElement();
 
         /// <summary>
+        /// Loads the element at current cursor as the specified type.
+        /// </summary>
+        /// <typeparam name="T">The concrete type of the OpenXmlElement to load.</typeparam>
+        /// <returns>The OpenXmlElement that was loaded.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the current is the end element or when the ElementType and <typeparamref name="T"/> do not match.</exception>
+        public virtual T LoadElement<T>()
+            where T : OpenXmlElement
+        {
+            if (ElementType == typeof(T))
+            {
+                return (T)LoadCurrentElement();
+            }
+            else
+            {
+                throw new InvalidOperationException(ExceptionMessages.ReaderIncorrectTypeOnLoad);
+            }
+        }
+
+        /// <summary>
+        /// Attempts to load the element at current cursor as the specified type.
+        /// </summary>
+        /// <typeparam name="T">The concrete type of the OpenXmlElement to load.</typeparam>
+        /// <param name="element">The OpenXmlElement that was loaded.</param>
+        /// <returns><c>true</c> if the element was loaded, otherwise <c>false</c>.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the current is the end element.</exception>
+        public virtual bool TryLoadElement<T>(out T element)
+            where T : OpenXmlElement
+        {
+            if (ElementType == typeof(T))
+            {
+                element = (T)LoadCurrentElement();
+                return true;
+            }
+            else
+            {
+                element = null;
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Gets the text of the element if the element is an OpenXmlLeafTextElement. Returns String.Empty for other elements.
         /// </summary>
         /// <returns>

--- a/src/DocumentFormat.OpenXml/Resources/ExceptionMessages.Designer.cs
+++ b/src/DocumentFormat.OpenXml/Resources/ExceptionMessages.Designer.cs
@@ -704,6 +704,15 @@ namespace DocumentFormat.OpenXml {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The reader is currently at a {0} but {1} was specified..
+        /// </summary>
+        internal static string ReaderIncorrectTypeOnLoad {
+            get {
+                return ResourceManager.GetString("ReaderIncorrectTypeOnLoad", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The reader is now positioned at the end element tag..
         /// </summary>
         internal static string ReaderInEndState {

--- a/src/DocumentFormat.OpenXml/Resources/ExceptionMessages.resx
+++ b/src/DocumentFormat.OpenXml/Resources/ExceptionMessages.resx
@@ -393,4 +393,7 @@
   <data name="StreamAccessModeShouldRead" xml:space="preserve">
     <value>The stream was not opened for reading.</value>
   </data>
+  <data name="ReaderIncorrectTypeOnLoad" xml:space="preserve">
+    <value>The reader is currently at a {0} but {1} was specified.</value>
+  </data>
 </root>

--- a/test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlReaderTest.cs
+++ b/test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlReaderTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using DocumentFormat.OpenXml.Wordprocessing;
+using System;
 using System.IO;
 using System.Text;
 using Xunit;
@@ -537,6 +538,67 @@ namespace DocumentFormat.OpenXml.Tests
             Assert.False(targetReader.IsMiscNode);
             Assert.Equal(typeof(Paragraph), targetReader.ElementType);
             Assert.True(string.IsNullOrEmpty(targetReader.GetText()));
+        }
+
+        ///<summary>
+        ///  A test for the LoadElement generic method.
+        ///</summary>
+        [Fact]
+        public void SuccessfulLoadElementGeneric()
+        {
+            string paragraphOuterXml = "<w:p w:rsidP=\"001\" xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\"><w:r><w:t>Run Text.</w:t><w:t>Run 2.</w:t></w:r></w:p>";
+            Paragraph para = new Paragraph(paragraphOuterXml);
+
+            OpenXmlReader targetReader = OpenXmlReader.Create(para);
+            targetReader.Read();
+
+            Paragraph readPara = targetReader.LoadElement<Paragraph>();
+
+            Assert.NotNull(readPara);
+            Assert.IsType<Paragraph>(readPara);
+            Assert.True(para.Equals(readPara));
+
+            targetReader.Close();
+        }
+
+        ///<summary>
+        ///  A test for the LoadElement generic method.
+        ///</summary>
+        [Fact]
+        public void ThrowingLoadElementGeneric()
+        {
+            string paragraphOuterXml = "<w:p w:rsidP=\"001\" xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\"><w:r><w:t>Run Text.</w:t><w:t>Run 2.</w:t></w:r></w:p>";
+            Paragraph para = new Paragraph(paragraphOuterXml);
+
+            OpenXmlReader targetReader = OpenXmlReader.Create(para);
+            targetReader.Read();
+
+            Assert.Throws<InvalidOperationException>(() => targetReader.LoadElement<Picture>());
+
+            targetReader.Close();
+        }
+
+        ///<summary>
+        ///  A test for the TryLoadElement generic method.
+        ///</summary>
+        [Fact]
+        public void TryLoadElementGeneric()
+        {
+            string paragraphOuterXml = "<w:p w:rsidP=\"001\" xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\"><w:r><w:t>Run Text.</w:t><w:t>Run 2.</w:t></w:r></w:p>";
+            Paragraph para = new Paragraph(paragraphOuterXml);
+
+            OpenXmlReader targetReader = OpenXmlReader.Create(para);
+            targetReader.Read();
+
+            Assert.False(targetReader.TryLoadElement(out Picture fakePicture));
+            Assert.Null(fakePicture);
+
+            Assert.True(targetReader.TryLoadElement(out Paragraph readPara));
+            Assert.NotNull(readPara);
+            Assert.IsType<Paragraph>(readPara);
+            Assert.True(para.Equals(readPara));
+
+            targetReader.Close();
         }
     }
 }


### PR DESCRIPTION
This implements the request I made in #398.

* I dropped the word `Current` as it is additional fluff of a word - the property is `ElementType` so i deemed it unnecessary 
* I went with the `Try` in the name of the "safe" method, although i wish there was a better pattern.
* Made the methods virtual since this is an abstract class for backwards compatibility.
* Added one resource string.
* Added test coverage.