### PR TITLE
Add .NET Standard 2.0 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Version 2.10.0
 ### Added
 - Added initial Office 2016 support, including `FileFormatVersion.Office2016`, `ExtendedChartPart` and other new schema elements (#586)
+- Add .NET Standard 2.0 target (#587)
 
 ## Version 2.9.1 - 2019-03-13
 ### Changed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -44,10 +44,9 @@
     </When>
     <When Condition=" '$(ProjectLoadStyle)' == 'DevCore21' ">
       <PropertyGroup>
-        <ProductTargetFrameworks>netstandard1.3</ProductTargetFrameworks>
+        <ProductTargetFrameworks>netstandard2.0</ProductTargetFrameworks>
         <TestTargetFrameworks>netcoreapp2.1</TestTargetFrameworks>
         <AssetsTargetFrameworks>netstandard1.3</AssetsTargetFrameworks>
-        <!-- BenchmarkDotNet only supports .NET Standard 2.0-->
         <BenchmarkTargetFrameworks>netcoreapp2.1</BenchmarkTargetFrameworks>
       </PropertyGroup>
     </When>
@@ -57,7 +56,7 @@
         .NET Standard target must be first to avoid a ResXFileCodeGenerator issue
         (tracked at https://github.com/dotnet/project-system/issues/1519)
         -->
-        <ProductTargetFrameworks>netstandard1.3;net35;net40;net46</ProductTargetFrameworks>
+        <ProductTargetFrameworks>netstandard1.3;netstandard2.0;net35;net40;net46</ProductTargetFrameworks>
         <AssetsTargetFrameworks>net452;netstandard1.3</AssetsTargetFrameworks>
         <TestTargetFrameworks>net452;net46;netcoreapp1.0;netcoreapp1.1;netcoreapp2.1</TestTargetFrameworks>
         <BenchmarkTargetFrameworks>net461;netcoreapp2.1</BenchmarkTargetFrameworks>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -33,9 +33,12 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net46' ">
-    <DefineConstants>$(DefineConstants);FEATURE_ABSTRACT_XML_CLOSE;FEATURE_CLOSE;FEATURE_PACKAGE_FLUSH;FEATURE_SCHEMA_GENERATOR;FEATURE_SERIALIZATION;FEATURE_SYSTEMEXCEPTION;FEATURE_XML_QUOTECHAR;FEATURE_XML_SCHEMA</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ABSTRACT_XML_CLOSE;FEATURE_CLOSE;FEATURE_SCHEMA_GENERATOR;FEATURE_SERIALIZATION;FEATURE_SYSTEMEXCEPTION;FEATURE_XML_QUOTECHAR;FEATURE_XML_SCHEMA</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <DefineConstants>$(DefineConstants);FEATURE_PACKAGE_FLUSH</DefineConstants>
+  </PropertyGroup>
 
   <ItemGroup>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -28,11 +28,11 @@
     <DefineConstants>$(DefineConstants);FEATURE_ABSTRACT_XML_CLOSE;FEATURE_CLOSE;FEATURE_PACKAGE_FLUSH;FEATURE_SERIALIZATION;FEATURE_SYSTEMEXCEPTION;FEATURE_XML_DISPOSE_PROTECTED;FEATURE_XML_QUOTECHAR;FEATURE_XML_SCHEMA</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'net46' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net46' ">
     <DefineConstants> $(DefineConstants);FEATURE_DCS_SETTINGS;FEATURE_ARRAY_EMPTY</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net46' ">
     <DefineConstants>$(DefineConstants);FEATURE_ABSTRACT_XML_CLOSE;FEATURE_CLOSE;FEATURE_PACKAGE_FLUSH;FEATURE_SCHEMA_GENERATOR;FEATURE_SERIALIZATION;FEATURE_SYSTEMEXCEPTION;FEATURE_XML_QUOTECHAR;FEATURE_XML_SCHEMA</DefineConstants>
   </PropertyGroup>
 

--- a/Open-XML-SDK.sln
+++ b/Open-XML-SDK.sln
@@ -1,11 +1,12 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2027
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28729.10
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0B53C729-D408-450D-B755-7A57184CDE93}"
 	ProjectSection(SolutionItems) = preProject
 		appveyor.yml = appveyor.yml
+		CHANGELOG.md = CHANGELOG.md
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		DocumentFormat.OpenXml.Package.props = DocumentFormat.OpenXml.Package.props
@@ -32,7 +33,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DocumentFormat.OpenXml.Test
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DocumentFormat.OpenXml.Benchmarks", "test\DocumentFormat.OpenXml.Benchmarks\DocumentFormat.OpenXml.Benchmarks.csproj", "{B4604C70-721C-42C4-9D29-87E9084E927F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocumentFormat.OpenXml.Framework.Tests", "test\DocumentFormat.OpenXml.Framework.Tests\DocumentFormat.OpenXml.Framework.Tests.csproj", "{65D509D0-46DC-4883-AEB3-FF7E521B1E9F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DocumentFormat.OpenXml.Framework.Tests", "test\DocumentFormat.OpenXml.Framework.Tests\DocumentFormat.OpenXml.Framework.Tests.csproj", "{65D509D0-46DC-4883-AEB3-FF7E521B1E9F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/DocumentFormat.OpenXml/DocumentFormat.OpenXml.csproj
+++ b/src/DocumentFormat.OpenXml/DocumentFormat.OpenXml.csproj
@@ -71,6 +71,17 @@
         <Compile Include="System\Reflection\SubclassExtensions.cs" />
       </ItemGroup>
     </When>
+
+    <When Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+      <ItemGroup>
+        <PackageReference Include="System.IO.Packaging" Version="4.5.0" />
+      </ItemGroup>
+
+      <!-- In order to support .NET Native, we need to include an appropriate .rd.xml -->
+      <ItemGroup>
+        <EmbeddedResource Include="Properties\DocumentFormat.OpenXml.rd.xml" />
+      </ItemGroup>
+    </When>
   </Choose>
 
   <!-- Include the constraint data that are stored in bin files -->


### PR DESCRIPTION
According to the documentation (https://docs.microsoft.com/en-us/dotnet/standard/net-standard), it is recommended that even if we target .NET Standard 1.3, we should also provide a .NET Standard 2.0 build as well. This will minimize the dependency graph required by consumers.

With this change, tests for .NET Standard 1.3 are run on the .NET Core 1.x builds while those for .NET Standard 2.0 are run on .NET Core 2.1.