### PR TITLE
Ignore compat while system is down

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,8 +28,8 @@ test_script:
 artifacts:
   - path: 'bin\**\*.nupkg'
 
-on_finish:
-  - cmd: compat-agent.exe -config compat.yml -version %GitVersion_NuGetVersionV2%
+#on_finish:
+#  - cmd: compat-agent.exe -config compat.yml -version %GitVersion_NuGetVersionV2%
 
 deploy:
   provider: NuGet


### PR DESCRIPTION
Compat analyzer is currently down so disabling for now