### PR TITLE
A few perf improvements

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -16,7 +16,6 @@
     FEATURE_XML_PROHIBIT_DTD         : XML settings only has ProhibitDtd property
     FEATURE_XML_QUOTECHAR            : XmlReader.QuoteChar is an abstract member
     FEATURE_XML_SCHEMA               : XML Schema is available in the platform
-    FEATURE_XML_VERIFYTOKEN          : XmlConvert.VerifyTOKEN is available in the platform
   -->
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net35' ">
@@ -24,7 +23,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net35' OR '$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net452' ">
-    <DefineConstants>$(DefineConstants);FEATURE_ABSTRACT_XML_CLOSE;FEATURE_CLOSE;FEATURE_PACKAGE_FLUSH;FEATURE_SERIALIZATION;FEATURE_SYSTEMEXCEPTION;FEATURE_XML_DISPOSE_PROTECTED;FEATURE_XML_QUOTECHAR;FEATURE_XML_SCHEMA;FEATURE_XML_VERIFYTOKEN</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ABSTRACT_XML_CLOSE;FEATURE_CLOSE;FEATURE_PACKAGE_FLUSH;FEATURE_SERIALIZATION;FEATURE_SYSTEMEXCEPTION;FEATURE_XML_DISPOSE_PROTECTED;FEATURE_XML_QUOTECHAR;FEATURE_XML_SCHEMA</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'net46' ">
@@ -32,7 +31,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <DefineConstants>$(DefineConstants);FEATURE_ABSTRACT_XML_CLOSE;FEATURE_CLOSE;FEATURE_PACKAGE_FLUSH;FEATURE_SERIALIZATION;FEATURE_SYSTEMEXCEPTION;FEATURE_XML_QUOTECHAR;FEATURE_XML_SCHEMA;FEATURE_XML_VERIFYTOKEN</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ABSTRACT_XML_CLOSE;FEATURE_CLOSE;FEATURE_PACKAGE_FLUSH;FEATURE_SERIALIZATION;FEATURE_SYSTEMEXCEPTION;FEATURE_XML_QUOTECHAR;FEATURE_XML_SCHEMA</DefineConstants>
   </PropertyGroup>
 
 

--- a/src/DocumentFormat.OpenXml/OpenXmlElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlElement.cs
@@ -2039,7 +2039,7 @@ namespace DocumentFormat.OpenXml
 
         internal abstract void Populate(XmlReader xmlReader, OpenXmlLoadMode loadMode);
 
-        internal virtual void ParseXml()
+        private protected virtual void ParseXml()
         {
             Debug.Assert(!XmlParsed);
 
@@ -2050,15 +2050,9 @@ namespace DocumentFormat.OpenXml
 
             using (XmlReader xmlReader = CreateXmlReader())
             {
-                xmlReader.Read(); // move the reader to the start of the element.
-                if (OpenXmlElementContext != null)
-                {
-                    Populate(xmlReader, OpenXmlElementContext.LoadMode);
-                }
-                else
-                {
-                    Populate(xmlReader, OpenXmlLoadMode.Full);
-                }
+                // move the reader to the start of the element.
+                xmlReader.Read();
+                Populate(xmlReader, OpenXmlElementContext?.LoadMode ?? OpenXmlLoadMode.Full);
             }
         }
 

--- a/src/DocumentFormat.OpenXml/OpenXmlNonElementNode.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlNonElementNode.cs
@@ -276,9 +276,8 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <inheritdoc/>
-        internal override void ParseXml()
+        private protected override void ParseXml()
         {
-            // do nothing
         }
 
         /// <summary>

--- a/src/DocumentFormat.OpenXml/SimpleTypes/EnumStringLookup.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/EnumStringLookup.cs
@@ -141,7 +141,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-        private struct EnumStringInfo
+        private readonly struct EnumStringInfo
         {
             public EnumStringInfo(FileFormatVersions versions, string name)
             {

--- a/src/DocumentFormat.OpenXml/Validation/Schema/Restrictions/HexBinaryRestriction.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Schema/Restrictions/HexBinaryRestriction.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using DocumentFormat.OpenXml.Validation;
 using System.Runtime.Serialization;
-using System.Text.RegularExpressions;
 
 namespace DocumentFormat.OpenXml.Validation.Schema.Restrictions
 {
@@ -31,14 +29,33 @@ namespace DocumentFormat.OpenXml.Validation.Schema.Restrictions
             {
                 return false;
             }
-            else if (attributeValue.InnerText.Length == 0)
+
+            var length = attributeValue.InnerText.Length;
+
+            if (length % 2 == 1)
             {
-                return true;
+                return false;
             }
 
-            string pattern = @"\A([0-9a-fA-F][0-9a-fA-F])+\z";
+            for (var i = 0; i < length; i++)
+            {
+                var current = attributeValue.InnerText[i];
+                var isDigit = IsLetterBetween(current, '0', '9');
+                var isLower = IsLetterBetween(current, 'a', 'f');
+                var isUpper = IsLetterBetween(current, 'A', 'F');
 
-            return Regex.IsMatch(attributeValue.InnerText, pattern, RegexOptions.CultureInvariant);
+                if (!isDigit && !isLower && !isUpper)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool IsLetterBetween(char check, char lower, char upper)
+        {
+            return check >= lower && check <= upper;
         }
 
         /// <inheritdoc />

--- a/src/DocumentFormat.OpenXml/Validation/Schema/Restrictions/LanguageRestriction.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Schema/Restrictions/LanguageRestriction.cs
@@ -3,7 +3,6 @@
 
 using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
-using System.Xml;
 
 namespace DocumentFormat.OpenXml.Validation.Schema.Restrictions
 {
@@ -19,7 +18,7 @@ namespace DocumentFormat.OpenXml.Validation.Schema.Restrictions
     [DataContract]
     internal class LanguageRestriction : TokenRestriction
     {
-        private static string LanguageLexicalPattern = @"\A[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*\z";
+        private static Regex LanguageLexicalPattern = new Regex(@"\A[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*\z", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
         /// <inheritdoc />
         public override XsdType XsdType => XsdType.Language;
@@ -30,16 +29,12 @@ namespace DocumentFormat.OpenXml.Validation.Schema.Restrictions
         /// <inheritdoc />
         public override bool ValidateValueType(OpenXmlSimpleType attributeValue)
         {
-            try
+            if (VerifyTOKEN(attributeValue.InnerText))
             {
-                VerifyTOKEN(attributeValue.InnerText);
-            }
-            catch (XmlException)
-            {
-                return false;
+                return LanguageLexicalPattern.IsMatch(attributeValue.InnerText);
             }
 
-            return Regex.IsMatch(attributeValue.InnerText, LanguageLexicalPattern, RegexOptions.CultureInvariant);
+            return false;
         }
     }
 }

--- a/src/DocumentFormat.OpenXml/Validation/Schema/Restrictions/TokenRestriction.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Schema/Restrictions/TokenRestriction.cs
@@ -24,6 +24,8 @@ namespace DocumentFormat.OpenXml.Validation.Schema.Restrictions
     [DataContract]
     internal class TokenRestriction : StringRestriction
     {
+        private static char[] crt = { '\n', '\r', '\t' };
+
         /// <inheritdoc />
         public override XsdType XsdType => XsdType.Token;
 
@@ -33,40 +35,25 @@ namespace DocumentFormat.OpenXml.Validation.Schema.Restrictions
         /// <inheritdoc />
         public override bool ValidateValueType(OpenXmlSimpleType attributeValue)
         {
-            try
+            return VerifyTOKEN(attributeValue.InnerText);
+        }
+
+        /// <summary>
+        /// An implementation of XmlConvert.VerifyTOKEN(string) as it is not available cross platform and throws if fails
+        /// </summary>
+        public static bool VerifyTOKEN(string token)
+        {
+            if (token == null || token.Length == 0)
             {
-                VerifyTOKEN(attributeValue.InnerText);
+                return true;
             }
-            catch (XmlException)
+
+            if (token[0] == ' ' || token[token.Length - 1] == ' ' || token.IndexOfAny(crt) != -1 || token.IndexOf("  ", StringComparison.Ordinal) != -1)
             {
                 return false;
             }
 
             return true;
         }
-
-#if FEATURE_XML_VERIFYTOKEN
-        protected static string VerifyTOKEN(string token)
-        {
-            return XmlConvert.VerifyTOKEN(token);
-        }
-#else
-        private static char[] crt = new char[] { '\n', '\r', '\t' };
-
-        protected static string VerifyTOKEN(string token)
-        {
-            if (token == null || token.Length == 0)
-            {
-                return token;
-            }
-
-            if (token[0] == ' ' || token[token.Length - 1] == ' ' || token.IndexOfAny(crt) != -1 || token.IndexOf("  ", StringComparison.Ordinal) != -1)
-            {
-                throw new System.Xml.XmlException($"Not a valid token: '{token}'");
-            }
-
-            return token;
-        }
-#endif
     }
 }

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeValuePatternConstraint.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeValuePatternConstraint.cs
@@ -13,8 +13,8 @@ namespace DocumentFormat.OpenXml.Validation.Semantic
     /// </summary>
     internal class AttributeValuePatternConstraint : SemanticConstraint
     {
-        private byte _attribute;
-        private string _pattern;
+        private readonly byte _attribute;
+        private readonly Regex _pattern;
 
         public AttributeValuePatternConstraint(byte attribute, string pattern)
             : base(SemanticValidationLevel.Element)
@@ -23,14 +23,12 @@ namespace DocumentFormat.OpenXml.Validation.Semantic
 
             _attribute = attribute;
 
-            if (pattern.StartsWith("^", StringComparison.Ordinal) && pattern.EndsWith("$", StringComparison.Ordinal))
+            if (!pattern.StartsWith("^", StringComparison.Ordinal) || !pattern.EndsWith("$", StringComparison.Ordinal))
             {
-                _pattern = pattern;
+                pattern = string.Concat("^", pattern, "$");
             }
-            else
-            {
-                _pattern = "^" + pattern + "$";
-            }
+
+            _pattern = new Regex(pattern, RegexOptions.Compiled);
         }
 
         public override ValidationErrorInfo Validate(ValidationContext context)
@@ -43,8 +41,7 @@ namespace DocumentFormat.OpenXml.Validation.Semantic
                 return null;
             }
 
-            Regex regex = new Regex(_pattern);
-            if (regex.IsMatch(attributeValue.InnerText))
+            if (_pattern.IsMatch(attributeValue.InnerText))
             {
                 return null;
             }

--- a/src/DocumentFormat.OpenXml/Validation/ValidationTraverser.cs
+++ b/src/DocumentFormat.OpenXml/Validation/ValidationTraverser.cs
@@ -39,7 +39,7 @@ namespace DocumentFormat.OpenXml.Validation
 
             // bookkeep MC context,
             // MC Spec: Compatibility-rule attributes shall affect the element to which they 1 are attached, including the element’s other attributes and contents.
-            validationContext.McContext.PushMCAttributes2(element.MCAttributes, prefix => element.LookupNamespace(prefix));
+            validationContext.McContext.PushMCAttributes2(element.MCAttributes, element.LookupNamespace);
 
             if (element.IsStrongTypedElement())
             {

--- a/test/DocumentFormat.OpenXml.Tests/Validation/Schema/Restrictions/HexBinaryRestrictionTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/Validation/Schema/Restrictions/HexBinaryRestrictionTests.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using NSubstitute;
+using System.Xml;
+using Xunit;
+
+namespace DocumentFormat.OpenXml.Validation.Schema.Restrictions.Tests
+{
+    public class HexBinaryRestrictionTests
+    {
+        [InlineData(null, false)]
+        [InlineData("", true)]
+        [InlineData("a", false)]
+        [InlineData("A", false)]
+        [InlineData("zz", false)]
+        [InlineData("gg", false)]
+        [InlineData("bb", true)]
+        [InlineData("0A", true)]
+        [InlineData("5A", true)]
+        [InlineData("5dA", false)]
+        [InlineData("5AbC5AbC5AbC5AbC5AbC5AbC5AbC5AbC", true)]
+        [InlineData("5AbC5AbC5AbC5AbC5AbC5AbC5AbC5Ab", false)]
+        [Theory]
+        public void ValidateValue(string innerText, bool expected)
+        {
+            var restriction = new HexBinaryRestriction();
+            var type = Substitute.ForPartsOf<OpenXmlSimpleType>();
+
+            type.InnerText.Returns(innerText);
+
+            Assert.Equal(expected, restriction.ValidateValueType(type));
+        }
+    }
+}

--- a/test/DocumentFormat.OpenXml.Tests/Validation/Schema/Restrictions/TokenRestrictionTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/Validation/Schema/Restrictions/TokenRestrictionTests.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using NSubstitute;
+using System.Collections.Generic;
+using Xunit;
+
+namespace DocumentFormat.OpenXml.Validation.Schema.Restrictions.Tests
+{
+    public class TokenRestrictionTests
+    {
+        public static IEnumerable<object[]> GetData()
+        {
+            yield return new object[] { null, true };
+            yield return new object[] { string.Empty, true };
+            yield return new object[] { " ", false };
+            yield return new object[] { "a ", false };
+            yield return new object[] { "a\nd", false };
+            yield return new object[] { "a\td", false };
+            yield return new object[] { "a\rd", false };
+            yield return new object[] { "abc def", true };
+            yield return new object[] { "abc  def", false };
+        }
+
+        [MemberData(nameof(GetData))]
+        [Theory]
+        public void VerifyTOKEN(string text, bool expected)
+        {
+            Assert.Equal(expected, TokenRestriction.VerifyTOKEN(text));
+        }
+
+        [MemberData(nameof(GetData))]
+        [Theory]
+        public void ValidateText(string innerText, bool expected)
+        {
+            var restriction = new TokenRestriction();
+            var type = Substitute.ForPartsOf<OpenXmlSimpleType>();
+
+            type.InnerText.Returns(innerText);
+
+            Assert.Equal(expected, restriction.ValidateValueType(type));
+        }
+    }
+}


### PR DESCRIPTION
- A `.Where` in the SemanticConstraintRegistry is in a hot path for validation and adds a number of allocations during validation
- A few restrictions were using Regex values. These are removed where easy, and otherwise precompiled if possible
- ValidationTraverser contained a lambda that was unnecessary and is on a hot path so it was allocating a large percentage of the validation memory