### PR TITLE
Add Obsolete to OpenXmlAttribute setters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added `OpenXmlElementFunctionalExtensions.With` extension methods, which offer flexible means for constructing `OpenXmlElement` instances in the context of pure functional transformations.
 
+### Changes
+- Marked the property setters in `OpenXmlAttribute` as obsolete as structs should not have mutable state (#698)
+
 ## Version 2.10.1 - 2020-02-28
 ### Fixed
 - Ensures attributes are available when `OpenXmlElement` is initialized with outer XML (#684, #692)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -120,7 +120,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)\rules.ruleset</CodeAnalysisRuleSet>
 
     <!-- Signing -->

--- a/samples/IsolatedStorageExceptionWorkaround/IsolatedStorageExceptionWorkaround.csproj
+++ b/samples/IsolatedStorageExceptionWorkaround/IsolatedStorageExceptionWorkaround.csproj
@@ -14,14 +14,14 @@
       </ItemGroup>
     </When>
     <Otherwise>
-      <ItemGroup >
+      <ItemGroup>
         <Compile Remove="Program.cs" />
       </ItemGroup>
     </Otherwise>
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.9.1" />
+    <ProjectReference Include="..\..\src\DocumentFormat.OpenXml\DocumentFormat.OpenXml.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/DocumentFormat.OpenXml/OpenXmlAttribute.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlAttribute.cs
@@ -13,6 +13,8 @@ namespace DocumentFormat.OpenXml
     /// </summary>
     public struct OpenXmlAttribute : IEquatable<OpenXmlAttribute>
     {
+        private const string ObsoleteMessage = "OpenXmlAttribute is a struct so setters may not behave as you might expect. Mutable setters will be removed in a future version.";
+
         private string _namespaceUri;
 
         internal OpenXmlAttribute(in ElementPropertyCollection<OpenXmlSimpleType>.PropertyEntry entry)
@@ -37,9 +39,11 @@ namespace DocumentFormat.OpenXml
 
             OpenXmlElement.SplitName(qualifiedName, out var prefix, out var localName);
 
+#pragma warning disable CS0618 // Type or member is obsolete
             Prefix = prefix;
             LocalName = localName;
             Value = value;
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         /// <summary>
@@ -56,10 +60,12 @@ namespace DocumentFormat.OpenXml
                 throw new ArgumentNullException(nameof(localName));
             }
 
+#pragma warning disable CS0618 // Type or member is obsolete
             _namespaceUri = namespaceUri;
             LocalName = localName;
             Prefix = prefix;
             Value = value;
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         /// <summary>
@@ -68,23 +74,39 @@ namespace DocumentFormat.OpenXml
         public string NamespaceUri
         {
             get => _namespaceUri ?? string.Empty;
+            [Obsolete(ObsoleteMessage)]
             set => _namespaceUri = value;
         }
 
         /// <summary>
         /// Gets or sets the local name of the attribute.
         /// </summary>
-        public string LocalName { get; set; }
+        public string LocalName
+        {
+            get;
+            [Obsolete(ObsoleteMessage)]
+            set;
+        }
 
         /// <summary>
         /// Gets or sets the namespace prefix of the current attribute.
         /// </summary>
-        public string Prefix { get; set; }
+        public string Prefix
+        {
+            get;
+            [Obsolete(ObsoleteMessage)]
+            set;
+        }
 
         /// <summary>
         /// Gets or sets the text value of the attribute.
         /// </summary>
-        public string Value { get; set; }
+        public string Value
+        {
+            get;
+            [Obsolete(ObsoleteMessage)]
+            set;
+        }
 
         /// <summary>
         /// Gets the qualified name of the attribute.

--- a/test/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/OpenXmlCompositeElementTestClass.cs
+++ b/test/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/OpenXmlCompositeElementTestClass.cs
@@ -587,13 +587,15 @@ namespace DocumentFormat.OpenXml.Tests
             Log.VerifyFalse(object.ReferenceEquals(oxaX, oxaY), "The assigned OpenXmlAttribute variable IS reference equal to original one.");
 
             Log.Comment("Constructing OpenXmlAttribute w:rsidR and assigning it to another variable...");
-            var wrsidR = new OpenXmlAttribute { NamespaceUri = "http://schemas.openxmlformats.org/wordprocessingml/2006/main", Prefix = "w", LocalName = "rsidR", Value = "00B327F7" };
+            var wrsidR = new OpenXmlAttribute("w", "rsidR", "http://schemas.openxmlformats.org/wordprocessingml/2006/main", "00B327F7");
             var wrsidP = wrsidR;
             Log.VerifyTrue(wrsidP == wrsidR, "The assigned OpenXmlAttribute variable is NOT equal to original one.");
             Log.VerifyFalse(object.ReferenceEquals(wrsidP, wrsidR), "The assigned OpenXmlAttribute variable IS reference equal to original one.");
 
+#pragma warning disable CS0618 // Type or member is obsolete
             wrsidP.LocalName = "rsidP";
             wrsidP.Value = "00EC35BB";
+#pragma warning restore CS0618 // Type or member is obsolete
             Log.Comment("Assigned new LocalName: {0} with ByValue: {1} and comparing it with original w:rsidR", wrsidP.LocalName, wrsidP.Value);
             Log.VerifyFalse(wrsidP == wrsidR, "The assigned OpenXmlAttribute variable IS equal to original one.");
             Log.VerifyFalse(object.ReferenceEquals(wrsidP, wrsidR), "The assigned OpenXmlAttribute variable IS reference equal to original one.");
@@ -608,16 +610,16 @@ namespace DocumentFormat.OpenXml.Tests
             Log.VerifyTrue(defaultA == defaultB, "Two default OpenXmlAttribute are NOT equal.");
             Log.VerifyFalse(defaultA != defaultB, "Two default OpenXmlAttribute are Equal.");
 
-            var wrsidRA = new OpenXmlAttribute { NamespaceUri = "http://schemas.openxmlformats.org/wordprocessingml/2006/main", Prefix = "w", LocalName = "rsidR", Value = "00B327F7" };
-            var wrsidRB = new OpenXmlAttribute { NamespaceUri = "http://schemas.openxmlformats.org/wordprocessingml/2006/main", Prefix = "w", LocalName = "rsidR", Value = "00B327F7" };
+            var wrsidRA = new OpenXmlAttribute("w", "rsidR", "http://schemas.openxmlformats.org/wordprocessingml/2006/main", "00B327F7");
+            var wrsidRB = new OpenXmlAttribute("w", "rsidR", "http://schemas.openxmlformats.org/wordprocessingml/2006/main", "00B327F7");
             Log.Comment("Comparing two {0} OpenXmlAttribute with value {1}...", wrsidRA.GetFullName(), wrsidRA.Value);
             Log.Comment("HashCode for {0}: {1}", wrsidRA.XmlQualifiedName, wrsidRA.GetHashCode());
             Log.VerifyTrue(wrsidRA == wrsidRB, "Two OpenXmlAttribute with same leftBorders are NOT equal by ==.");
             Log.VerifyTrue(wrsidRA.Equals((object)wrsidRB), "Two OpenXmlAttribute with same leftBorders are NOT equal by Equals().");
             Log.VerifyFalse(wrsidRA != wrsidRB, "Two OpenXmlAttribute with fame leftBorders are NOT equal by !=.");
 
-            var wrsidR = new OpenXmlAttribute { NamespaceUri = "http://schemas.openxmlformats.org/wordprocessingml/2006/main", Prefix = "w", LocalName = "rsidR", Value = "00B327F7" };
-            var wrsidP = new OpenXmlAttribute { NamespaceUri = "http://schemas.openxmlformats.org/wordprocessingml/2006/main", Prefix = "w", LocalName = "rsidP", Value = "00EC35BB" };
+            var wrsidR = new OpenXmlAttribute("w", "rsidR", "http://schemas.openxmlformats.org/wordprocessingml/2006/main", "00B327F7");
+            var wrsidP = new OpenXmlAttribute("w", "rsidP", "http://schemas.openxmlformats.org/wordprocessingml/2006/main", "00EC35BB");
             Log.Comment("HashCode for {0}: {1}", wrsidR.XmlQualifiedName, wrsidR.GetHashCode());
             Log.Comment("HashCode for {0}: {1}", wrsidP.XmlQualifiedName, wrsidP.GetHashCode());
             Log.Comment("Comparing two different OpenXmlAttribute with different value...");

--- a/test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlElementTest.cs
+++ b/test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlElementTest.cs
@@ -440,6 +440,7 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void OpenXmlAttributeTest()
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             var target = new OpenXmlAttribute("test", "http://test", "test", "value");
             var other = new OpenXmlAttribute("test", "http://test", "test", "value");
 
@@ -480,6 +481,7 @@ namespace DocumentFormat.OpenXml.Tests
             Assert.False(target.Equals((object)other));
             Assert.False(Equals(target, other));
             Assert.NotEqual(target.GetHashCode(), other.GetHashCode());
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         /// <summary>


### PR DESCRIPTION
This change takes advantage of a C# 8.0 features that allows obsolete messages for setters independent of the getter. Since `OpenXmlAttribute` is an attribute, we should remove the setters from it so the attribute becomes immutable. That's a breaking change, so we'll mark it as obsolete, and the next major version will remove it.