### PR TITLE
Lazily create XmlPath in ValidationErrorInfo

### DIFF
--- a/src/DocumentFormat.OpenXml/Validation/DocumentValidator.cs
+++ b/src/DocumentFormat.OpenXml/Validation/DocumentValidator.cs
@@ -124,7 +124,6 @@ namespace DocumentFormat.OpenXml.Validation
                     ErrorType = ValidationErrorType.Schema,
                     Id = "ExceptionError",
                     Part = part,
-                    Path = new XmlPath(part),
                     Description = SR.Format(ValidationResources.ExceptionError, e.Message),
                 };
 
@@ -236,7 +235,6 @@ namespace DocumentFormat.OpenXml.Validation
                     if (e.Part != null)
                     {
                         errorInfo.Part = e.Part;
-                        errorInfo.Path = new XmlPath(e.Part);
                     }
 
                     errorInfo.RelatedPart = e.SubPart;

--- a/src/DocumentFormat.OpenXml/Validation/ValidationErrorInfo.cs
+++ b/src/DocumentFormat.OpenXml/Validation/ValidationErrorInfo.cs
@@ -12,17 +12,21 @@ namespace DocumentFormat.OpenXml.Validation
     [DebuggerDisplay("Description={Description}")]
     public class ValidationErrorInfo
     {
+        private XmlPath _xmlPath;
+        private OpenXmlElement _element;
+        private OpenXmlPart _part;
+
 #if DEBUG
         /// <summary>
         /// Gets the XML qualified name for the attribute.
         /// Returns null if the error is not for attribute.
         /// </summary>
-        public string AttributeQualifiedName { get; internal set; }
+        public string AttributeQualifiedName { get; private set; }
 
         /// <summary>
         /// Gets schema validation error category.
         /// </summary>
-        public string ValidationErrorCategory { get; internal set; }
+        public string ValidationErrorCategory { get; private set; }
 #endif
 
         /// <summary>
@@ -59,10 +63,25 @@ namespace DocumentFormat.OpenXml.Validation
         /// <summary>
         /// Gets the XmlPath information of this error.
         /// </summary>
-        public XmlPath Path { get; internal set; }
+        public XmlPath Path
+        {
+            get
+            {
+                if (_xmlPath is null)
+                {
+                    if (_element != null)
+                    {
+                        _xmlPath = XmlPath.GetXPath(_element);
+                    }
+                    else if (Part != null)
+                    {
+                        _xmlPath = XmlPath.GetXPath(Part);
+                    }
+                }
 
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private OpenXmlElement _element;
+                return _xmlPath;
+            }
+        }
 
         /// <summary>
         /// Gets the OpenXmlElement of the invalid node.
@@ -76,23 +95,25 @@ namespace DocumentFormat.OpenXml.Validation
 
             internal set
             {
+                Part = value.GetPart();
                 _element = value;
-                Path = XmlPath.GetXPath(value);
-                if (Part == null)
-                {
-                    Part = _element.GetPart();
-                }
-                else
-                {
-                    Debug.Assert(Part == _element.GetPart());
-                }
             }
         }
 
         /// <summary>
         /// Gets the part which the invalid element is in.
         /// </summary>
-        public OpenXmlPart Part { get; internal set; }
+        public OpenXmlPart Part
+        {
+            get => _part;
+
+            internal set
+            {
+                _part = value;
+                _element = null;
+                _xmlPath = null;
+            }
+        }
 
         /// <summary>
         /// Gets elements related with the invalid node.


### PR DESCRIPTION
If any errors are encountered, `ValidationErrorInfo` automatically creates an `Xmlpath` instance. However, this is somewhat expensive to create and may not be used. The validation perf test on master is this:

| Method     | Mean     | Error   | StdDev  | Gen 0     | Allocated |
| ---------- | -------- | ------- | ------- | --------- | --------- |
| Before     | 141.8 ms | 2.75 ms | 2.70 ms | 5000.0000 | 23.72 MB  |
| After      | 138.5 ms | 4.55 ms | 4.68 ms | 4000.0000 | 19.87 MB  |

There's a slight reduction in time, but a large reduction in Gen0 and overall allocations (~17%)