### PR TITLE
Consider altChunk parts in Flat OPC transformation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Fixed some documentation inconsistencies (#582)
+- Fixed `ToFlatOpcDocument`, `ToFlatOpcString`, `FromFlatOpcDocument`, and `FromFlatOpcString` to correctly process Alternative Format Import Parts, or "altChunk parts" (#659)
 
 ## Version 2.9.1 - 2019-03-13
 ### Changed

--- a/src/DocumentFormat.OpenXml/Packaging/PresentationDocument.FlatOpc.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/PresentationDocument.FlatOpc.cs
@@ -11,7 +11,7 @@ namespace DocumentFormat.OpenXml.Packaging
     /// <summary>
     /// Defines PresentationDocument - an OpenXmlPackage represents a Presentation document
     /// </summary>
-    public partial class PresentationDocument : OpenXmlPackage
+    public partial class PresentationDocument
     {
         /// <summary>
         /// Converts an OpenXml package in OPC format to an <see cref="XDocument"/>
@@ -54,7 +54,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            return PresentationDocument.Open(FromFlatOpcDocumentCore(document, stream), isEditable);
+            return Open(FromFlatOpcDocumentCore(document, stream), isEditable);
         }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 throw new ArgumentNullException(nameof(path));
             }
 
-            return PresentationDocument.Open(FromFlatOpcDocumentCore(document, path), isEditable);
+            return Open(FromFlatOpcDocumentCore(document, path), isEditable);
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 throw new ArgumentNullException(nameof(package));
             }
 
-            return PresentationDocument.Open(FromFlatOpcDocumentCore(document, package));
+            return Open(FromFlatOpcDocumentCore(document, package));
         }
 
         /// <summary>

--- a/src/DocumentFormat.OpenXml/Packaging/SpreadsheetDocument.FlatOpc.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/SpreadsheetDocument.FlatOpc.cs
@@ -11,7 +11,7 @@ namespace DocumentFormat.OpenXml.Packaging
     /// <summary>
     /// Defines SpreadsheetDocument - an OpenXmlPackage represents a Spreadsheet document.
     /// </summary>
-    public partial class SpreadsheetDocument : OpenXmlPackage
+    public partial class SpreadsheetDocument
     {
         /// <summary>
         /// Converts an OpenXml package in OPC format to an <see cref="XDocument"/>
@@ -54,7 +54,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            return SpreadsheetDocument.Open(FromFlatOpcDocumentCore(document, stream), true);
+            return Open(FromFlatOpcDocumentCore(document, stream), true);
         }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 throw new ArgumentNullException(nameof(path));
             }
 
-            return SpreadsheetDocument.Open(FromFlatOpcDocumentCore(document, path), isEditable);
+            return Open(FromFlatOpcDocumentCore(document, path), isEditable);
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 throw new ArgumentNullException(nameof(package));
             }
 
-            return SpreadsheetDocument.Open(FromFlatOpcDocumentCore(document, package));
+            return Open(FromFlatOpcDocumentCore(document, package));
         }
 
         /// <summary>

--- a/src/DocumentFormat.OpenXml/Packaging/WordprocessingDocument.FlatOpc.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/WordprocessingDocument.FlatOpc.cs
@@ -11,7 +11,7 @@ namespace DocumentFormat.OpenXml.Packaging
     /// <summary>
     /// Defines WordprocessingDocument - an OpenXmlPackage represents a Word document.
     /// </summary>
-    public partial class WordprocessingDocument : OpenXmlPackage
+    public partial class WordprocessingDocument
     {
         /// <summary>
         /// Converts an OpenXml package in OPC format to an <see cref="XDocument"/>
@@ -54,7 +54,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            return WordprocessingDocument.Open(FromFlatOpcDocumentCore(document, stream), isEditable);
+            return Open(FromFlatOpcDocumentCore(document, stream), isEditable);
         }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 throw new ArgumentNullException(nameof(path));
             }
 
-            return WordprocessingDocument.Open(FromFlatOpcDocumentCore(document, path), isEditable);
+            return Open(FromFlatOpcDocumentCore(document, path), isEditable);
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 throw new ArgumentNullException(nameof(package));
             }
 
-            return WordprocessingDocument.Open(FromFlatOpcDocumentCore(document, package));
+            return Open(FromFlatOpcDocumentCore(document, package));
         }
 
         /// <summary>

--- a/src/DocumentFormat.OpenXml/Resources/ExceptionMessages.Designer.cs
+++ b/src/DocumentFormat.OpenXml/Resources/ExceptionMessages.Designer.cs
@@ -12,7 +12,6 @@ namespace DocumentFormat.OpenXml {
     using System;
     using System.Reflection;
     
-    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -229,15 +228,6 @@ namespace DocumentFormat.OpenXml {
         internal static string ElementIsNotInOfficeVersion {
             get {
                 return ResourceManager.GetString("ElementIsNotInOfficeVersion", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The validator is set to validate content based on Microsoft Office 2016 rules. The passed in element is not defined in Microsoft Office 2016..
-        /// </summary>
-        internal static string ElementIsNotInOffice2016 {
-            get {
-                return ResourceManager.GetString("ElementIsNotInOffice2016", resourceCulture);
             }
         }
         
@@ -677,15 +667,6 @@ namespace DocumentFormat.OpenXml {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The validator is set to validate content based on Microsoft Office 2016 rules. The passed in part is not defined in Microsoft Office 2016..
-        /// </summary>
-        internal static string PartIsNotInOffice2016 {
-            get {
-                return ResourceManager.GetString("PartIsNotInOffice2016", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to A relationship can only be created between two parts in a package..
         /// </summary>
         internal static string PartNotInSamePackage {
@@ -772,6 +753,15 @@ namespace DocumentFormat.OpenXml {
         internal static string RequiredPartDoNotExist {
             get {
                 return ResourceManager.GetString("RequiredPartDoNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Root element is null..
+        /// </summary>
+        internal static string RootElementIsNull {
+            get {
+                return ResourceManager.GetString("RootElementIsNull", resourceCulture);
             }
         }
         

--- a/src/DocumentFormat.OpenXml/Resources/ExceptionMessages.resx
+++ b/src/DocumentFormat.OpenXml/Resources/ExceptionMessages.resx
@@ -393,4 +393,7 @@
   <data name="StreamAccessModeShouldRead" xml:space="preserve">
     <value>The stream was not opened for reading.</value>
   </data>
+  <data name="RootElementIsNull" xml:space="preserve">
+    <value>Root element is null.</value>
+  </data>
 </root>

--- a/test/DocumentFormat.OpenXml.Packaging.Tests/OpenXmlPackageTests.cs
+++ b/test/DocumentFormat.OpenXml.Packaging.Tests/OpenXmlPackageTests.cs
@@ -1,0 +1,144 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Wordprocessing;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Xunit;
+
+namespace DocumentFormat.OpenXml.Packaging.Tests
+{
+    public class OpenXmlPackageTests
+    {
+        private static readonly XNamespace Pkg = "http://schemas.microsoft.com/office/2006/xmlPackage";
+        private const WordprocessingDocumentType Document = WordprocessingDocumentType.Document;
+
+        // This is a sample XHTML document.
+        private const string XhtmlString =
+            @"<!DOCTYPE html PUBLIC ""-//W3C//DTD XHTML 1.0 Transitional//EN""
+""http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"">
+
+<html xmlns=""http://www.w3.org/1999/xhtml"">
+<head>
+  <title>Title of XHTML Document</title>
+</head>
+<body>
+  <h1>XHTML Document Heading</h1>
+  <p>This is a paragraph.</p>
+</body>
+</html>";
+
+        // This is a sample XML document.
+        private const string XmlString =
+            @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes""?><root><element>Some text</element></root>";
+
+        // The following are some of the content types of AlternativeFormatInputParts.
+        // Note that all of those end in "xml" or even "+xml". And note that the content
+        // type of AlternativeFormatInputParts containing WordprocessingML documents is
+        // identical to the content type of the MainDocumentPart.
+        private const string XhtmlContentType = "application/xhtml+xml";
+        private const string XmlContentType = "application/xml";
+        private const string WordprocessingMLContentType =
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml";
+
+        private static AltChunk CreateWordprocessingMLAltChunk(WordprocessingDocument wordDocument, string text)
+        {
+            using (Stream stream = CreateWordprocessingDocument(text))
+            {
+                string altChunkId = "DocxAltChunkId-" + Guid.NewGuid();
+                AlternativeFormatImportPart chunk = wordDocument.MainDocumentPart.AddAlternativeFormatImportPart(
+                    AlternativeFormatImportPartType.WordprocessingML, altChunkId);
+
+                chunk.FeedData(stream);
+                return new AltChunk { Id = altChunkId };
+            }
+        }
+
+        private static Stream CreateWordprocessingDocument(string text)
+        {
+            var stream = new MemoryStream();
+
+            using (WordprocessingDocument chunkDocument = WordprocessingDocument.Create(stream, Document))
+            {
+                MainDocumentPart mainDocumentPart = chunkDocument.AddMainDocumentPart();
+                mainDocumentPart.Document = new Document(new Body(new Paragraph(new Run(new Text(text)))));
+            }
+
+            stream.Seek(0, SeekOrigin.Begin);
+            return stream;
+        }
+
+        private static AltChunk CreateXhtmlAltChunk(WordprocessingDocument wordDocument)
+        {
+            string altChunkId = "XhtmlAltChunkId-" + Guid.NewGuid();
+            AlternativeFormatImportPart chunk = wordDocument.MainDocumentPart.AddAlternativeFormatImportPart(
+                AlternativeFormatImportPartType.Xhtml, altChunkId);
+
+            using (Stream stream = chunk.GetStream(FileMode.Create))
+            using (var writer = new StreamWriter(stream))
+            {
+                writer.WriteLine(XhtmlString);
+            }
+
+            return new AltChunk { Id = altChunkId };
+        }
+
+        private static AltChunk CreateXmlAltChunk(WordprocessingDocument wordDocument)
+        {
+            string altChunkId = "XmlAltChunkId-" + Guid.NewGuid();
+            AlternativeFormatImportPart chunk = wordDocument.MainDocumentPart.AddAlternativeFormatImportPart(
+                AlternativeFormatImportPartType.Xml, altChunkId);
+
+            using (Stream stream = chunk.GetStream(FileMode.Create))
+            using (var writer = new StreamWriter(stream))
+            {
+                writer.WriteLine(XmlString);
+            }
+
+            return new AltChunk { Id = altChunkId };
+        }
+
+        [Fact]
+        public void CanTransformWordprocessingDocumentWithAltChunksToFlatOpc()
+        {
+            using (var stream = new MemoryStream())
+            using (WordprocessingDocument wordDocument = WordprocessingDocument.Create(stream, Document))
+            {
+                MainDocumentPart mainPart = wordDocument.AddMainDocumentPart();
+                mainPart.Document =
+                    new Document(
+                        new Body(
+                            CreateWordprocessingMLAltChunk(wordDocument, Guid.NewGuid().ToString()),
+                            CreateXhtmlAltChunk(wordDocument),
+                            CreateXmlAltChunk(wordDocument)));
+
+                XDocument flatOpcDocument = wordDocument.ToFlatOpcDocument();
+
+                XElement mainDocumentPart = flatOpcDocument
+                    .Descendants(Pkg + "part")
+                    .First(p => p.Attributes(Pkg + "name").Any(a => a.Value == "/word/document.xml"));
+
+                IEnumerable<XElement> altChunkParts = flatOpcDocument
+                    .Descendants(Pkg + "part")
+                    .Where(p => p.Attributes(Pkg + "name").Any(a => a.Value.Contains("afchunk")))
+                    .ToList();
+
+                // We want our MainDocumentPart to contain XML data.
+                Assert.Equal(WordprocessingMLContentType, (string) mainDocumentPart.Attribute(Pkg + "contentType"));
+                Assert.NotEmpty(mainDocumentPart.Elements(Pkg + "xmlData"));
+
+                // We want to see each one of our AlternativeFormatImportParts.
+                Assert.Contains(altChunkParts, p => (string) p.Attribute(Pkg + "contentType") == XhtmlContentType);
+                Assert.Contains(altChunkParts, p => (string) p.Attribute(Pkg + "contentType") == XmlContentType);
+                Assert.Contains(altChunkParts, p => (string) p.Attribute(Pkg + "contentType") == WordprocessingMLContentType);
+
+                // We want all of our AlternativeFormatImportParts to contain binary data,
+                // even though two of them have a content type ending with "+xml".
+                Assert.All(altChunkParts, p => Assert.NotEmpty(p.Elements(Pkg + "binaryData")));
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit enhances the

  ```XDocument OpenXmlPackage.ToFlatOpcDocument(XProcessingInstruction)```

method to consider "altChunk parts" (AlternativeFormatInputParts),
which must have their content rendered in binary form even if it is XML
content (e.g., XML, XHTML).

Fixes #525.