### PR TITLE
Separate out test yaml scripts

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
 
          - DevFramework40: .NET Framework 4.0
          - DevFramework46: .NET Framework 4.6
-         - DevCore10:      .NET Core 1.0
+         - DevCore11:      .NET Core 1.1
          - DevCore21:      .NET Core 2.1
          - All: Will build for all platforms
          -->
@@ -34,10 +34,10 @@
         <BenchmarkTargetFrameworks>net461</BenchmarkTargetFrameworks>
       </PropertyGroup>
     </When>
-    <When Condition=" '$(ProjectLoadStyle)' == 'DevCore10' ">
+    <When Condition=" '$(ProjectLoadStyle)' == 'DevCore11' ">
       <PropertyGroup>
         <ProductTargetFrameworks>netstandard1.3</ProductTargetFrameworks>
-        <TestTargetFrameworks>netcoreapp1.0</TestTargetFrameworks>
+        <TestTargetFrameworks>netcoreapp1.1</TestTargetFrameworks>
         <AssetsTargetFrameworks>netstandard1.3</AssetsTargetFrameworks>
         <!-- BenchmarkDotNet only supports .NET Standard 2.0-->
         <BenchmarkTargetFrameworks>netcoreapp2.1</BenchmarkTargetFrameworks>
@@ -59,7 +59,7 @@
         -->
         <ProductTargetFrameworks>netstandard1.3;netstandard2.0;net35;net40;net46</ProductTargetFrameworks>
         <AssetsTargetFrameworks>net452;netstandard1.3</AssetsTargetFrameworks>
-        <TestTargetFrameworks>net452;net46;netcoreapp1.0;netcoreapp1.1;netcoreapp2.1</TestTargetFrameworks>
+        <TestTargetFrameworks>net452;net46;netcoreapp1.1;netcoreapp2.1</TestTargetFrameworks>
         <BenchmarkTargetFrameworks>net461;netcoreapp2.1</BenchmarkTargetFrameworks>
 
         <!-- Must disable this due to https://github.com/NuGet/Home/issues/7414 so .NET Core 1.x will build -->
@@ -90,7 +90,5 @@
 
   <PropertyGroup>
     <IsTestProject Condition=" '$(IsTestProject)' == '' ">false</IsTestProject>
-    <EnableCodeCoverage Condition=" '$(EnableCodeCoverage)' == '' ">false</EnableCodeCoverage>
-    <DebugType Condition="$(EnableCodeCoverage)">Full</DebugType>
   </PropertyGroup>
 </Project>

--- a/Tests.targets
+++ b/Tests.targets
@@ -1,32 +1,9 @@
 <Project>
   <Choose>
     <When Condition="$(IsTestProject)">
-      <PropertyGroup >
-        <TestArchitecture Condition="'$(TestArchitecture)' == ''">x64</TestArchitecture>
-        <_TestTargetName Condition="'$(TargetFrameworks)' == ''">InnerTest</_TestTargetName>
-        <_TestTargetName Condition="'$(TargetFrameworks)' != ''">OuterTest</_TestTargetName>
-
-        <TestLogger Condition=" '$(TestLogger)' == '' ">trx</TestLogger>
-      </PropertyGroup>
-
-      <Choose>
-        <When Condition="$(TargetFramework.StartsWith('netcoreapp'))">
-          <PropertyGroup>
-            <TestExe>dotnet.exe</TestExe>
-            <TestArgs>vstest /Framework:FrameworkCore10</TestArgs>
-          </PropertyGroup>
-        </When>
-        <Otherwise>
-          <PropertyGroup>
-            <TestExe>vstest.console.exe</TestExe>
-            <TestArgs>/Framework:Framework45</TestArgs>
-          </PropertyGroup>
-        </Otherwise>
-      </Choose>
 
       <ItemGroup>
         <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-        <PackageReference Include="OpenCover" Version="4.6.519" Condition="$(EnableCodeCoverage)" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
         <PackageReference Include="NSubstitute" Version="4.2.0" />
@@ -57,68 +34,17 @@
     </When>
   </Choose>
 
-  <!-- An empty target so that we can run /t:test at the solution level and skip all non-tests -->
-  <Target Name="Test">
-    <Message Text="No tests available as this is not a test project. Please mark test projects with IsTestProject=true to enable test run." />
+  <Target Name="PublishProjectIfFrameworkSet"
+          DependsOnTargets="Publish"
+          Condition=" '$(TargetFramework)' != '' " />
+
+  <Target Name="PublishProjectForAllFrameworksIfFrameworkUnset" Condition=" '$(TargetFramework)' == '' ">
+    <ItemGroup>
+      <_PublishFramework Include="$(TargetFrameworks)" />
+    </ItemGroup>
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Publish" Properties="TargetFramework=%(_PublishFramework.Identity)" />
   </Target>
 
-  <Target Name="Test" DependsOnTargets="$(_TestTargetName)" Condition="$(IsTestProject)" />
-
-  <Target Name="InnerTest" Condition="$(IsTestProject)">
-    <PropertyGroup>
-      <_TestLogPath>$(OutputPath)\test_log.txt</_TestLogPath>
-      <TestArgs>$(TestArgs) /Logger:$(TestLogger) $(TargetPath) /Platform:$(TestArchitecture)</TestArgs>
-      <TestCommand>$(TestExe) $(TestArgs)</TestCommand>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="$(EnableCodeCoverage)">
-      <CoverageOutput>$(OutputPath)\coverage.xml</CoverageOutput>
-      <OpenCoverExe>$(NuGetPackageRoot)\OpenCover\4.6.519\tools\OpenCover.Console.exe</OpenCoverExe>
-      <InstrumentationStyle Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">-oldStyle</InstrumentationStyle>
-      <TestCommand>"$(OpenCoverExe)" -register:user -target:"$(TestExe)" $(InstrumentationStyle) -targetargs:"$(TestArgs)" -threshold:1 -output:"$(CoverageOutput)" -filter:"+[DocumentFormat.OpenXml]*"</TestCommand>
-    </PropertyGroup>
-
-    <Error Message="Could not find OpenCover" Condition="!Exists($(OpenCoverExe)) AND $(EnableCodeCoverage)" />
-
-    <Delete Files="$(_TestLogPath)" />
-    <MakeDir Directories="$(ArtifactsTestResultsDir)"/>
-
-    <Exec Command='$(TestCommand) > $(_TestLogPath)'
-          LogStandardErrorAsError="true"
-          WorkingDirectory="$(OutputPath)"
-          IgnoreExitCode="true">
-
-      <Output TaskParameter="ExitCode" PropertyName="ExitCode" />
-    </Exec>
-
-    <Message Text="Test succeeded: $(MSBuildProjectName) [$(TargetFramework)|%(_TestArchitectureItems.Identity)]" Condition="'$(ExitCode)' == '0'" />
-    <Error Text="Test failed with exit code: $(ExitCode); log: $(_TestLogPath)" Condition="'$(ExitCode)' != '0'" />
-
-  </Target>
-
-  <Target Name="UploadCodeCoverageReport" AfterTargets="InnerTest" Condition="$(EnableCodeCoverage)">
-    <PropertyGroup>
-      <CodeCov>codecov</CodeCov>
-      <CodeCovTokenParam Condition=" '$(CodeCovToken)' != '' ">-t $(CodeCovToken)</CodeCovTokenParam>
-    </PropertyGroup>
-
-    <Exec Command='"$(CodeCov)" -f "$(CoverageOutput)" $(CodeCovTokenParam) --required --name $(TargetFramework)'
-          LogStandardErrorAsError="true"
-          WorkingDirectory="$(OutputPath)"
-          IgnoreExitCode="true">
-      <Output TaskParameter="ExitCode" PropertyName="ExitCode" />
-    </Exec>
-
-    <Message Text="Coverage file uploaded: $(MSBuildProjectName) [$(TargetFramework)|%(_TestArchitectureItems.Identity)]" Condition="'$(ExitCode)' == '0'" />
-    <Error Text="Coverage file upload failed with exit code: $(ExitCode)" Condition="'$(ExitCode)' != '0'" />
-  </Target>
-
-  <Target Name="OuterTest" DependsOnTargets="_SetTestInnerTarget;DispatchToInnerBuilds" Condition="$(IsTestProject)"/>
-
-  <Target Name="_SetTestInnerTarget" Returns="@(InnerOutput)" Condition="$(IsTestProject)">
-    <PropertyGroup Condition="'$(InnerTargets)' == ''">
-      <InnerTargets>InnerTest</InnerTargets>
-    </PropertyGroup>
-  </Target>
+  <Target Name="PublishAll" Condition="$(IsTestProject)" DependsOnTargets="PublishProjectIfFrameworkSet;PublishProjectForAllFrameworksIfFrameworkUnset" />
 
 </Project>

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -1,5 +1,4 @@
 variables:
-  SdkSolution: 'Open-XML-SDK.sln'
   BuildPlatform: 'Any CPU'
   BuildConfiguration: 'Release'
   ProjectLoadStyle: 'All'
@@ -13,23 +12,64 @@ pr:
     include:
     - master
 
-jobs:
-  - job: Build
-    displayName: Build SDK
-    pool:
-      name: Hosted VS2017
-      demands:
-      - msbuild
-      - visualstudio
-      - vstest
-    steps:
-      - template: build.yml
+stages:
+  - stage: Build
+    jobs:
+      - job: Build
+        displayName: Build SDK
+        pool:
+          name: Hosted VS2017
+          demands:
+          - msbuild
+          - visualstudio
+          - vstest
+        steps:
+          - template: build.yml
 
-  - job: Sign
-    displayName: Sign assemblies and package
-    pool:
-      name: Hosted VS2017
-    steps:
-      - template: sign.yml
+  - stage: Test
+    jobs:
+    - job: net452
+      displayName: Test .NET Framework 4.5.2
+      pool:
+        name: Hosted VS2017
+      steps:
+        - template: test.yml
+          parameters:
+            framework: net452
+    - job: net46
+      displayName: Test .NET Framework 4.6
+      pool:
+        name: Hosted VS2017
+      steps:
+        - template: test.yml
+          parameters:
+            framework: net46
+    - job: netcoreapp11
+      displayName: Test .NET Core 1.1
+      pool:
+        name: Hosted VS2017
+      steps:
+        - template: test.yml
+          parameters:
+            framework: netcoreapp1.1
+    - job: netcoreapp21
+      displayName: Test .NET Core 2.1
+      pool:
+        name: Hosted VS2017
+      steps:
+        - template: test.yml
+          parameters:
+            framework: netcoreapp2.1
+    dependsOn: Build
+    condition: succeeded()
+
+  - stage: Sign
+    jobs:
+    - job: Sign
+      displayName: Sign assemblies and package
+      pool:
+        name: Hosted VS2017
+      steps:
+        - template: sign.yml
     dependsOn: Build
     condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -28,38 +28,17 @@ stages:
 
   - stage: Test
     jobs:
-    - job: net452
-      displayName: Test .NET Framework 4.5.2
-      pool:
-        name: Hosted VS2017
-      steps:
-        - template: test.yml
-          parameters:
-            framework: net452
-    - job: net46
-      displayName: Test .NET Framework 4.6
-      pool:
-        name: Hosted VS2017
-      steps:
-        - template: test.yml
-          parameters:
-            framework: net46
-    - job: netcoreapp11
-      displayName: Test .NET Core 1.1
-      pool:
-        name: Hosted VS2017
-      steps:
-        - template: test.yml
-          parameters:
-            framework: netcoreapp1.1
-    - job: netcoreapp21
-      displayName: Test .NET Core 2.1
-      pool:
-        name: Hosted VS2017
-      steps:
-        - template: test.yml
-          parameters:
-            framework: netcoreapp2.1
+    - template: test.yml
+      parameters:
+        frameworks:
+          - tfm: net452
+            name: net452
+          - tfm: net46
+            name: net46
+          - tfm: netcoreapp1.1
+            name: netcoreapp1_1
+          - tfm: netcoreapp2.1
+            name: netcoreapp2_1
     dependsOn: Build
     condition: succeeded()
 

--- a/build/build.yml
+++ b/build/build.yml
@@ -3,32 +3,29 @@ steps:
   - task: VSBuild@1
     displayName: 'Build SDK'
     inputs:
-      solution: '$(SdkSolution)'
+      solution: 'Open-XML-SDK.sln'
       msbuildArgs: '/t:restore;build /p:ProjectLoadStyle=$(ProjectLoadStyle)'
       platform: '$(BuildPlatform)'
       configuration: '$(BuildConfiguration)'
 
-  - task: VSTest@2
-    displayName: 'VsTest - testAssemblies'
+  - task: VSBuild@1
+    displayName: 'Publish tests'
     inputs:
-      testAssemblyVer2: |
-        bin\$(BuildConfiguration)\**\*test*.dll
-      runInParallel: true
-      codeCoverageEnabled: true
-      otherConsoleOptions: '/Platform:x64'
+      solution: 'Open-XML-SDK.sln'
+      msbuildArgs: '/m /t:PublishAll /p:ProjectLoadStyle=$(ProjectLoadStyle)'
       platform: '$(BuildPlatform)'
       configuration: '$(BuildConfiguration)'
-      diagnosticsEnabled: True
+
+  - publish: 'bin/$(BuildConfiguration)'
+    artifact: build
 
   - task: VSBuild@1
     displayName: 'Pack SDK'
     inputs:
-      msbuildArgs: '/t:pack /p:ProjectLoadStyle=$(ProjectLoadStyle) /p:PackageOutputPath=$(Build.ArtifactStagingDirectory)'
+      msbuildArgs: '/t:pack /p:ProjectLoadStyle=$(ProjectLoadStyle) /p:PackageOutputPath=$(Build.ArtifactStagingDirectory)/unsigned'
       platform: '$(BuildPlatform)'
       configuration: '$(BuildConfiguration)'
 
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Unsigned'
-    inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: 'unsigned'
+  - publish: '$(Build.ArtifactStagingDirectory)/unsigned'
+    artifact: unsigned
+    displayName: 'Publish Unsigned Packages'

--- a/build/sign.yml
+++ b/build/sign.yml
@@ -1,28 +1,25 @@
 steps:
   - checkout: none
 
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Download Build Artifacts'
-    inputs:
-      artifactName: unsigned
-      downloadPath: $(System.DefaultWorkingDirectory)
+  - download: current
+    artifact: unsigned
 
   - powershell: |
       $version=gci DocumentFormat.OpenXml.*.nupkg | % { $_ -match 'DocumentFormat.OpenXml.(.*).nupkg' | Out-Null; $matches[1] }
       Write-Host "##vso[task.setvariable variable=Version]$version"
       Write-Host "Setting version to $version"
-    workingDirectory: '$(System.DefaultWorkingDirectory)/unsigned'
+    workingDirectory: '$(Pipeline.Workspace)/unsigned'
 
   - task: ExtractFiles@1
     inputs:
-      archiveFilePatterns: '$(System.DefaultWorkingDirectory)/unsigned/DocumentFormat.OpenXml.$(Version).nupkg'
-      destinationFolder: '$(System.DefaultWorkingDirectory)/$(Version)'
+      archiveFilePatterns: '$(Pipeline.Workspace)/unsigned/DocumentFormat.OpenXml.$(Version).nupkg'
+      destinationFolder: '$(Pipeline.Workspace)/$(Version)'
 
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
     displayName: 'OpenXML SDK Assembly ESRP CodeSigning'
     inputs:
       ConnectedServiceName: 'Open-XML-SDK-ESRP'
-      FolderPath: '$(System.DefaultWorkingDirectory)\$(Version)'
+      FolderPath: '$(Pipeline.Workspace)\$(Version)'
       Pattern: '**\DocumentFormat.OpenXml.dll'
       UseMinimatch: true
       signConfigType: inlineSignParams
@@ -60,7 +57,7 @@ steps:
 
   - task: ArchiveFiles@2
     inputs:
-      rootFolderOrFile: '$(System.DefaultWorkingDirectory)/$(Version)' 
+      rootFolderOrFile: '$(Pipeline.Workspace)/$(Version)' 
       includeRootFolder: false
       archiveType: 'zip'
       archiveFile: '$(Build.ArtifactStagingDirectory)/DocumentFormat.OpenXml.$(Version).nupkg' 

--- a/build/test.yml
+++ b/build/test.yml
@@ -1,0 +1,25 @@
+parameters:
+  framework: ''
+
+steps:
+  - checkout: none
+
+  - download: current
+    artifact: build
+    patterns: '*.Tests/${{ parameters.framework }}/publish/**/*'
+
+  - powershell: |
+      gci -r
+    workingDirectory: '$(Pipeline.Workspace)'
+
+  - task: VSTest@2
+    inputs:
+      testAssemblyVer2: |
+        **\publish\*Tests.dll
+      runInParallel: true
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
+      ${{ if contains(parameters.framework, 'core')}}:
+        otherConsoleOptions: '/Framework:FrameworkCore10 /platform:x64'
+      diagnosticsEnabled: True
+      searchFolder: '$(Pipeline.Workspace)\build'

--- a/build/test.yml
+++ b/build/test.yml
@@ -1,21 +1,24 @@
 parameters:
-  framework: ''
+  frameworks: []
 
-steps:
-  - checkout: none
+jobs:
+- ${{ each framework in parameters.frameworks }}:
+  - job: ${{ framework.name }}
+    steps:
+      - checkout: none
 
-  - download: current
-    artifact: build
-    patterns: '*.Tests/${{ parameters.framework }}/publish/**/*'
+      - download: current
+        artifact: build
+        patterns: '*.Tests/${{ framework.tfm }}/publish/**/*'
 
-  - task: VSTest@2
-    inputs:
-      testAssemblyVer2: |
-        **\publish\*Tests.dll
-      runInParallel: true
-      platform: '$(BuildPlatform)'
-      configuration: '$(BuildConfiguration)'
-      ${{ if contains(parameters.framework, 'core')}}:
-        otherConsoleOptions: '/Framework:FrameworkCore10 /platform:x64'
-      diagnosticsEnabled: True
-      searchFolder: '$(Pipeline.Workspace)\build'
+      - task: VSTest@2
+        inputs:
+          testAssemblyVer2: |
+            **\publish\*Tests.dll
+          runInParallel: true
+          platform: '$(BuildPlatform)'
+          configuration: '$(BuildConfiguration)'
+          ${{ if contains(framework.tfm, 'core')}}:
+            otherConsoleOptions: '/Framework:FrameworkCore10 /platform:x64'
+          diagnosticsEnabled: True
+          searchFolder: '$(Pipeline.Workspace)\build'

--- a/build/test.yml
+++ b/build/test.yml
@@ -4,6 +4,9 @@ parameters:
 jobs:
 - ${{ each framework in parameters.frameworks }}:
   - job: ${{ framework.name }}
+    displayName: ${{ framework.tfm }}
+    pool:
+      name: Hosted VS2017
     steps:
       - checkout: none
 

--- a/build/test.yml
+++ b/build/test.yml
@@ -8,10 +8,6 @@ steps:
     artifact: build
     patterns: '*.Tests/${{ parameters.framework }}/publish/**/*'
 
-  - powershell: |
-      gci -r
-    workingDirectory: '$(Pipeline.Workspace)'
-
   - task: VSTest@2
     inputs:
       testAssemblyVer2: |


### PR DESCRIPTION
Update tests to be run on separate machines so that they can be completed in parallel. Before this, they actually weren't being run for .NET Core runtimes