### PR TITLE
Ensure attributes are available when OuterXml property is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `OpenXmlElementFunctionalExtensions.With` extension methods, which offer flexible means for constructing `OpenXmlElement` instances in the context of pure functional transformations.
 
 ### Fixed
-- Ensures attributes are available when `OpenXmlElement` is initialized with outer XML (#684)
+- Ensures attributes are available when `OpenXmlElement` is initialized with outer XML (#684, #692)
 - Some documentation errors (#681)
 - Removed state that made it non-threadsafe to validate elements under certain conditions (#686)
 - Correctly inserts strongly-typed elements before known elements that are not strongly-typed (#690)

--- a/src/DocumentFormat.OpenXml/OpenXmlElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlElement.cs
@@ -433,6 +433,7 @@ namespace DocumentFormat.OpenXml
                 if (!string.IsNullOrEmpty(value))
                 {
                     RawOuterXml = value;
+                    MakeSureParsed();
                 }
                 else
                 {
@@ -1722,6 +1723,13 @@ namespace DocumentFormat.OpenXml
             {
                 // move the reader to the start of the element.
                 xmlReader.Read();
+
+                // Skip any whitespace
+                while (xmlReader.NodeType == XmlNodeType.Whitespace)
+                {
+                    xmlReader.Skip();
+                }
+
                 Populate(xmlReader, OpenXmlElementContext?.LoadMode ?? OpenXmlLoadMode.Full);
             }
         }

--- a/src/DocumentFormat.OpenXml/OpenXmlMiscNode.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlMiscNode.cs
@@ -226,7 +226,7 @@ namespace DocumentFormat.OpenXml
         {
             return new OpenXmlMiscNode(XmlNodeType)
             {
-                OuterXml = OuterXml,
+                RawOuterXml = OuterXml,
             };
         }
 

--- a/test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlElementTest.cs
+++ b/test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlElementTest.cs
@@ -292,7 +292,7 @@ namespace DocumentFormat.OpenXml.Tests
             Assert.Equal(run1Text + run2Text, p.InnerText);
 
             var unknownElement = OpenXmlUnknownElement.CreateOpenXmlUnknownElement(paragraphOuterXml);
-            Assert.Equal(paragraphOuterXml, unknownElement.OuterXml);
+            Assert.Equal(paragraphOuterXml2, unknownElement.OuterXml);
             Assert.Equal(paragraphInnerXml, unknownElement.InnerXml);
         }
 
@@ -664,13 +664,15 @@ namespace DocumentFormat.OpenXml.Tests
         {
             // Valid outer xml
             var validOuterXml = "<myElement  xmlns=\"http://schemas.microsoft.com/office/2006/01/customui\"></myElement>";
+            var actualOuterXml = "<myElement xmlns=\"http://schemas.microsoft.com/office/2006/01/customui\" />";
             var unknown1 = OpenXmlUnknownElement.CreateOpenXmlUnknownElement(validOuterXml);
-            Assert.Equal(validOuterXml, unknown1.OuterXml);
+            Assert.Equal(actualOuterXml, unknown1.OuterXml);
 
             // Valid outer xml but starting with whitespace.
             var validOuterXmlWithWhitespaces = "   <myElement  xmlns=\"http://schemas.microsoft.com/office/2006/01/customui\"></myElement>";
+            var actualValidOuterXmlWithWhitespaces = "<myElement xmlns=\"http://schemas.microsoft.com/office/2006/01/customui\" />";
             var unknown2 = OpenXmlUnknownElement.CreateOpenXmlUnknownElement(validOuterXmlWithWhitespaces);
-            Assert.Equal(validOuterXmlWithWhitespaces, unknown2.OuterXml);
+            Assert.Equal(actualValidOuterXmlWithWhitespaces, unknown2.OuterXml);
 
             // Check bug #484153.
             var outerXmlWithXmlDecl = "<?xml version=\"1.0\" encoding=\"utf-8\"?><customUI  xmlns=\"http://schemas.microsoft.com/office/2006/01/customui\"></customUI>";
@@ -998,10 +1000,19 @@ namespace DocumentFormat.OpenXml.Tests
         }
 
         [Fact]
-        public void AttributesAvaialbleWhenInitializedWithOuterXml()
+        public void AttributesAvailableWhenInitializedWithOuterXml()
         {
             var style1 = new Style { StyleId = new StringValue("1") };
             var style2 = new Style(style1.OuterXml);
+
+            Assert.Equal(style1.StyleId, style2.StyleId);
+        }
+
+        [Fact]
+        public void AttributesAvailableWhenOuterXmlUpdated()
+        {
+            var style1 = new Style { StyleId = new StringValue("1") };
+            var style2 = new Style { OuterXml = style1.OuterXml };
 
             Assert.Equal(style1.StyleId, style2.StyleId);
         }


### PR DESCRIPTION
Continues #684 for the `OuterXml` property as well as the constructor.