### PR TITLE
Add gfxdata attribute 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `OpenXmlElementFunctionalExtensions.With(...)` extension methods, which offer flexible means for constructing `OpenXmlElement` instances in the context of pure functional transformations (#679)
 - Added minimum Office versions for enum types and values (#707).
 - Added additional `CompatSettingNameValues` values: `UseWord2013TrackBottomHyphenation`, `AllowHyphenationAtTrackBottom`, and `AllowTextAfterFloatingTableBreak` (#706).
-- Added gfxdata attribue to Arc, Curve, Line, PolyLine, Group, Image, Oval, Rect, and RoundRect shape complex types per MS-OI29500 2.1.1783-1799 ($709)
+- Added gfxdata attribue to Arc, Curve, Line, PolyLine, Group, Image, Oval, Rect, and RoundRect shape complex types per MS-OI29500 2.1.1783-1799 (#709)
 
 ### Changes
 - Marked the property setters in `OpenXmlAttribute` as obsolete as structs should not have mutable state (#698)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `OpenXmlElementFunctionalExtensions.With(...)` extension methods, which offer flexible means for constructing `OpenXmlElement` instances in the context of pure functional transformations (#679)
 - Added minimum Office versions for enum types and values (#707).
 - Added additional `CompatSettingNameValues` values: `UseWord2013TrackBottomHyphenation`, `AllowHyphenationAtTrackBottom`, and `AllowTextAfterFloatingTableBreak` (#706).
+- Added gfxdata attribue to Arc, Curve, Line, PolyLine, Group, Image, Oval, Rect, and RoundRect shape complex types per MS-OI29500 2.1.1783-1799 ($709)
 
 ### Changes
 - Marked the property setters in `OpenXmlAttribute` as obsolete as structs should not have mutable state (#698)

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas-microsoft-com_vml.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas-microsoft-com_vml.g.cs
@@ -3169,11 +3169,22 @@ namespace DocumentFormat.OpenXml.Vml
         public EnumValue<DocumentFormat.OpenXml.Vml.Office.InsetMarginValues> InsetMode { get; set; }
 
         /// <summary>
+        /// <para>Encoded Package</para>
+        /// <para>Represents the following attribute in the schema: o:gfxdata</para>
+        /// </summary>
+        /// <remark>
+        /// xmlns:o=urn:schemas-microsoft-com:office:office
+        /// </remark>
+        [SchemaAttr(27, "gfxdata")]
+        [Index(30)]
+        public Base64BinaryValue Gfxdata { get; set; }
+
+        /// <summary>
         /// <para>Group Diagram Type</para>
         /// <para>Represents the following attribute in the schema: editas</para>
         /// </summary>
         [SchemaAttr(0, "editas")]
-        [Index(30)]
+        [Index(31)]
         public EnumValue<DocumentFormat.OpenXml.Vml.EditAsValues> EditAs { get; set; }
 
         /// <summary>
@@ -3184,7 +3195,7 @@ namespace DocumentFormat.OpenXml.Vml
         /// xmlns:o=urn:schemas-microsoft-com:office:office
         /// </remark>
         [SchemaAttr(27, "tableproperties")]
-        [Index(31)]
+        [Index(32)]
         public StringValue TableProperties { get; set; }
 
         /// <summary>
@@ -3195,7 +3206,7 @@ namespace DocumentFormat.OpenXml.Vml
         /// xmlns:o=urn:schemas-microsoft-com:office:office
         /// </remark>
         [SchemaAttr(27, "tablelimits")]
-        [Index(32)]
+        [Index(33)]
         public StringValue TableLimits { get; set; }
 
         private static readonly CompiledParticle _constraint = new CompositeParticle(ParticleType.Choice, 1, 0)
@@ -3880,12 +3891,23 @@ namespace DocumentFormat.OpenXml.Vml
         public TrueFalseValue Clip { get; set; }
 
         /// <summary>
+        /// <para>Encoded Package</para>
+        /// <para>Represents the following attribute in the schema: o:gfxdata</para>
+        /// </summary>
+        /// <remark>
+        /// xmlns:o=urn:schemas-microsoft-com:office:office
+        /// </remark>
+        [SchemaAttr(27, "gfxdata")]
+        [Index(40)]
+        public Base64BinaryValue Gfxdata { get; set; }
+
+        /// <summary>
         /// <para>Unique Identifier</para>
         /// <para>Represents the following attribute in the schema: id</para>
         /// </summary>
         [StringValidator(IsToken = true, MaxLength = 255L)]
         [SchemaAttr(0, "id")]
-        [Index(40)]
+        [Index(41)]
         public StringValue Id { get; set; }
 
         /// <summary>
@@ -3893,7 +3915,7 @@ namespace DocumentFormat.OpenXml.Vml
         /// <para>Represents the following attribute in the schema: style</para>
         /// </summary>
         [SchemaAttr(0, "style")]
-        [Index(41)]
+        [Index(42)]
         public StringValue Style { get; set; }
 
         /// <summary>
@@ -3901,7 +3923,7 @@ namespace DocumentFormat.OpenXml.Vml
         /// <para>Represents the following attribute in the schema: href</para>
         /// </summary>
         [SchemaAttr(0, "href")]
-        [Index(42)]
+        [Index(43)]
         public StringValue Href { get; set; }
 
         /// <summary>
@@ -3909,7 +3931,7 @@ namespace DocumentFormat.OpenXml.Vml
         /// <para>Represents the following attribute in the schema: target</para>
         /// </summary>
         [SchemaAttr(0, "target")]
-        [Index(43)]
+        [Index(44)]
         public StringValue Target { get; set; }
 
         /// <summary>
@@ -3917,7 +3939,7 @@ namespace DocumentFormat.OpenXml.Vml
         /// <para>Represents the following attribute in the schema: title</para>
         /// </summary>
         [SchemaAttr(0, "title")]
-        [Index(44)]
+        [Index(45)]
         public StringValue Title { get; set; }
 
         /// <summary>
@@ -3925,7 +3947,7 @@ namespace DocumentFormat.OpenXml.Vml
         /// <para>Represents the following attribute in the schema: alt</para>
         /// </summary>
         [SchemaAttr(0, "alt")]
-        [Index(45)]
+        [Index(46)]
         public StringValue Alternate { get; set; }
 
         /// <summary>
@@ -3933,7 +3955,7 @@ namespace DocumentFormat.OpenXml.Vml
         /// <para>Represents the following attribute in the schema: coordsize</para>
         /// </summary>
         [SchemaAttr(0, "coordsize")]
-        [Index(46)]
+        [Index(47)]
         public StringValue CoordinateSize { get; set; }
 
         /// <summary>
@@ -3941,7 +3963,7 @@ namespace DocumentFormat.OpenXml.Vml
         /// <para>Represents the following attribute in the schema: coordorigin</para>
         /// </summary>
         [SchemaAttr(0, "coordorigin")]
-        [Index(47)]
+        [Index(48)]
         public StringValue CoordinateOrigin { get; set; }
 
         /// <summary>
@@ -3949,7 +3971,7 @@ namespace DocumentFormat.OpenXml.Vml
         /// <para>Represents the following attribute in the schema: wrapcoords</para>
         /// </summary>
         [SchemaAttr(0, "wrapcoords")]
-        [Index(48)]
+        [Index(49)]
         public StringValue Wrapcoords { get; set; }
 
         /// <summary>
@@ -3957,7 +3979,7 @@ namespace DocumentFormat.OpenXml.Vml
         /// <para>Represents the following attribute in the schema: print</para>
         /// </summary>
         [SchemaAttr(0, "print")]
-        [Index(49)]
+        [Index(50)]
         public TrueFalseValue Print { get; set; }
 
         /// <summary>
@@ -3965,7 +3987,7 @@ namespace DocumentFormat.OpenXml.Vml
         /// <para>Represents the following attribute in the schema: startangle</para>
         /// </summary>
         [SchemaAttr(0, "startangle")]
-        [Index(50)]
+        [Index(51)]
         public DecimalValue StartAngle { get; set; }
 
         /// <summary>
@@ -3973,7 +3995,7 @@ namespace DocumentFormat.OpenXml.Vml
         /// <para>Represents the following attribute in the schema: endangle</para>
         /// </summary>
         [SchemaAttr(0, "endangle")]
-        [Index(51)]
+        [Index(52)]
         public DecimalValue EndAngle { get; set; }
 
         private static readonly CompiledParticle _constraint = new CompositeParticle(ParticleType.Sequence, 1, 1)
@@ -4618,11 +4640,22 @@ namespace DocumentFormat.OpenXml.Vml
         public TrueFalseValue Clip { get; set; }
 
         /// <summary>
+        /// <para>Encoded Package</para>
+        /// <para>Represents the following attribute in the schema: o:gfxdata</para>
+        /// </summary>
+        /// <remark>
+        /// xmlns:o=urn:schemas-microsoft-com:office:office
+        /// </remark>
+        [SchemaAttr(27, "gfxdata")]
+        [Index(51)]
+        public Base64BinaryValue Gfxdata { get; set; }
+
+        /// <summary>
         /// <para>Curve Starting Point</para>
         /// <para>Represents the following attribute in the schema: from</para>
         /// </summary>
         [SchemaAttr(0, "from")]
-        [Index(51)]
+        [Index(52)]
         public StringValue From { get; set; }
 
         /// <summary>
@@ -4630,7 +4663,7 @@ namespace DocumentFormat.OpenXml.Vml
         /// <para>Represents the following attribute in the schema: control1</para>
         /// </summary>
         [SchemaAttr(0, "control1")]
-        [Index(52)]
+        [Index(53)]
         public StringValue Control1 { get; set; }
 
         /// <summary>
@@ -4638,7 +4671,7 @@ namespace DocumentFormat.OpenXml.Vml
         /// <para>Represents the following attribute in the schema: control2</para>
         /// </summary>
         [SchemaAttr(0, "control2")]
-        [Index(53)]
+        [Index(54)]
         public StringValue Control2 { get; set; }
 
         /// <summary>
@@ -4646,7 +4679,7 @@ namespace DocumentFormat.OpenXml.Vml
         /// <para>Represents the following attribute in the schema: to</para>
         /// </summary>
         [SchemaAttr(0, "to")]
-        [Index(54)]
+        [Index(55)]
         public StringValue To { get; set; }
 
         private static readonly CompiledParticle _constraint = new CompositeParticle(ParticleType.Sequence, 1, 1)
@@ -5362,6 +5395,17 @@ namespace DocumentFormat.OpenXml.Vml
         [Index(59)]
         public TrueFalseValue BiLevel { get; set; }
 
+        /// <summary>
+        /// <para>Encoded Package</para>
+        /// <para>Represents the following attribute in the schema: o:gfxdata</para>
+        /// </summary>
+        /// <remark>
+        /// xmlns:o=urn:schemas-microsoft-com:office:office
+        /// </remark>
+        [SchemaAttr(27, "gfxdata")]
+        [Index(60)]
+        public Base64BinaryValue Gfxdata { get; set; }
+
         private static readonly CompiledParticle _constraint = new CompositeParticle(ParticleType.Sequence, 1, 1)
         {
             new CompositeParticle(ParticleType.Group, 0, 0)
@@ -6004,11 +6048,22 @@ namespace DocumentFormat.OpenXml.Vml
         public TrueFalseValue Clip { get; set; }
 
         /// <summary>
+        /// <para>Encoded Package</para>
+        /// <para>Represents the following attribute in the schema: o:gfxdata</para>
+        /// </summary>
+        /// <remark>
+        /// xmlns:o=urn:schemas-microsoft-com:office:office
+        /// </remark>
+        [SchemaAttr(27, "gfxdata")]
+        [Index(51)]
+        public Base64BinaryValue Gfxdata { get; set; }
+
+        /// <summary>
         /// <para>Line Start</para>
         /// <para>Represents the following attribute in the schema: from</para>
         /// </summary>
         [SchemaAttr(0, "from")]
-        [Index(51)]
+        [Index(52)]
         public StringValue From { get; set; }
 
         /// <summary>
@@ -6016,7 +6071,7 @@ namespace DocumentFormat.OpenXml.Vml
         /// <para>Represents the following attribute in the schema: to</para>
         /// </summary>
         [SchemaAttr(0, "to")]
-        [Index(52)]
+        [Index(53)]
         public StringValue To { get; set; }
 
         private static readonly CompiledParticle _constraint = new CompositeParticle(ParticleType.Sequence, 1, 1)
@@ -6659,6 +6714,17 @@ namespace DocumentFormat.OpenXml.Vml
         [SchemaAttr(27, "clip")]
         [Index(50)]
         public TrueFalseValue Clip { get; set; }
+
+        /// <summary>
+        /// <para>Encoded Package</para>
+        /// <para>Represents the following attribute in the schema: o:gfxdata</para>
+        /// </summary>
+        /// <remark>
+        /// xmlns:o=urn:schemas-microsoft-com:office:office
+        /// </remark>
+        [SchemaAttr(27, "gfxdata")]
+        [Index(51)]
+        public Base64BinaryValue Gfxdata { get; set; }
 
         private static readonly CompiledParticle _constraint = new CompositeParticle(ParticleType.Choice, 1, 0)
         {
@@ -7304,11 +7370,22 @@ namespace DocumentFormat.OpenXml.Vml
         public TrueFalseValue Clip { get; set; }
 
         /// <summary>
+        /// <para>Encoded Package</para>
+        /// <para>Represents the following attribute in the schema: o:gfxdata</para>
+        /// </summary>
+        /// <remark>
+        /// xmlns:o=urn:schemas-microsoft-com:office:office
+        /// </remark>
+        [SchemaAttr(27, "gfxdata")]
+        [Index(51)]
+        public Base64BinaryValue Gfxdata { get; set; }
+
+        /// <summary>
         /// <para>Points for Compound Line</para>
         /// <para>Represents the following attribute in the schema: points</para>
         /// </summary>
         [SchemaAttr(0, "points")]
-        [Index(51)]
+        [Index(52)]
         public StringValue Points { get; set; }
 
         private static readonly CompiledParticle _constraint = new CompositeParticle(ParticleType.Choice, 0, 0)
@@ -7953,6 +8030,17 @@ namespace DocumentFormat.OpenXml.Vml
         [Index(50)]
         public TrueFalseValue Clip { get; set; }
 
+        /// <summary>
+        /// <para>Encoded Package</para>
+        /// <para>Represents the following attribute in the schema: o:gfxdata</para>
+        /// </summary>
+        /// <remark>
+        /// xmlns:o=urn:schemas-microsoft-com:office:office
+        /// </remark>
+        [SchemaAttr(27, "gfxdata")]
+        [Index(51)]
+        public Base64BinaryValue Gfxdata { get; set; }
+
         private static readonly CompiledParticle _constraint = new CompositeParticle(ParticleType.Choice, 1, 0)
         {
             new CompositeParticle(ParticleType.Group, 0, 0)
@@ -8587,11 +8675,22 @@ namespace DocumentFormat.OpenXml.Vml
         public TrueFalseValue Clip { get; set; }
 
         /// <summary>
+        /// <para>Encoded Package</para>
+        /// <para>Represents the following attribute in the schema: o:gfxdata</para>
+        /// </summary>
+        /// <remark>
+        /// xmlns:o=urn:schemas-microsoft-com:office:office
+        /// </remark>
+        [SchemaAttr(27, "gfxdata")]
+        [Index(50)]
+        public Base64BinaryValue Gfxdata { get; set; }
+
+        /// <summary>
         /// <para>Rounded Corner Arc Size</para>
         /// <para>Represents the following attribute in the schema: arcsize</para>
         /// </summary>
         [SchemaAttr(0, "arcsize")]
-        [Index(50)]
+        [Index(51)]
         public StringValue ArcSize { get; set; }
 
         private static readonly CompiledParticle _constraint = new CompositeParticle(ParticleType.Choice, 1, 0)

--- a/test/DocumentFormat.OpenXml.Tests/TestDocx01.cs
+++ b/test/DocumentFormat.OpenXml.Tests/TestDocx01.cs
@@ -304,7 +304,7 @@ namespace DocumentFormat.OpenXml.Tests
 
                 var v = new OpenXmlValidator(FileFormatVersions.Office2013);
 
-                Assert.Equal(2, v.Validate(doc).Count());
+                Assert.Single(v.Validate(doc));
             }
         }
 
@@ -318,7 +318,7 @@ namespace DocumentFormat.OpenXml.Tests
                 var cnt = doc.MainDocumentPart.Document.Descendants().Count();
                 var v = new OpenXmlValidator(FileFormatVersions.Office2013);
 
-                Assert.Equal(2, v.Validate(doc).Count());
+                Assert.Single(v.Validate(doc));
             }
         }
 
@@ -340,7 +340,7 @@ namespace DocumentFormat.OpenXml.Tests
 
                     var v = new OpenXmlValidator(FileFormatVersions.Office2013);
 
-                    Assert.Equal(36, v.Validate(doc).Count());
+                    Assert.Equal(35, v.Validate(doc).Count());
                 }
             }
         }
@@ -453,7 +453,7 @@ namespace DocumentFormat.OpenXml.Tests
 
                 var v = new OpenXmlValidator(FileFormatVersions.Office2013);
 
-                Assert.Equal(2, v.Validate(doc).Count());
+                Assert.Single(v.Validate(doc));
             }
         }
 
@@ -476,7 +476,7 @@ namespace DocumentFormat.OpenXml.Tests
 
                 var v = new OpenXmlValidator(FileFormatVersions.Office2013);
 
-                Assert.Equal(2, v.Validate(doc).Count());
+                Assert.Single(v.Validate(doc));
             }
         }
 
@@ -493,7 +493,7 @@ namespace DocumentFormat.OpenXml.Tests
 
                 var v = new OpenXmlValidator(FileFormatVersions.Office2013);
 
-                Assert.Equal(3, v.Validate(doc).Count());
+                Assert.Equal(2, v.Validate(doc).Count());
             }
         }
 
@@ -556,7 +556,7 @@ namespace DocumentFormat.OpenXml.Tests
 
                 var v = new OpenXmlValidator(FileFormatVersions.Office2013);
 
-                Assert.Equal(2, v.Validate(doc).Count());
+                Assert.Single(v.Validate(doc));
             }
         }
 
@@ -573,7 +573,7 @@ namespace DocumentFormat.OpenXml.Tests
 
                 var v = new OpenXmlValidator(FileFormatVersions.Office2013);
 
-                Assert.Equal(2, v.Validate(doc).Count());
+                Assert.Single(v.Validate(doc));
             }
         }
 
@@ -588,7 +588,7 @@ namespace DocumentFormat.OpenXml.Tests
                 var p = firstPara.LookupPrefix("http://schemas.openxmlformats.org/wordprocessingml/2006/main");
                 var v = new OpenXmlValidator(FileFormatVersions.Office2013);
 
-                Assert.Equal(2, v.Validate(doc).Count());
+                Assert.Single(v.Validate(doc));
             }
         }
 
@@ -603,7 +603,7 @@ namespace DocumentFormat.OpenXml.Tests
                 var ns = firstPara.NamespaceDeclarations;
                 var v = new OpenXmlValidator(FileFormatVersions.Office2013);
 
-                Assert.Equal(2, v.Validate(doc).Count());
+                Assert.Single(v.Validate(doc));
             }
         }
 
@@ -619,7 +619,7 @@ namespace DocumentFormat.OpenXml.Tests
                 var s2 = firstPara.InnerText;
                 var v = new OpenXmlValidator(FileFormatVersions.Office2013);
 
-                Assert.Equal(2, v.Validate(doc).Count());
+                Assert.Single(v.Validate(doc));
             }
         }
 
@@ -634,7 +634,7 @@ namespace DocumentFormat.OpenXml.Tests
                 var s = firstPara.OuterXml;
                 var v = new OpenXmlValidator(FileFormatVersions.Office2013);
 
-                Assert.Equal(2, v.Validate(doc).Count());
+                Assert.Single(v.Validate(doc));
             }
         }
 
@@ -653,7 +653,7 @@ namespace DocumentFormat.OpenXml.Tests
 
                 var v = new OpenXmlValidator(FileFormatVersions.Office2013);
 
-                Assert.Equal(2, v.Validate(doc).Count());
+                Assert.Single(v.Validate(doc));
             }
         }
 
@@ -676,7 +676,7 @@ namespace DocumentFormat.OpenXml.Tests
 
                 var v = new OpenXmlValidator(FileFormatVersions.Office2013);
 
-                Assert.Equal(2, v.Validate(doc).Count());
+                Assert.Single(v.Validate(doc));
             }
         }
 
@@ -692,7 +692,7 @@ namespace DocumentFormat.OpenXml.Tests
 
                 var v = new OpenXmlValidator(FileFormatVersions.Office2013);
 
-                Assert.Equal(2, v.Validate(doc).Count());
+                Assert.Single(v.Validate(doc));
             }
         }
 
@@ -714,7 +714,7 @@ namespace DocumentFormat.OpenXml.Tests
 
                 var v = new OpenXmlValidator(FileFormatVersions.Office2013);
 
-                Assert.Equal(2, v.Validate(doc).Count());
+                Assert.Single(v.Validate(doc));
             }
         }
 
@@ -734,7 +734,7 @@ namespace DocumentFormat.OpenXml.Tests
 
                 var v = new OpenXmlValidator(FileFormatVersions.Office2013);
 
-                Assert.Equal(2, v.Validate(doc).Count());
+                Assert.Single(v.Validate(doc));
             }
         }
 
@@ -756,7 +756,7 @@ namespace DocumentFormat.OpenXml.Tests
                 var errs = v.Validate(doc);
                 var cnt = errs.Count();
 
-                Assert.Equal(2, v.Validate(doc).Count());
+                Assert.Equal(1, v.Validate(doc).Count());
             }
         }
 
@@ -1074,9 +1074,9 @@ namespace DocumentFormat.OpenXml.Tests
         }
 
         [Theory]
-        [InlineData(FileFormatVersions.Office2007, 416)]
+        [InlineData(FileFormatVersions.Office2007, 415)]
         [InlineData(FileFormatVersions.Office2010, 0)]
-        [InlineData(FileFormatVersions.Office2013, 2)]
+        [InlineData(FileFormatVersions.Office2013, 1)]
         public void W003_DocxValidation(FileFormatVersions version, int count)
         {
             using (var stream = GetStream(TestFiles.Document, false))

--- a/test/DocumentFormat.OpenXml.Tests/TestDocx01.cs
+++ b/test/DocumentFormat.OpenXml.Tests/TestDocx01.cs
@@ -756,7 +756,7 @@ namespace DocumentFormat.OpenXml.Tests
                 var errs = v.Validate(doc);
                 var cnt = errs.Count();
 
-                Assert.Equal(1, v.Validate(doc).Count());
+                Assert.Single(v.Validate(doc));
             }
         }
 


### PR DESCRIPTION
add gfxdata attribue to Arc, Curve, Line, PolyLine, Group, Image, Oval, Rect, and RoundRect shape complex types per MS-OI29500 2.1.1783-1799

Fixes #709 