### PR TITLE
Ready for 2.10.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Version 2.11.0 - Unreleased
-### Added
-- Added `OpenXmlElementFunctionalExtensions.With` extension methods, which offer flexible means for constructing `OpenXmlElement` instances in the context of pure functional transformations.
+## Version 2.10.1 - 2020-02-26
 
 ### Fixed
 - Ensures attributes are available when `OpenXmlElement` is initialized with outer XML (#684)
 - Some documentation errors (#681)
-- Removed state that made it non-threadsafe to validate elements under certain conditions (#686)
+- Removed state that made it non-thread safe to validate elements under certain conditions (#686)
 - Correctly inserts strongly-typed elements before known elements that are not strongly-typed (#690)
 
 ## Version 2.10.0 - 2020-01-10

--- a/src/DocumentFormat.OpenXml/DocumentFormat.OpenXml.csproj
+++ b/src/DocumentFormat.OpenXml/DocumentFormat.OpenXml.csproj
@@ -15,6 +15,7 @@
     <!-- Remove all files under System as they need to be specifically opted into. They are
          helper files to fill the gaps of the various platforms that are targeted -->
     <Compile Remove="System\**\*.cs" />
+    <Compile Remove="OpenXmlElementFunctionalExtensions.cs" />
     <Compile Include="System\UriHelper.cs" />
   </ItemGroup>
 

--- a/test/DocumentFormat.OpenXml.Tests/DocumentFormat.OpenXml.Tests.csproj
+++ b/test/DocumentFormat.OpenXml.Tests/DocumentFormat.OpenXml.Tests.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="OpenXmlElementFunctionalExtensionsTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\DocumentFormat.OpenXml\DocumentFormat.OpenXml.csproj" />
     <ProjectReference Include="..\DocumentFormat.OpenXml.Tests.Assets\DocumentFormat.OpenXml.Tests.Assets.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Thie excludes OpenXmlElementFunctionalExtensions and tests for 2.10.1 release since that is new surface area not appropriate for a revision release. This will be re-enabled after the revision release. This is to get a couple of fixes out for #684 and #690 that were breaking behavior from 2.10.0