### PR TITLE
Rename StrictTranslation to StrictRelationshipFound and make public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added additional `CompatSettingNameValues` values: `UseWord2013TrackBottomHyphenation`, `AllowHyphenationAtTrackBottom`, and `AllowTextAfterFloatingTableBreak` (#706).
 - Added gfxdata attribue to Arc, Curve, Line, PolyLine, Group, Image, Oval, Rect, and RoundRect shape complex types per MS-OI29500 2.1.1783-1799 (#709)
 - Added `TryGetPartById` in `OpenXmlPartContainer`. This allows try to get the child part by the relationship ID (#714)
+- Added `StrictRelationshipFound` property on `OpenXmlPackage` indicating whether this package contains Transitional relationships converted from Strict. (#716)
 
 ### Changes
 - Marked the property setters in `OpenXmlAttribute` as obsolete as structs should not have mutable state (#698)

--- a/src/DocumentFormat.OpenXml/OpenXmlElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlElement.cs
@@ -1466,13 +1466,13 @@ namespace DocumentFormat.OpenXml
         /// <param name="namespaceUri"></param>
         /// <param name="localName"></param>
         /// <param name="value"></param>
-        /// <param name="strictTranslation"></param>
+        /// <param name="strictRelationshipFound"></param>
         /// <returns>true if the attribute is a known attribute.</returns>
-        private bool TrySetFixedAttribute(string namespaceUri, string localName, string value, bool strictTranslation)
+        private bool TrySetFixedAttribute(string namespaceUri, string localName, string value, bool strictRelationshipFound)
         {
             if (ElementData.RawAttributes.Any())
             {
-                if (strictTranslation)
+                if (strictRelationshipFound)
                 {
                     return StrictTranslateAttribute(namespaceUri, localName, value);
                 }
@@ -1505,7 +1505,7 @@ namespace DocumentFormat.OpenXml
             {
                 while (xmlReader.MoveToNextAttribute())
                 {
-                    if (!TrySetFixedAttribute(xmlReader.NamespaceURI, xmlReader.LocalName, xmlReader.Value, ((XmlConvertingReader)xmlReader).StrictTranslation))
+                    if (!TrySetFixedAttribute(xmlReader.NamespaceURI, xmlReader.LocalName, xmlReader.Value, ((XmlConvertingReader)xmlReader).StrictRelationshipFound))
                     {
                         if (xmlReader.NamespaceURI == AlternateContent.MarkupCompatibilityNamespace)
                         {

--- a/src/DocumentFormat.OpenXml/OpenXmlPartRootElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlPartRootElement.cs
@@ -121,7 +121,7 @@ namespace DocumentFormat.OpenXml
             OpenXmlElementContext.XmlReaderSettings.DtdProcessing = DtdProcessing.Prohibit; // set to prohibit explicitly for security fix
 #endif
 
-            using (XmlReader xmlReader = XmlConvertingReaderFactory.Create(partStream, OpenXmlElementContext.XmlReaderSettings, openXmlPart.OpenXmlPackage.StrictTranslation))
+            using (XmlReader xmlReader = XmlConvertingReaderFactory.Create(partStream, OpenXmlElementContext.XmlReaderSettings, openXmlPart.OpenXmlPackage.StrictRelationshipFound))
             {
                 OpenXmlElementContext.MCSettings = openXmlPart.MCSettings;
 

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
@@ -240,7 +240,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Gets a value indicating whether this package contains Transitional relationships converted from Strict.
         /// </summary>
-        public bool StrictRelationshipFound { get; internal set; } = false;
+        public bool StrictRelationshipFound { get; private set; } = false;
 
         /// <summary>
         /// Gets the package of the document.

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
@@ -181,13 +181,13 @@ namespace DocumentFormat.OpenXml.Packaging
                 bool hasMainPart = false;
                 RelationshipCollection relationshipCollection = new PackageRelationshipPropertyCollection(_package);
 
-                // relationCollection.StrictTranslation is true when this collection contains Transitional relationships converted from Strict.
-                StrictTranslation = relationshipCollection.StrictTranslation;
+                // relationCollection.StrictRelationshipFound is true when this collection contains Transitional relationships converted from Strict.
+                StrictRelationshipFound = relationshipCollection.StrictRelationshipFound;
 
                 // AutoSave must be false when opening ISO Strict doc as editable.
                 // (Attention: #2545529. Now we disable this code until we finally decide to go with this. Instead, we take an alternative approach that is added in the SavePartContents() method
-                // which we ignore AutoSave when this.StrictTranslation is true to keep consistency in the document.)
-                //if (this.StrictTranslation && (this._accessMode == FileAccess.ReadWrite || this._accessMode == FileAccess.Write) && !this.AutoSave)
+                // which we ignore AutoSave when this.StrictRelationshipFound is true to keep consistency in the document.)
+                //if (this.StrictRelationshipFound && (this._accessMode == FileAccess.ReadWrite || this._accessMode == FileAccess.Write) && !this.AutoSave)
                 //{
                 //    OpenXmlPackageException exception = new OpenXmlPackageException(ExceptionMessages.StrictEditNeedsAutoSave);
                 //    throw exception;
@@ -237,7 +237,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
         internal virtual ApplicationType ApplicationType => ApplicationType.None;
 
-        internal bool StrictTranslation { get; set; } = false;
+        internal bool StrictRelationshipFound { get; set; } = false;
 
         /// <summary>
         /// Gets the package of the document.
@@ -698,8 +698,8 @@ namespace DocumentFormat.OpenXml.Packaging
                 return; // do nothing if the package is open in read-only mode.
             }
 
-            // When this.StrictTranslation is true, we ignore the save argument to do the translation if isAnyPartChanged is true. That's the way to keep consistency.
-            if (!save && !StrictTranslation)
+            // When this.StrictRelationshipFound is true, we ignore the save argument to do the translation if isAnyPartChanged is true. That's the way to keep consistency.
+            if (!save && !StrictRelationshipFound)
             {
                 return; // do nothing if saving is false.
             }
@@ -726,7 +726,7 @@ namespace DocumentFormat.OpenXml.Packaging
                     TrySavePartContent(part);
                 }
 
-                if (StrictTranslation)
+                if (StrictRelationshipFound)
                 {
                     RelationshipCollection relationshipCollection;
 
@@ -745,8 +745,8 @@ namespace DocumentFormat.OpenXml.Packaging
             Debug.Assert(part != null);
             Debug.Assert(part.OpenXmlPackage != null);
 
-            // If StrictTranslation is true, we need to update the part anyway.
-            if (part.OpenXmlPackage.StrictTranslation)
+            // If StrictRelationshipFound is true, we need to update the part anyway.
+            if (part.OpenXmlPackage.StrictRelationshipFound)
             {
                 RelationshipCollection relationshipCollection;
 

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
@@ -237,7 +237,10 @@ namespace DocumentFormat.OpenXml.Packaging
 
         internal virtual ApplicationType ApplicationType => ApplicationType.None;
 
-        internal bool StrictRelationshipFound { get; set; } = false;
+        /// <summary>
+        /// Gets a value indicating whether this package contains Transitional relationships converted from Strict.
+        /// </summary>
+        public bool StrictRelationshipFound { get; internal set; } = false;
 
         /// <summary>
         /// Gets the package of the document.

--- a/src/DocumentFormat.OpenXml/Packaging/RelationshipCollection.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/RelationshipCollection.cs
@@ -16,7 +16,7 @@ namespace DocumentFormat.OpenXml.Packaging
     {
         protected PackageRelationshipCollection BasePackageRelationshipCollection { get; set; }
 
-        internal bool StrictTranslation { get; set; }
+        internal bool StrictRelationshipFound { get; set; }
 
         /// <summary>
         /// This method fills the collection with PackageRels from the PackageRelationshipCollection that is given in the sub class.
@@ -36,7 +36,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 if (NamespaceIdMap.TryGetTransitionalRelationship(relationshipProperty.RelationshipType, out var transitionalNamespace))
                 {
                     relationshipProperty.RelationshipType = transitionalNamespace;
-                    StrictTranslation = true;
+                    StrictRelationshipFound = true;
                 }
 
                 Add(relationshipProperty);

--- a/src/DocumentFormat.OpenXml/XmlConvertingReader.cs
+++ b/src/DocumentFormat.OpenXml/XmlConvertingReader.cs
@@ -16,11 +16,11 @@ namespace DocumentFormat.OpenXml
         /// Creates an instance of <see cref="XmlConvertingReader"/>
         /// </summary>
         /// <param name="baseReader">XmlReader</param>
-        /// <param name="strictTranslation">bool</param>
-        public XmlConvertingReader(XmlReader baseReader, bool strictTranslation)
+        /// <param name="strictRelationshipFound">bool</param>
+        public XmlConvertingReader(XmlReader baseReader, bool strictRelationshipFound)
         {
             BaseReader = baseReader ?? throw new ArgumentNullException(nameof(baseReader));
-            StrictTranslation = strictTranslation;
+            StrictRelationshipFound = strictRelationshipFound;
         }
 
         /// <summary>
@@ -31,7 +31,7 @@ namespace DocumentFormat.OpenXml
         /// <summary>
         /// Gets a value indicating whether strict translation is enabled.
         /// </summary>
-        public bool StrictTranslation { get; }
+        public bool StrictRelationshipFound { get; }
 
 #if FEATURE_ABSTRACT_XML_CLOSE
         /// <inheritdoc/>
@@ -166,7 +166,7 @@ namespace DocumentFormat.OpenXml
 
         private string ApplyStrictTranslation(string uri)
         {
-            if (StrictTranslation)
+            if (StrictRelationshipFound)
             {
                 if (NamespaceIdMap.TryGetTransitionalNamespace(uri, out var transitionalNamespace))
                 {

--- a/src/DocumentFormat.OpenXml/XmlConvertingReaderFactory.cs
+++ b/src/DocumentFormat.OpenXml/XmlConvertingReaderFactory.cs
@@ -11,18 +11,18 @@ namespace DocumentFormat.OpenXml
     /// </summary>
     internal static class XmlConvertingReaderFactory
     {
-        // When the strictTranslation flag is 'true', the XmlConvertingReader tries to search the incoming xml stream for any Strict namespace
+        // When the strictRelationshipFound flag is 'true', the XmlConvertingReader tries to search the incoming xml stream for any Strict namespace
         // that can be translated to Transitional. When the flag is 'false', the reader skips searching.
         public static XmlReader Create(Stream partStream, XmlReaderSettings settings)
         {
             return Create(partStream, settings, true);
         }
 
-        public static XmlReader Create(Stream partStream, XmlReaderSettings settings, bool strictTranslation)
+        public static XmlReader Create(Stream partStream, XmlReaderSettings settings, bool strictRelationshipFound)
         {
             XmlReader xmlReader = XmlReader.Create(partStream, settings);
 
-            return new XmlConvertingReader(xmlReader, strictTranslation);
+            return new XmlConvertingReader(xmlReader, strictRelationshipFound);
         }
 
         public static XmlReader Create(TextReader textReader, XmlReaderSettings settings)
@@ -30,11 +30,11 @@ namespace DocumentFormat.OpenXml
             return Create(textReader, settings, true);
         }
 
-        public static XmlReader Create(TextReader textReader, XmlReaderSettings settings, bool strictTranslation)
+        public static XmlReader Create(TextReader textReader, XmlReaderSettings settings, bool strictRelationshipFound)
         {
             XmlReader xmlReader = XmlReader.Create(textReader, settings);
 
-            return new XmlConvertingReader(xmlReader, strictTranslation);
+            return new XmlConvertingReader(xmlReader, strictRelationshipFound);
         }
 
         public static XmlReader Create(TextReader textReader)
@@ -42,11 +42,11 @@ namespace DocumentFormat.OpenXml
             return Create(textReader, true);
         }
 
-        public static XmlReader Create(TextReader textReader, bool strictTranslation)
+        public static XmlReader Create(TextReader textReader, bool strictRelationshipFound)
         {
             XmlReader xmlReader = XmlReader.Create(textReader);
 
-            return new XmlConvertingReader(xmlReader, strictTranslation);
+            return new XmlConvertingReader(xmlReader, strictRelationshipFound);
         }
     }
 }

--- a/test/DocumentFormat.OpenXml.Tests/IsoStrictTest/IsoStrictTest.cs
+++ b/test/DocumentFormat.OpenXml.Tests/IsoStrictTest/IsoStrictTest.cs
@@ -32,7 +32,7 @@ namespace DocumentFormat.OpenXml.Tests
             using (var file = OpenFile(path, false))
             using (var document = file.Open(false))
             {
-                Assert.True(document.StrictTranslation);
+                Assert.True(document.StrictRelationshipFound);
             }
         }
 

--- a/test/DocumentFormat.OpenXml.Tests/XmlConvertingReaderTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/XmlConvertingReaderTests.cs
@@ -26,13 +26,13 @@ namespace DocumentFormat.OpenXml.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void SetsProperties(bool strictTranslation)
+        public void SetsProperties(bool strictRelationshipFound)
         {
             using (var baseReader = Substitute.For<XmlReader>())
-            using (var reader = new AccessBaseReader(baseReader, strictTranslation))
+            using (var reader = new AccessBaseReader(baseReader, strictRelationshipFound))
             {
                 Assert.Same(baseReader, reader.BaseReader);
-                Assert.Equal(strictTranslation, reader.StrictTranslation);
+                Assert.Equal(strictRelationshipFound, reader.StrictRelationshipFound);
             }
         }
 
@@ -40,10 +40,10 @@ namespace DocumentFormat.OpenXml.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void DelegatesCallClose(bool strictTranslation)
+        public void DelegatesCallClose(bool strictRelationshipFound)
         {
             using (var baseReader = Substitute.For<XmlReader>())
-            using (var reader = new XmlConvertingReader(baseReader, strictTranslation))
+            using (var reader = new XmlConvertingReader(baseReader, strictRelationshipFound))
             {
                 reader.Close();
                 baseReader.Received(1).Close();
@@ -54,10 +54,10 @@ namespace DocumentFormat.OpenXml.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void DelegatesCallDispose(bool strictTranslation)
+        public void DelegatesCallDispose(bool strictRelationshipFound)
         {
             using (var baseReader = Substitute.For<XmlReader>())
-            using (var reader = new XmlConvertingReader(baseReader, strictTranslation))
+            using (var reader = new XmlConvertingReader(baseReader, strictRelationshipFound))
             {
                 ((IDisposable)reader).Dispose();
                 ((IDisposable)baseReader).Received(1).Dispose();
@@ -77,10 +77,10 @@ namespace DocumentFormat.OpenXml.Tests
         [InlineData(TranslationalNamespaceExample1, TranslationalNamespaceExample1, false)]
         [InlineData(RandomNamespace, RandomNamespace, false)]
         [InlineData(ExtendedNamespace1, ExtendedNamespace1Result, false)]
-        public void NamespaceUriIsHandled(string baseNamespaceUri, string expectedNamespaceUri, bool strictTranslation)
+        public void NamespaceUriIsHandled(string baseNamespaceUri, string expectedNamespaceUri, bool strictRelationshipFound)
         {
             using (var baseReader = Substitute.For<XmlReader>())
-            using (var reader = new XmlConvertingReader(baseReader, strictTranslation))
+            using (var reader = new XmlConvertingReader(baseReader, strictRelationshipFound))
             {
                 baseReader.NamespaceURI.Returns(baseNamespaceUri);
 
@@ -101,10 +101,10 @@ namespace DocumentFormat.OpenXml.Tests
         [InlineData(RandomNamespace, RandomNamespace, XmlNodeType.Element, false)]
         [InlineData(ExtendedNamespace1, ExtendedNamespace1Result, XmlNodeType.Attribute, false)]
         [InlineData(ExtendedNamespace1, ExtendedNamespace1, XmlNodeType.Element, false)]
-        public void StrictTranslationAppliesToValue(string baseValue, string expectedValue, XmlNodeType nodeType, bool strictTranslation)
+        public void StrictTranslationAppliesToValue(string baseValue, string expectedValue, XmlNodeType nodeType, bool strictRelationshipFound)
         {
             using (var baseReader = Substitute.For<XmlReader>())
-            using (var reader = new XmlConvertingReader(baseReader, strictTranslation))
+            using (var reader = new XmlConvertingReader(baseReader, strictRelationshipFound))
             {
                 baseReader.Value.Returns(baseValue);
                 baseReader.NodeType.Returns(nodeType);
@@ -115,8 +115,8 @@ namespace DocumentFormat.OpenXml.Tests
 
         private class AccessBaseReader : XmlConvertingReader
         {
-            public AccessBaseReader(XmlReader baseReader, bool strictTranslation)
-                : base(baseReader, strictTranslation)
+            public AccessBaseReader(XmlReader baseReader, bool strictRelationshipFound)
+                : base(baseReader, strictRelationshipFound)
             {
             }
 

--- a/test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlPackageTest.cs
+++ b/test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlPackageTest.cs
@@ -813,7 +813,7 @@ namespace DocumentFormat.OpenXml.Tests
                 // Should open without exception.
 
                 // Referencing doc.MainDocumentPart.RootElement triggers to load the MainDocumentPart which underneath
-                // calls methods in XmlConvertingReader with the strictTranslation flag enabled.
+                // calls methods in XmlConvertingReader with the strictRelationshipFound flag enabled.
                 Assert.NotNull(doc.MainDocumentPart.RootElement);
             }
         }
@@ -832,7 +832,7 @@ namespace DocumentFormat.OpenXml.Tests
                 // Should open without exception.
 
                 // Calling doc.PresentationPart.RootElement triggers to load the PresentationPart which underneath
-                // calls methods in XmlConvertingReader with the strictTranslation flag enabled.
+                // calls methods in XmlConvertingReader with the strictRelationshipFound flag enabled.
                 Assert.NotNull(doc.PresentationPart.RootElement);
             }
         }
@@ -851,7 +851,7 @@ namespace DocumentFormat.OpenXml.Tests
                 // Should open without exception.
 
                 // Referencing doc.WorkbookPart.RootElement triggers to load the WorkbookPart which underneath
-                // calls methods in XmlConvertingReader with the strictTranslation flag enabled.
+                // calls methods in XmlConvertingReader with the strictRelationshipFound flag enabled.
                 Assert.NotNull(doc.WorkbookPart.RootElement);
             }
         }


### PR DESCRIPTION
Fixes #711 

This PR firstly renames `StrictTranslation` to `StrictRelationshipFound` and secondly makes the `OpenXmlPackage.StrictRelationshipFound` property public (from internal).

This will provide a hint to subsequent parsers that it may need to support strict mode parsing.