### PR TITLE
Add default NuGet.config

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/Open-XML-SDK.sln
+++ b/Open-XML-SDK.sln
@@ -10,6 +10,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.targets = Directory.Build.targets
 		GitVersion.yml = GitVersion.yml
 		LICENSE = LICENSE
+		NuGet.Config = NuGet.Config
 		README.md = README.md
 		rules.ruleset = rules.ruleset
 		stylecop.json = stylecop.json


### PR DESCRIPTION
Visual Studio seems to be adding this automatically and will make it easier to potentially add other sources in the future.