### PR TITLE
Remove attribute base from validators

### DIFF
--- a/src/DocumentFormat.OpenXml/Framework/Metadata/AttributeMetadata.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Metadata/AttributeMetadata.cs
@@ -69,11 +69,11 @@ namespace DocumentFormat.OpenXml.Framework.Metadata
 
                 if (instance is StringValue)
                 {
-                    return StringValidatorAttribute.Instance;
+                    return StringValidator.Instance;
                 }
                 else if (instance.IsEnum || instance is OnOffValue || instance is TrueFalseBlankValue)
                 {
-                    return EnumValidatorAttribute.Instance;
+                    return EnumValidator.Instance;
                 }
                 else if (instance is System.Collections.IEnumerable)
                 {
@@ -81,7 +81,7 @@ namespace DocumentFormat.OpenXml.Framework.Metadata
                 }
                 else
                 {
-                    return NumberValidatorAttribute.Instance;
+                    return NumberValidator.Instance;
                 }
             }
 

--- a/src/DocumentFormat.OpenXml/Framework/Metadata/ValidatorBuilder.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Metadata/ValidatorBuilder.cs
@@ -11,7 +11,7 @@ namespace DocumentFormat.OpenXml.Framework.Metadata
 
         public void AddValidator(IOpenXmlSimpleTypeValidator validator)
         {
-            if (validator is RequiredValidatorAttribute)
+            if (validator is RequiredValidator)
             {
                 _validators.Insert(0, validator);
             }

--- a/src/DocumentFormat.OpenXml/Framework/OfficeAvailabilityAttribute.cs
+++ b/src/DocumentFormat.OpenXml/Framework/OfficeAvailabilityAttribute.cs
@@ -11,7 +11,7 @@ namespace DocumentFormat.OpenXml
     /// Defines an OfficeAvailabilityAttribute class to indicate whether the property is available in a specific version of an Office application.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class | AttributeTargets.Field | AttributeTargets.Enum)]
-    public sealed class OfficeAvailabilityAttribute : Attribute, IOpenXmlSimpleTypeValidator
+    public sealed class OfficeAvailabilityAttribute : Attribute
     {
         /// <summary>
         /// Gets the Office version of the available property.
@@ -26,19 +26,6 @@ namespace DocumentFormat.OpenXml
         public OfficeAvailabilityAttribute(FileFormatVersions officeVersion)
         {
             OfficeVersion = officeVersion;
-        }
-
-        void IOpenXmlSimpleTypeValidator.Validate(ValidationContext context)
-        {
-            var current = context.Stack.Current;
-
-            if (!context.FileFormat.AtLeast(OfficeVersion) && current.Value?.HasValue == true && !context.McContext.IsIgnorableNs(current.Property.GetQName().Namespace))
-            {
-                context.CreateError(
-                    id: "Sch_UndeclaredAttribute",
-                    description: SR.Format(ValidationResources.Sch_UndeclaredAttribute, current.Property.GetQName()),
-                    errorType: ValidationErrorType.Schema);
-            }
         }
     }
 }

--- a/src/DocumentFormat.OpenXml/Framework/Validation/EnumValidator.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Validation/EnumValidator.cs
@@ -5,9 +5,9 @@ using DocumentFormat.OpenXml.Validation;
 
 namespace DocumentFormat.OpenXml.Framework
 {
-    internal sealed class EnumValidatorAttribute : VersionedValidatorAttribute
+    internal sealed class EnumValidator : VersionedValidator
     {
-        public static IOpenXmlSimpleTypeValidator Instance { get; } = new EnumValidatorAttribute();
+        public static IOpenXmlSimpleTypeValidator Instance { get; } = new EnumValidator();
 
         protected override void ValidateVersion(ValidationContext context)
         {

--- a/src/DocumentFormat.OpenXml/Framework/Validation/NumberValidator.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Validation/NumberValidator.cs
@@ -7,10 +7,9 @@ using System.Xml;
 
 namespace DocumentFormat.OpenXml.Framework
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
-    internal sealed class NumberValidatorAttribute : VersionedValidatorAttribute, IOpenXmlSimpleTypeValidator, INameProvider
+    internal sealed class NumberValidator : VersionedValidator, IOpenXmlSimpleTypeValidator, INameProvider
     {
-        public static IOpenXmlSimpleTypeValidator Instance { get; } = new NumberValidatorAttribute();
+        public static IOpenXmlSimpleTypeValidator Instance { get; } = new NumberValidator();
 
         private static readonly XmlQualifiedName _positiveQname = new XmlQualifiedName("positiveInteger", "http://www.w3.org/2001/XMLSchema");
         private static readonly XmlQualifiedName _nonNegativeQname = new XmlQualifiedName("nonNegativeInteger", "http://www.w3.org/2001/XMLSchema");

--- a/src/DocumentFormat.OpenXml/Framework/Validation/OfficeVersionValidator.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Validation/OfficeVersionValidator.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Validation;
+
+namespace DocumentFormat.OpenXml.Framework
+{
+    internal class OfficeVersionValidator : IOpenXmlSimpleTypeValidator
+    {
+        /// <summary>
+        /// Gets the Office version of the available property.
+        /// </summary>
+        public FileFormatVersions OfficeVersion { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the OfficeAvailabilityAttribute class.
+        /// </summary>
+        /// <param name="officeVersion">The Office version where this class or property is available.
+        /// If there is more than one version, use bitwise OR to specify multiple versions.</param>
+        public OfficeVersionValidator(FileFormatVersions officeVersion)
+        {
+            OfficeVersion = officeVersion;
+        }
+
+        public void Validate(ValidationContext context)
+        {
+            var current = context.Stack.Current;
+
+            if (!context.FileFormat.AtLeast(OfficeVersion) && current.Value?.HasValue == true && !context.McContext.IsIgnorableNs(current.Property.GetQName().Namespace))
+            {
+                context.CreateError(
+                    id: "Sch_UndeclaredAttribute",
+                    description: SR.Format(ValidationResources.Sch_UndeclaredAttribute, current.Property.GetQName()),
+                    errorType: ValidationErrorType.Schema);
+            }
+        }
+    }
+}

--- a/src/DocumentFormat.OpenXml/Framework/Validation/RequiredValidator.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Validation/RequiredValidator.cs
@@ -9,9 +9,10 @@ namespace DocumentFormat.OpenXml.Framework
     /// <summary>
     /// Describes a required item.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = true, Inherited = true)]
-    internal sealed class RequiredValidatorAttribute : VersionedValidatorAttribute
+    internal sealed class RequiredValidator : VersionedValidator
     {
+        public static IOpenXmlSimpleTypeValidator Instance { get; } = new RequiredValidator();
+
         public bool IsRequired { get; set; } = true;
 
         protected override void ValidateVersion(ValidationContext context)

--- a/src/DocumentFormat.OpenXml/Framework/Validation/StringValidator.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Validation/StringValidator.cs
@@ -3,7 +3,6 @@
 
 using DocumentFormat.OpenXml.Validation;
 using DocumentFormat.OpenXml.Validation.Schema.Restrictions;
-using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -11,10 +10,9 @@ using System.Xml;
 
 namespace DocumentFormat.OpenXml.Framework
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
-    internal sealed class StringValidatorAttribute : VersionedValidatorAttribute, INameProvider
+    internal sealed class StringValidator : VersionedValidator, INameProvider
     {
-        internal static IOpenXmlSimpleTypeValidator Instance { get; } = new StringValidatorAttribute();
+        internal static IOpenXmlSimpleTypeValidator Instance { get; } = new StringValidator();
 
         private static readonly XmlQualifiedName _anyUri = new XmlQualifiedName("anyUri", "http://www.w3.org/2001/XMLSchema");
         private static readonly XmlQualifiedName _token = new XmlQualifiedName("token", "http://www.w3.org/2001/XMLSchema");

--- a/src/DocumentFormat.OpenXml/Framework/Validation/VersionedValidator.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Validation/VersionedValidator.cs
@@ -2,11 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using DocumentFormat.OpenXml.Validation;
-using System;
 
 namespace DocumentFormat.OpenXml.Framework
 {
-    internal abstract class VersionedValidatorAttribute : Attribute, IOpenXmlSimpleTypeValidator
+    internal abstract class VersionedValidator : IOpenXmlSimpleTypeValidator
     {
         private FileFormatVersions? _version;
         private FileFormatVersions? _initialVersion;

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas-microsoft-com_office_excel.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas-microsoft-com_office_excel.g.cs
@@ -207,7 +207,7 @@ namespace DocumentFormat.OpenXml.Vml.Spreadsheet
             builder.AddElement<ClientData>()
 .AddAttribute(0, "ObjectType", a => a.ObjectType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -325,7 +325,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "MoveWithCells");
         }
 
@@ -363,7 +363,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "SizeWithCells");
         }
 
@@ -401,7 +401,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "Locked");
         }
 
@@ -439,7 +439,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "DefaultSize");
         }
 
@@ -477,7 +477,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "PrintObject");
         }
 
@@ -515,7 +515,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "Disabled");
         }
 
@@ -553,7 +553,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "AutoFill");
         }
 
@@ -591,7 +591,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "AutoLine");
         }
 
@@ -629,7 +629,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "AutoPict");
         }
 
@@ -667,7 +667,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "LockText");
         }
 
@@ -705,7 +705,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "JustLastX");
         }
 
@@ -743,7 +743,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "SecretEdit");
         }
 
@@ -781,7 +781,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "Default");
         }
 
@@ -819,7 +819,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "Help");
         }
 
@@ -857,7 +857,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "Cancel");
         }
 
@@ -895,7 +895,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "Dismiss");
         }
 
@@ -933,7 +933,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "Visible");
         }
 
@@ -971,7 +971,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "RowHidden");
         }
 
@@ -1009,7 +1009,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "ColHidden");
         }
 
@@ -1047,7 +1047,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "MultiLine");
         }
 
@@ -1085,7 +1085,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "VScroll");
         }
 
@@ -1123,7 +1123,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "ValidIds");
         }
 
@@ -1161,7 +1161,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "NoThreeD2");
         }
 
@@ -1199,7 +1199,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "Colored");
         }
 
@@ -1237,7 +1237,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "NoThreeD");
         }
 
@@ -1275,7 +1275,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "FirstButton");
         }
 
@@ -1313,7 +1313,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "Horiz");
         }
 
@@ -1351,7 +1351,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "MapOCX");
         }
 
@@ -1389,7 +1389,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "Camera");
         }
 
@@ -1427,7 +1427,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "RecalcAlways");
         }
 
@@ -1465,7 +1465,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "AutoScale");
         }
 
@@ -1503,7 +1503,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "DDE");
         }
 
@@ -1541,7 +1541,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "UIObj");
         }
 
@@ -2172,7 +2172,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<ByteValue>(new NumberValidator());
+            builder.AddValidator<ByteValue>(NumberValidator.Instance);
             builder.SetSchema(29, "Accel");
         }
 
@@ -2210,7 +2210,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<ByteValue>(new NumberValidator());
+            builder.AddValidator<ByteValue>(NumberValidator.Instance);
             builder.SetSchema(29, "Accel2");
         }
 
@@ -2248,7 +2248,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidator());
+            builder.AddValidator<IntegerValue>(NumberValidator.Instance);
             builder.SetSchema(29, "Row");
         }
 
@@ -2286,7 +2286,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidator());
+            builder.AddValidator<IntegerValue>(NumberValidator.Instance);
             builder.SetSchema(29, "Column");
         }
 
@@ -2324,7 +2324,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidator());
+            builder.AddValidator<IntegerValue>(NumberValidator.Instance);
             builder.SetSchema(29, "VTEdit");
         }
 
@@ -2362,7 +2362,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidator());
+            builder.AddValidator<IntegerValue>(NumberValidator.Instance);
             builder.SetSchema(29, "WidthMin");
         }
 
@@ -2400,7 +2400,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidator());
+            builder.AddValidator<IntegerValue>(NumberValidator.Instance);
             builder.SetSchema(29, "Sel");
         }
 
@@ -2438,7 +2438,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidator());
+            builder.AddValidator<IntegerValue>(NumberValidator.Instance);
             builder.SetSchema(29, "DropLines");
         }
 
@@ -2476,7 +2476,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidator());
+            builder.AddValidator<IntegerValue>(NumberValidator.Instance);
             builder.SetSchema(29, "Checked");
         }
 
@@ -2514,7 +2514,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidator());
+            builder.AddValidator<IntegerValue>(NumberValidator.Instance);
             builder.SetSchema(29, "Val");
         }
 
@@ -2552,7 +2552,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidator());
+            builder.AddValidator<IntegerValue>(NumberValidator.Instance);
             builder.SetSchema(29, "Min");
         }
 
@@ -2590,7 +2590,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidator());
+            builder.AddValidator<IntegerValue>(NumberValidator.Instance);
             builder.SetSchema(29, "Max");
         }
 
@@ -2628,7 +2628,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidator());
+            builder.AddValidator<IntegerValue>(NumberValidator.Instance);
             builder.SetSchema(29, "Inc");
         }
 
@@ -2666,7 +2666,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidator());
+            builder.AddValidator<IntegerValue>(NumberValidator.Instance);
             builder.SetSchema(29, "Page");
         }
 
@@ -2704,7 +2704,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidator());
+            builder.AddValidator<IntegerValue>(NumberValidator.Instance);
             builder.SetSchema(29, "Dx");
         }
 
@@ -2742,7 +2742,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.ClipboardFormatValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.ClipboardFormatValues>>(EnumValidator.Instance);
             builder.SetSchema(29, "CF");
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas-microsoft-com_office_excel.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas-microsoft-com_office_excel.g.cs
@@ -207,7 +207,7 @@ namespace DocumentFormat.OpenXml.Vml.Spreadsheet
             builder.AddElement<ClientData>()
 .AddAttribute(0, "ObjectType", a => a.ObjectType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -325,7 +325,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "MoveWithCells");
         }
 
@@ -363,7 +363,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "SizeWithCells");
         }
 
@@ -401,7 +401,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "Locked");
         }
 
@@ -439,7 +439,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "DefaultSize");
         }
 
@@ -477,7 +477,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "PrintObject");
         }
 
@@ -515,7 +515,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "Disabled");
         }
 
@@ -553,7 +553,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "AutoFill");
         }
 
@@ -591,7 +591,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "AutoLine");
         }
 
@@ -629,7 +629,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "AutoPict");
         }
 
@@ -667,7 +667,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "LockText");
         }
 
@@ -705,7 +705,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "JustLastX");
         }
 
@@ -743,7 +743,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "SecretEdit");
         }
 
@@ -781,7 +781,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "Default");
         }
 
@@ -819,7 +819,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "Help");
         }
 
@@ -857,7 +857,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "Cancel");
         }
 
@@ -895,7 +895,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "Dismiss");
         }
 
@@ -933,7 +933,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "Visible");
         }
 
@@ -971,7 +971,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "RowHidden");
         }
 
@@ -1009,7 +1009,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "ColHidden");
         }
 
@@ -1047,7 +1047,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "MultiLine");
         }
 
@@ -1085,7 +1085,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "VScroll");
         }
 
@@ -1123,7 +1123,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "ValidIds");
         }
 
@@ -1161,7 +1161,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "NoThreeD2");
         }
 
@@ -1199,7 +1199,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "Colored");
         }
 
@@ -1237,7 +1237,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "NoThreeD");
         }
 
@@ -1275,7 +1275,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "FirstButton");
         }
 
@@ -1313,7 +1313,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "Horiz");
         }
 
@@ -1351,7 +1351,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "MapOCX");
         }
 
@@ -1389,7 +1389,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "Camera");
         }
 
@@ -1427,7 +1427,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "RecalcAlways");
         }
 
@@ -1465,7 +1465,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "AutoScale");
         }
 
@@ -1503,7 +1503,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "DDE");
         }
 
@@ -1541,7 +1541,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.BooleanEntryWithBlankValues>>(new EnumValidator());
             builder.SetSchema(29, "UIObj");
         }
 
@@ -2134,7 +2134,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (256L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (256L) });
             builder.SetSchema(29, "FmlaMacro");
         }
 
@@ -2172,7 +2172,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<ByteValue>(new NumberValidatorAttribute());
+            builder.AddValidator<ByteValue>(new NumberValidator());
             builder.SetSchema(29, "Accel");
         }
 
@@ -2210,7 +2210,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<ByteValue>(new NumberValidatorAttribute());
+            builder.AddValidator<ByteValue>(new NumberValidator());
             builder.SetSchema(29, "Accel2");
         }
 
@@ -2248,7 +2248,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidatorAttribute());
+            builder.AddValidator<IntegerValue>(new NumberValidator());
             builder.SetSchema(29, "Row");
         }
 
@@ -2286,7 +2286,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidatorAttribute());
+            builder.AddValidator<IntegerValue>(new NumberValidator());
             builder.SetSchema(29, "Column");
         }
 
@@ -2324,7 +2324,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidatorAttribute());
+            builder.AddValidator<IntegerValue>(new NumberValidator());
             builder.SetSchema(29, "VTEdit");
         }
 
@@ -2362,7 +2362,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidatorAttribute());
+            builder.AddValidator<IntegerValue>(new NumberValidator());
             builder.SetSchema(29, "WidthMin");
         }
 
@@ -2400,7 +2400,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidatorAttribute());
+            builder.AddValidator<IntegerValue>(new NumberValidator());
             builder.SetSchema(29, "Sel");
         }
 
@@ -2438,7 +2438,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidatorAttribute());
+            builder.AddValidator<IntegerValue>(new NumberValidator());
             builder.SetSchema(29, "DropLines");
         }
 
@@ -2476,7 +2476,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidatorAttribute());
+            builder.AddValidator<IntegerValue>(new NumberValidator());
             builder.SetSchema(29, "Checked");
         }
 
@@ -2514,7 +2514,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidatorAttribute());
+            builder.AddValidator<IntegerValue>(new NumberValidator());
             builder.SetSchema(29, "Val");
         }
 
@@ -2552,7 +2552,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidatorAttribute());
+            builder.AddValidator<IntegerValue>(new NumberValidator());
             builder.SetSchema(29, "Min");
         }
 
@@ -2590,7 +2590,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidatorAttribute());
+            builder.AddValidator<IntegerValue>(new NumberValidator());
             builder.SetSchema(29, "Max");
         }
 
@@ -2628,7 +2628,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidatorAttribute());
+            builder.AddValidator<IntegerValue>(new NumberValidator());
             builder.SetSchema(29, "Inc");
         }
 
@@ -2666,7 +2666,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidatorAttribute());
+            builder.AddValidator<IntegerValue>(new NumberValidator());
             builder.SetSchema(29, "Page");
         }
 
@@ -2704,7 +2704,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidatorAttribute());
+            builder.AddValidator<IntegerValue>(new NumberValidator());
             builder.SetSchema(29, "Dx");
         }
 
@@ -2742,7 +2742,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.ClipboardFormatValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Spreadsheet.ClipboardFormatValues>>(new EnumValidator());
             builder.SetSchema(29, "CF");
         }
 
@@ -2780,7 +2780,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidatorAttribute() { IsNonNegative = (true) });
+            builder.AddValidator<IntegerValue>(new NumberValidator() { IsNonNegative = (true) });
             builder.SetSchema(29, "ScriptLanguage");
         }
 
@@ -2818,7 +2818,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<IntegerValue>(new NumberValidatorAttribute() { IsNonNegative = (true) });
+            builder.AddValidator<IntegerValue>(new NumberValidator() { IsNonNegative = (true) });
             builder.SetSchema(29, "ScriptLocation");
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas-microsoft-com_office_office.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas-microsoft-com_office_office.g.cs
@@ -659,11 +659,11 @@ namespace DocumentFormat.OpenXml.Vml.Office
 .AddAttribute(0, "issignatureline", a => a.IsSignatureLine)
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "provid", a => a.ProviderId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "signinginstructionsset", a => a.SigningInstructionsSet)
 .AddAttribute(0, "allowcomments", a => a.AllowComments)
@@ -2476,7 +2476,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<ClipPath>()
 .AddAttribute(27, "v", a => a.Value, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -2877,13 +2877,13 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Rule>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "type", a => a.Type)
 .AddAttribute(0, "how", a => a.How)
 .AddAttribute(0, "idref", a => a.ShapeReference, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -3040,15 +3040,15 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(26, "ext", a => a.Extension)
 .AddAttribute(0, "idsrc", a => a.SourceId, aBuilder =>
 {
-   aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+   aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "iddest", a => a.DestinationId, aBuilder =>
 {
-   aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+   aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "idcntr", a => a.CenterShapeId, aBuilder =>
 {
-   aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+   aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -3086,7 +3086,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Office.OleLinkValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Office.OleLinkValues>>(new EnumValidator());
             builder.SetSchema(27, "LinkType");
         }
 
@@ -3124,7 +3124,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<TrueFalseBlankValue>(new NumberValidatorAttribute());
+            builder.AddValidator<TrueFalseBlankValue>(new NumberValidator());
             builder.SetSchema(27, "LockedField");
         }
 
@@ -3232,12 +3232,12 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "end", a => a.End)
 .AddAttribute(0, "idref", a => a.ShapeReference, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
- aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+ aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "connectloc", a => a.ConnectionLocation, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
+ aBuilder.AddValidator(new RequiredValidator());
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas-microsoft-com_office_office.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas-microsoft-com_office_office.g.cs
@@ -2476,7 +2476,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<ClipPath>()
 .AddAttribute(27, "v", a => a.Value, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -2877,7 +2877,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Rule>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "type", a => a.Type)
 .AddAttribute(0, "how", a => a.How)
@@ -3086,7 +3086,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Office.OleLinkValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Vml.Office.OleLinkValues>>(EnumValidator.Instance);
             builder.SetSchema(27, "LinkType");
         }
 
@@ -3124,7 +3124,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<TrueFalseBlankValue>(new NumberValidator());
+            builder.AddValidator<TrueFalseBlankValue>(NumberValidator.Instance);
             builder.SetSchema(27, "LockedField");
         }
 
@@ -3232,12 +3232,12 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 .AddAttribute(0, "end", a => a.End)
 .AddAttribute(0, "idref", a => a.ShapeReference, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
  aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "connectloc", a => a.ConnectionLocation, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas-microsoft-com_office_word.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas-microsoft-com_office_word.g.cs
@@ -159,7 +159,7 @@ namespace DocumentFormat.OpenXml.Vml.Wordprocessing
                            .AddAttribute(0, "type", a => a.Type)
                            .AddAttribute(0, "width", a => a.Width, aBuilder =>
                            {
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { IsPositive = (true) });
+                               aBuilder.AddValidator(new NumberValidator() { IsPositive = (true) });
                            })
                            .AddAttribute(0, "shadow", a => a.Shadow);
         }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas-microsoft-com_vml.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas-microsoft-com_vml.g.cs
@@ -2673,7 +2673,7 @@ namespace DocumentFormat.OpenXml.Vml
 .AddAttribute(0, "insetpen", a => a.InsetPen)
 .AddAttribute(27, "spt", a => a.OptionalNumber, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (202L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (202L) });
 })
 .AddAttribute(27, "connectortype", a => a.ConnectorType)
 .AddAttribute(27, "bwmode", a => a.BlackWhiteMode)
@@ -3524,7 +3524,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
 .AddAttribute(0, "insetpen", a => a.InsetPen)
 .AddAttribute(27, "spt", a => a.OptionalNumber, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (202L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (202L) });
 })
 .AddAttribute(27, "connectortype", a => a.ConnectorType)
 .AddAttribute(27, "bwmode", a => a.BlackWhiteMode)
@@ -4283,7 +4283,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<Background>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MaxLength = (255L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MaxLength = (255L) });
 })
 .AddAttribute(0, "fill", a => a.Filled)
 .AddAttribute(0, "fillcolor", a => a.Fillcolor)
@@ -5083,7 +5083,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MaxLeng
 .AddAttribute(0, "insetpen", a => a.InsetPen)
 .AddAttribute(27, "spt", a => a.OptionalNumber, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (202L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (202L) });
 })
 .AddAttribute(27, "connectortype", a => a.ConnectorType)
 .AddAttribute(27, "bwmode", a => a.BlackWhiteMode)
@@ -5098,7 +5098,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
 .AddAttribute(27, "gfxdata", a => a.Gfxdata)
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MaxLength = (255L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MaxLength = (255L) });
 })
 .AddAttribute(0, "style", a => a.Style)
 .AddAttribute(0, "href", a => a.Href)
@@ -5964,7 +5964,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MaxLeng
 .AddAttribute(0, "insetpen", a => a.InsetPen)
 .AddAttribute(27, "spt", a => a.OptionalNumber, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (202L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (202L) });
 })
 .AddAttribute(27, "connectortype", a => a.ConnectorType)
 .AddAttribute(27, "bwmode", a => a.BlackWhiteMode)
@@ -6881,7 +6881,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
 .AddAttribute(0, "insetpen", a => a.InsetPen)
 .AddAttribute(27, "spt", a => a.OptionalNumber, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (202L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (202L) });
 })
 .AddAttribute(27, "connectortype", a => a.ConnectorType)
 .AddAttribute(27, "bwmode", a => a.BlackWhiteMode)
@@ -7735,7 +7735,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
 .AddAttribute(0, "insetpen", a => a.InsetPen)
 .AddAttribute(27, "spt", a => a.OptionalNumber, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (202L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (202L) });
 })
 .AddAttribute(27, "connectortype", a => a.ConnectorType)
 .AddAttribute(27, "bwmode", a => a.BlackWhiteMode)
@@ -8559,7 +8559,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
 .AddAttribute(0, "insetpen", a => a.InsetPen)
 .AddAttribute(27, "spt", a => a.OptionalNumber, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (202L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (202L) });
 })
 .AddAttribute(27, "connectortype", a => a.ConnectorType)
 .AddAttribute(27, "bwmode", a => a.BlackWhiteMode)
@@ -9395,7 +9395,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
 .AddAttribute(0, "insetpen", a => a.InsetPen)
 .AddAttribute(27, "spt", a => a.OptionalNumber, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (202L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (202L) });
 })
 .AddAttribute(27, "connectortype", a => a.ConnectorType)
 .AddAttribute(27, "bwmode", a => a.BlackWhiteMode)
@@ -10220,7 +10220,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
 .AddAttribute(0, "insetpen", a => a.InsetPen)
 .AddAttribute(27, "spt", a => a.OptionalNumber, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (202L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (202L) });
 })
 .AddAttribute(27, "connectortype", a => a.ConnectorType)
 .AddAttribute(27, "bwmode", a => a.BlackWhiteMode)
@@ -11043,7 +11043,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
 .AddAttribute(0, "insetpen", a => a.InsetPen)
 .AddAttribute(27, "spt", a => a.OptionalNumber, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (202L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (202L) });
 })
 .AddAttribute(27, "connectortype", a => a.ConnectorType)
 .AddAttribute(27, "bwmode", a => a.BlackWhiteMode)

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_ink_2010_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_ink_2010_main.g.cs
@@ -278,20 +278,20 @@ namespace DocumentFormat.OpenXml.Office2010.Ink
             builder.AddElement<ContextNode>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Office2010.Ink.KnownContextNodeTypeValues>>(new EnumValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Office2010.Ink.KnownContextNodeTypeValues>>(new EnumValidator());
+union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
 })
 .AddAttribute(0, "rotatedBoundingBox", a => a.RotatedBoundingBox, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("-?[0-9]+,-?[0-9]+") });
+aBuilder.AddValidator(new StringValidator() { Pattern = ("-?[0-9]+,-?[0-9]+") });
 })
 .AddAttribute(0, "alignmentLevel", a => a.AlignmentLevel)
 .AddAttribute(0, "contentType", a => a.ContentType)
@@ -299,37 +299,37 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("-?[0-9]+,-?[0
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<ListValue<StringValue>>(new NumberValidatorAttribute());
-union.AddValidator<Int32Value>(new NumberValidatorAttribute());
+union.AddValidator<ListValue<StringValue>>(new NumberValidator());
+union.AddValidator<Int32Value>(new NumberValidator());
 });
 })
 .AddAttribute(0, "descender", a => a.Descender, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<ListValue<StringValue>>(new NumberValidatorAttribute());
-union.AddValidator<Int32Value>(new NumberValidatorAttribute());
+union.AddValidator<ListValue<StringValue>>(new NumberValidator());
+union.AddValidator<Int32Value>(new NumberValidator());
 });
 })
 .AddAttribute(0, "baseline", a => a.Baseline, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<ListValue<StringValue>>(new NumberValidatorAttribute());
-union.AddValidator<Int32Value>(new NumberValidatorAttribute());
+union.AddValidator<ListValue<StringValue>>(new NumberValidator());
+union.AddValidator<Int32Value>(new NumberValidator());
 });
 })
 .AddAttribute(0, "midline", a => a.Midline, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<ListValue<StringValue>>(new NumberValidatorAttribute());
-union.AddValidator<Int32Value>(new NumberValidatorAttribute());
+union.AddValidator<ListValue<StringValue>>(new NumberValidator());
+union.AddValidator<Int32Value>(new NumberValidator());
 });
 })
 .AddAttribute(0, "customRecognizerId", a => a.CustomRecognizerId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "mathML", a => a.MathML)
 .AddAttribute(0, "mathStruct", a => a.MathStruct)
@@ -339,24 +339,24 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
 .AddAttribute(0, "rotationAngle", a => a.RotationAngle)
 .AddAttribute(0, "hotPoints", a => a.HotPoints, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("-?[0-9]+,-?[0-9]+") });
+aBuilder.AddValidator(new StringValidator() { Pattern = ("-?[0-9]+,-?[0-9]+") });
 })
 .AddAttribute(0, "centroid", a => a.Centroid, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("-?[0-9]+,-?[0-9]+") });
+aBuilder.AddValidator(new StringValidator() { Pattern = ("-?[0-9]+,-?[0-9]+") });
 })
 .AddAttribute(0, "semanticType", a => a.SemanticType, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Office2010.Ink.KnownSemanticTypeValues>>(new EnumValidatorAttribute());
-union.AddValidator<UInt32Value>(new NumberValidatorAttribute());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Office2010.Ink.KnownSemanticTypeValues>>(new EnumValidator());
+union.AddValidator<UInt32Value>(new NumberValidator());
 });
 })
 .AddAttribute(0, "shapeName", a => a.ShapeName)
 .AddAttribute(0, "shapeGeometry", a => a.ShapeGeometry, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("-?[0-9]+,-?[0-9]+") });
+aBuilder.AddValidator(new StringValidator() { Pattern = ("-?[0-9]+,-?[0-9]+") });
 });
         }
 
@@ -417,7 +417,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("-?[0-9]+,-?[0
             builder.AddElement<ContextNodeProperty>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
 
@@ -516,8 +516,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
                            {
                                aBuilder.AddUnion(union =>
                                {
-                                   union.AddValidator(new StringValidatorAttribute() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
-                                   union.AddValidator<UInt32Value>(new NumberValidatorAttribute());
+                                   union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+                                   union.AddValidator<UInt32Value>(new NumberValidator());
                                });
                            });
         }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_ink_2010_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_ink_2010_main.g.cs
@@ -282,10 +282,10 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
 })
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Office2010.Ink.KnownContextNodeTypeValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Office2010.Ink.KnownContextNodeTypeValues>>(EnumValidator.Instance);
 union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
 })
@@ -299,32 +299,32 @@ aBuilder.AddValidator(new StringValidator() { Pattern = ("-?[0-9]+,-?[0-9]+") })
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<ListValue<StringValue>>(new NumberValidator());
-union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator<ListValue<StringValue>>(NumberValidator.Instance);
+union.AddValidator<Int32Value>(NumberValidator.Instance);
 });
 })
 .AddAttribute(0, "descender", a => a.Descender, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<ListValue<StringValue>>(new NumberValidator());
-union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator<ListValue<StringValue>>(NumberValidator.Instance);
+union.AddValidator<Int32Value>(NumberValidator.Instance);
 });
 })
 .AddAttribute(0, "baseline", a => a.Baseline, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<ListValue<StringValue>>(new NumberValidator());
-union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator<ListValue<StringValue>>(NumberValidator.Instance);
+union.AddValidator<Int32Value>(NumberValidator.Instance);
 });
 })
 .AddAttribute(0, "midline", a => a.Midline, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<ListValue<StringValue>>(new NumberValidator());
-union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator<ListValue<StringValue>>(NumberValidator.Instance);
+union.AddValidator<Int32Value>(NumberValidator.Instance);
 });
 })
 .AddAttribute(0, "customRecognizerId", a => a.CustomRecognizerId, aBuilder =>
@@ -349,8 +349,8 @@ aBuilder.AddValidator(new StringValidator() { Pattern = ("-?[0-9]+,-?[0-9]+") })
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Office2010.Ink.KnownSemanticTypeValues>>(new EnumValidator());
-union.AddValidator<UInt32Value>(new NumberValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Office2010.Ink.KnownSemanticTypeValues>>(EnumValidator.Instance);
+union.AddValidator<UInt32Value>(NumberValidator.Instance);
 });
 })
 .AddAttribute(0, "shapeName", a => a.ShapeName)
@@ -517,7 +517,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
                                aBuilder.AddUnion(union =>
                                {
                                    union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
-                                   union.AddValidator<UInt32Value>(new NumberValidator());
+                                   union.AddValidator<UInt32Value>(NumberValidator.Instance);
                                });
                            });
         }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_2006_01_customui.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_2006_01_customui.g.cs
@@ -293,95 +293,95 @@ namespace DocumentFormat.OpenXml.Office.CustomUI
             builder.AddElement<UnsizedControlClone>()
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -710,111 +710,111 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<UnsizedButton>()
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -1083,93 +1083,93 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<CheckBox>()
 .AddAttribute(0, "getPressed", a => a.GetPressed, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -1711,174 +1711,174 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<UnsizedGallery>()
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "invalidateContentOnDrop", a => a.InvalidateContentOnDrop)
 .AddAttribute(0, "columns", a => a.Columns, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
 })
 .AddAttribute(0, "rows", a => a.Rows, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
 })
 .AddAttribute(0, "itemWidth", a => a.ItemWidth, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (4096L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (4096L), IsPositive = (true) });
 })
 .AddAttribute(0, "itemHeight", a => a.ItemHeight, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (4096L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (4096L), IsPositive = (true) });
 })
 .AddAttribute(0, "getItemWidth", a => a.GetItemWidth, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemHeight", a => a.GetItemHeight, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showItemLabel", a => a.ShowItemLabel)
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showItemImage", a => a.ShowItemImage)
 .AddAttribute(0, "getItemCount", a => a.GetItemCount, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemLabel", a => a.GetItemLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemScreentip", a => a.GetItemScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemSupertip", a => a.GetItemSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemImage", a => a.GetItemImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemID", a => a.GetItemID, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "sizeString", a => a.SizeString, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSelectedItemID", a => a.GetSelectedItemID, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSelectedItemIndex", a => a.GetSelectedItemIndex, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -2231,115 +2231,115 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<UnsizedToggleButton>()
 .AddAttribute(0, "getPressed", a => a.GetPressed, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -2448,35 +2448,35 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<MenuSeparator>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "title", a => a.Title, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getTitle", a => a.GetTitle, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -2701,57 +2701,57 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -3143,107 +3143,107 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "itemSize", a => a.ItemSize)
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -3615,113 +3615,113 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<UnsizedDynamicMenu>()
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getContent", a => a.GetContent, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "invalidateContentOnDrop", a => a.InvalidateContentOnDrop)
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -3946,57 +3946,57 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -4387,108 +4387,108 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<MenuWithTitle>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "itemSize", a => a.ItemSize)
 .AddAttribute(0, "title", a => a.Title, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getTitle", a => a.GetTitle, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -4851,107 +4851,107 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "size", a => a.Size)
 .AddAttribute(0, "getSize", a => a.GetSize, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -5180,74 +5180,74 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<TextLabel>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -5597,115 +5597,115 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "size", a => a.Size)
 .AddAttribute(0, "getSize", a => a.GetSize, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -6065,119 +6065,119 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "size", a => a.Size)
 .AddAttribute(0, "getSize", a => a.GetSize, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getPressed", a => a.GetPressed, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -6517,114 +6517,114 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "maxLength", a => a.MaxLength, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
 })
 .AddAttribute(0, "getText", a => a.GetText, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onChange", a => a.OnChange, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "sizeString", a => a.SizeString, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -7075,140 +7075,140 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "showItemImage", a => a.ShowItemImage)
 .AddAttribute(0, "getItemCount", a => a.GetItemCount, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemLabel", a => a.GetItemLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemScreentip", a => a.GetItemScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemSupertip", a => a.GetItemSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemImage", a => a.GetItemImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemID", a => a.GetItemID, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "sizeString", a => a.SizeString, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "invalidateContentOnDrop", a => a.InvalidateContentOnDrop)
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "maxLength", a => a.MaxLength, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
 })
 .AddAttribute(0, "getText", a => a.GetText, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onChange", a => a.OnChange, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -7670,141 +7670,141 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<DropDown>()
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showItemImage", a => a.ShowItemImage)
 .AddAttribute(0, "getItemCount", a => a.GetItemCount, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemLabel", a => a.GetItemLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemScreentip", a => a.GetItemScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemSupertip", a => a.GetItemSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemImage", a => a.GetItemImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemID", a => a.GetItemID, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "sizeString", a => a.SizeString, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSelectedItemID", a => a.GetSelectedItemID, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSelectedItemIndex", a => a.GetSelectedItemIndex, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showItemLabel", a => a.ShowItemLabel)
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -8378,178 +8378,178 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "size", a => a.Size)
 .AddAttribute(0, "getSize", a => a.GetSize, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "invalidateContentOnDrop", a => a.InvalidateContentOnDrop)
 .AddAttribute(0, "columns", a => a.Columns, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
 })
 .AddAttribute(0, "rows", a => a.Rows, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
 })
 .AddAttribute(0, "itemWidth", a => a.ItemWidth, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (4096L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (4096L), IsPositive = (true) });
 })
 .AddAttribute(0, "itemHeight", a => a.ItemHeight, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (4096L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (4096L), IsPositive = (true) });
 })
 .AddAttribute(0, "getItemWidth", a => a.GetItemWidth, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemHeight", a => a.GetItemHeight, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showItemLabel", a => a.ShowItemLabel)
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showItemImage", a => a.ShowItemImage)
 .AddAttribute(0, "getItemCount", a => a.GetItemCount, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemLabel", a => a.GetItemLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemScreentip", a => a.GetItemScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemSupertip", a => a.GetItemSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemImage", a => a.GetItemImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemID", a => a.GetItemID, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "sizeString", a => a.SizeString, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSelectedItemID", a => a.GetSelectedItemID, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSelectedItemIndex", a => a.GetSelectedItemIndex, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -8963,112 +8963,112 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "size", a => a.Size)
 .AddAttribute(0, "getSize", a => a.GetSize, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "itemSize", a => a.ItemSize)
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -9464,117 +9464,117 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "size", a => a.Size)
 .AddAttribute(0, "getSize", a => a.GetSize, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getContent", a => a.GetContent, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "invalidateContentOnDrop", a => a.InvalidateContentOnDrop)
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -9819,62 +9819,62 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "size", a => a.Size)
 .AddAttribute(0, "getSize", a => a.GetSize, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -10068,32 +10068,32 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<Box>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "boxStyle", a => a.BoxStyle);
         }
@@ -10269,32 +10269,32 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLeng
             builder.AddElement<ButtonGroup>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -10416,11 +10416,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLeng
             builder.AddElement<MenuRoot>()
 .AddAttribute(0, "title", a => a.Title, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getTitle", a => a.GetTitle, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "itemSize", a => a.ItemSize);
         }
@@ -10533,11 +10533,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<CustomUI>()
 .AddAttribute(0, "onLoad", a => a.OnLoad, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "loadImage", a => a.LoadImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -10660,27 +10660,27 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<Item>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-  aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+  aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-  aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+  aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-  aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+  aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-  aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+  aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-  aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+  aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-  aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+  aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -10989,106 +10989,106 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<VisibleButton>()
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -11407,110 +11407,110 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<VisibleToggleButton>()
 .AddAttribute(0, "getPressed", a => a.GetPressed, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -11619,32 +11619,32 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<VerticalSeparator>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -12019,84 +12019,84 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLeng
             builder.AddElement<Group>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -12459,108 +12459,108 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<QuickAccessToolbarControlClone>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "size", a => a.Size)
 .AddAttribute(0, "getSize", a => a.GetSize, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -12951,56 +12951,56 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<Tab>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -13100,13 +13100,13 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<ContextualTabSet>()
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -13182,16 +13182,16 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<RepurposedCommand>()
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_2006_01_customui.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_2006_01_customui.g.cs
@@ -3639,7 +3639,7 @@ aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (102
 })
 .AddAttribute(0, "getContent", a => a.GetContent, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "invalidateContentOnDrop", a => a.InvalidateContentOnDrop)
@@ -9492,7 +9492,7 @@ aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (102
 })
 .AddAttribute(0, "getContent", a => a.GetContent, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "invalidateContentOnDrop", a => a.InvalidateContentOnDrop)
@@ -13100,7 +13100,7 @@ aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (102
             builder.AddElement<ContextualTabSet>()
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_2006_activeX.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_2006_activeX.g.cs
@@ -116,13 +116,13 @@ namespace DocumentFormat.OpenXml.Office.ActiveX
             builder.AddElement<ActiveXControlData>()
 .AddAttribute(35, "classid", a => a.ActiveXControlClassId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(35, "license", a => a.License)
 .AddAttribute(19, "id", a => a.Id)
 .AddAttribute(35, "persistence", a => a.Persistence, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -217,7 +217,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ActiveXObjectProperty>()
 .AddAttribute(35, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(35, "value", a => a.Value);
         }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_2006_activeX.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_2006_activeX.g.cs
@@ -116,13 +116,13 @@ namespace DocumentFormat.OpenXml.Office.ActiveX
             builder.AddElement<ActiveXControlData>()
 .AddAttribute(35, "classid", a => a.ActiveXControlClassId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(35, "license", a => a.License)
 .AddAttribute(19, "id", a => a.Id)
 .AddAttribute(35, "persistence", a => a.Persistence, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -217,7 +217,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ActiveXObjectProperty>()
 .AddAttribute(35, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(35, "value", a => a.Value);
         }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_2006_customDocumentInformationPanel.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_2006_customDocumentInformationPanel.g.cs
@@ -136,7 +136,7 @@ namespace DocumentFormat.OpenXml.Office.CustomDocumentInformationPanel
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+            builder.AddValidator(new StringValidator() { IsUri = (true) });
             builder.SetSchema(37, "XMLNamespace");
         }
 
@@ -174,7 +174,7 @@ namespace DocumentFormat.OpenXml.Office.CustomDocumentInformationPanel
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+            builder.AddValidator(new StringValidator() { IsUri = (true) });
             builder.SetSchema(37, "defaultPropertyEditorNamespace");
         }
 
@@ -249,7 +249,7 @@ namespace DocumentFormat.OpenXml.Office.CustomDocumentInformationPanel
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<BooleanValue>(new NumberValidatorAttribute());
+            builder.AddValidator<BooleanValue>(new NumberValidator());
             builder.SetSchema(37, "showOnOpen");
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_2006_customDocumentInformationPanel.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_2006_customDocumentInformationPanel.g.cs
@@ -249,7 +249,7 @@ namespace DocumentFormat.OpenXml.Office.CustomDocumentInformationPanel
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<BooleanValue>(new NumberValidator());
+            builder.AddValidator<BooleanValue>(NumberValidator.Instance);
             builder.SetSchema(37, "showOnOpen");
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_2006_metadata_contentType.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_2006_metadata_contentType.g.cs
@@ -165,11 +165,11 @@ namespace DocumentFormat.OpenXml.Office.ContentType
 .AddAttribute(41, "contentTypeName", a => a.ContentTypeName)
 .AddAttribute(41, "contentTypeID", a => a.ContentTypeID, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("0x([0-9A-Fa-f][1-9A-Fa-f]|[1-9A-Fa-f][0-9A-Fa-f]|00[0-9A-Fa-f]{32})*"), MinLength = (2L), MaxLength = (1026L) });
+aBuilder.AddValidator(new StringValidator() { Pattern = ("0x([0-9A-Fa-f][1-9A-Fa-f]|[1-9A-Fa-f][0-9A-Fa-f]|00[0-9A-Fa-f]{32})*"), MinLength = (2L), MaxLength = (1026L) });
 })
 .AddAttribute(41, "contentTypeVersion", a => a.ContentTypeVersion, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 })
 .AddAttribute(41, "contentTypeDescription", a => a.ContentTypeDescription)
 .AddAttribute(41, "contentTypeScope", a => a.ContentTypeScope)

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_2006_metadata_properties_metaAttributes.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_2006_metadata_properties_metaAttributes.g.cs
@@ -210,7 +210,7 @@ namespace DocumentFormat.OpenXml.Office.MetaAttributes
 .AddAttribute(0, "hidden", a => a.Hidden)
 .AddAttribute(0, "index", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 })
 .AddAttribute(0, "internalName", a => a.InternalName)
 .AddAttribute(0, "LCID", a => a.LCID)
@@ -222,7 +222,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
 .AddAttribute(0, "showField", a => a.ShowField)
 .AddAttribute(0, "web", a => a.Web, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}") });
+aBuilder.AddValidator(new StringValidator() { Pattern = ("[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}") });
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_2009_07_customui.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_2009_07_customui.g.cs
@@ -3680,7 +3680,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true
 })
 .AddAttribute(0, "getContent", a => a.GetContent, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "invalidateContentOnDrop", a => a.InvalidateContentOnDrop)
@@ -9692,7 +9692,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true
 })
 .AddAttribute(0, "getContent", a => a.GetContent, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "invalidateContentOnDrop", a => a.InvalidateContentOnDrop)
@@ -18043,7 +18043,7 @@ aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (102
             builder.AddElement<TabSet>()
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_2009_07_customui.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_2009_07_customui.g.cs
@@ -295,95 +295,95 @@ namespace DocumentFormat.OpenXml.Office2010.CustomUI
             builder.AddElement<ControlCloneRegular>()
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -713,111 +713,111 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<ButtonRegular>()
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -1093,93 +1093,93 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<CheckBox>()
 .AddAttribute(0, "getPressed", a => a.GetPressed, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -1732,175 +1732,175 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<GalleryRegular>()
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "invalidateContentOnDrop", a => a.InvalidateContentOnDrop)
 .AddAttribute(0, "columns", a => a.Columns, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
 })
 .AddAttribute(0, "rows", a => a.Rows, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
 })
 .AddAttribute(0, "itemWidth", a => a.ItemWidth, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (4096L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (4096L), IsPositive = (true) });
 })
 .AddAttribute(0, "itemHeight", a => a.ItemHeight, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (4096L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (4096L), IsPositive = (true) });
 })
 .AddAttribute(0, "getItemWidth", a => a.GetItemWidth, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemHeight", a => a.GetItemHeight, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showItemLabel", a => a.ShowItemLabel)
 .AddAttribute(0, "showInRibbon", a => a.ShowInRibbon)
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showItemImage", a => a.ShowItemImage)
 .AddAttribute(0, "getItemCount", a => a.GetItemCount, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemLabel", a => a.GetItemLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemScreentip", a => a.GetItemScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemSupertip", a => a.GetItemSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemImage", a => a.GetItemImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemID", a => a.GetItemID, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "sizeString", a => a.SizeString, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSelectedItemID", a => a.GetSelectedItemID, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSelectedItemIndex", a => a.GetSelectedItemIndex, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -2254,115 +2254,115 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<ToggleButtonRegular>()
 .AddAttribute(0, "getPressed", a => a.GetPressed, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -2482,39 +2482,39 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<MenuSeparator>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "title", a => a.Title, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getTitle", a => a.GetTitle, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -2740,57 +2740,57 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -3183,107 +3183,107 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "itemSize", a => a.ItemSize)
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -3656,113 +3656,113 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<DynamicMenuRegular>()
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getContent", a => a.GetContent, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "invalidateContentOnDrop", a => a.InvalidateContentOnDrop)
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -3988,57 +3988,57 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -4430,108 +4430,108 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<MenuWithTitle>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "itemSize", a => a.ItemSize)
 .AddAttribute(0, "title", a => a.Title, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getTitle", a => a.GetTitle, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -4664,31 +4664,31 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<MenuSeparatorNoTitle>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -5019,107 +5019,107 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLeng
 .AddAttribute(0, "size", a => a.Size)
 .AddAttribute(0, "getSize", a => a.GetSize, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -5355,74 +5355,74 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<LabelControl>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -5773,115 +5773,115 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "size", a => a.Size)
 .AddAttribute(0, "getSize", a => a.GetSize, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -6248,119 +6248,119 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "size", a => a.Size)
 .AddAttribute(0, "getSize", a => a.GetSize, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getPressed", a => a.GetPressed, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -6701,114 +6701,114 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "maxLength", a => a.MaxLength, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
 })
 .AddAttribute(0, "getText", a => a.GetText, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onChange", a => a.OnChange, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "sizeString", a => a.SizeString, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -7260,140 +7260,140 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "showItemImage", a => a.ShowItemImage)
 .AddAttribute(0, "getItemCount", a => a.GetItemCount, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemLabel", a => a.GetItemLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemScreentip", a => a.GetItemScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemSupertip", a => a.GetItemSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemImage", a => a.GetItemImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemID", a => a.GetItemID, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "sizeString", a => a.SizeString, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "invalidateContentOnDrop", a => a.InvalidateContentOnDrop)
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "maxLength", a => a.MaxLength, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
 })
 .AddAttribute(0, "getText", a => a.GetText, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onChange", a => a.OnChange, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -7856,141 +7856,141 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<DropDownRegular>()
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showItemImage", a => a.ShowItemImage)
 .AddAttribute(0, "getItemCount", a => a.GetItemCount, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemLabel", a => a.GetItemLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemScreentip", a => a.GetItemScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemSupertip", a => a.GetItemSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemImage", a => a.GetItemImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemID", a => a.GetItemID, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "sizeString", a => a.SizeString, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSelectedItemID", a => a.GetSelectedItemID, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSelectedItemIndex", a => a.GetSelectedItemIndex, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showItemLabel", a => a.ShowItemLabel)
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -8575,179 +8575,179 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "size", a => a.Size)
 .AddAttribute(0, "getSize", a => a.GetSize, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "invalidateContentOnDrop", a => a.InvalidateContentOnDrop)
 .AddAttribute(0, "columns", a => a.Columns, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
 })
 .AddAttribute(0, "rows", a => a.Rows, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
 })
 .AddAttribute(0, "itemWidth", a => a.ItemWidth, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (4096L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (4096L), IsPositive = (true) });
 })
 .AddAttribute(0, "itemHeight", a => a.ItemHeight, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (4096L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (4096L), IsPositive = (true) });
 })
 .AddAttribute(0, "getItemWidth", a => a.GetItemWidth, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemHeight", a => a.GetItemHeight, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showItemLabel", a => a.ShowItemLabel)
 .AddAttribute(0, "showInRibbon", a => a.ShowInRibbon)
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showItemImage", a => a.ShowItemImage)
 .AddAttribute(0, "getItemCount", a => a.GetItemCount, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemLabel", a => a.GetItemLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemScreentip", a => a.GetItemScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemSupertip", a => a.GetItemSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemImage", a => a.GetItemImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemID", a => a.GetItemID, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "sizeString", a => a.SizeString, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSelectedItemID", a => a.GetSelectedItemID, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSelectedItemIndex", a => a.GetSelectedItemIndex, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -9162,112 +9162,112 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "size", a => a.Size)
 .AddAttribute(0, "getSize", a => a.GetSize, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "itemSize", a => a.ItemSize)
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -9664,117 +9664,117 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "size", a => a.Size)
 .AddAttribute(0, "getSize", a => a.GetSize, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getContent", a => a.GetContent, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "invalidateContentOnDrop", a => a.InvalidateContentOnDrop)
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -10020,62 +10020,62 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "size", a => a.Size)
 .AddAttribute(0, "getSize", a => a.GetSize, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -10280,36 +10280,36 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<Box>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "boxStyle", a => a.BoxStyle);
         }
@@ -10498,36 +10498,36 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLeng
             builder.AddElement<ButtonGroup>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -10754,66 +10754,66 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLeng
             builder.AddElement<BackstageMenuButton>()
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "isDefinitive", a => a.IsDefinitive)
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -10993,57 +10993,57 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<BackstageMenuCheckBox>()
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getPressed", a => a.GetPressed, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -11264,61 +11264,61 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<BackstageSubMenu>()
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -11541,69 +11541,69 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<BackstageMenuToggleButton>()
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getPressed", a => a.GetPressed, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -11855,74 +11855,74 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "style", a => a.Style)
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "isDefinitive", a => a.IsDefinitive)
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -12153,73 +12153,73 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
 .AddAttribute(0, "expand", a => a.Expand)
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getPressed", a => a.GetPressed, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -12419,59 +12419,59 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<BackstageEditBox>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "alignLabel", a => a.AlignLabel)
 .AddAttribute(0, "expand", a => a.Expand)
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getText", a => a.GetText, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onChange", a => a.OnChange, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "maxLength", a => a.MaxLength, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (1024L), IsPositive = (true) });
 })
 .AddAttribute(0, "sizeString", a => a.SizeString, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -12762,83 +12762,83 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<BackstageDropDown>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "alignLabel", a => a.AlignLabel)
 .AddAttribute(0, "expand", a => a.Expand)
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSelectedItemIndex", a => a.GetSelectedItemIndex, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "sizeString", a => a.SizeString, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemCount", a => a.GetItemCount, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemLabel", a => a.GetItemLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemID", a => a.GetItemID, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -13086,63 +13086,63 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<RadioGroup>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "alignLabel", a => a.AlignLabel)
 .AddAttribute(0, "expand", a => a.Expand)
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSelectedItemIndex", a => a.GetSelectedItemIndex, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemCount", a => a.GetItemCount, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemLabel", a => a.GetItemLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemID", a => a.GetItemID, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -13400,67 +13400,67 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<BackstageComboBox>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "alignLabel", a => a.AlignLabel)
 .AddAttribute(0, "expand", a => a.Expand)
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getText", a => a.GetText, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onChange", a => a.OnChange, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "sizeString", a => a.SizeString, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemCount", a => a.GetItemCount, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemLabel", a => a.GetItemLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getItemID", a => a.GetItemID, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -13727,83 +13727,83 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<Hyperlink>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "alignLabel", a => a.AlignLabel)
 .AddAttribute(0, "expand", a => a.Expand)
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "target", a => a.Target, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getTarget", a => a.GetTarget, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -13953,35 +13953,35 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<BackstageLabelControl>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "alignLabel", a => a.AlignLabel)
 .AddAttribute(0, "expand", a => a.Expand)
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "noWrap", a => a.NoWrap);
         }
@@ -14123,24 +14123,24 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<GroupBox>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "expand", a => a.Expand)
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -14304,15 +14304,15 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<LayoutContainer>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "align", a => a.Align)
 .AddAttribute(0, "expand", a => a.Expand)
@@ -14488,45 +14488,45 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<ImageControl>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "altText", a => a.AltText, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getAltText", a => a.GetAltText, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -14771,66 +14771,66 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<BackstageGroup>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "style", a => a.Style)
 .AddAttribute(0, "getStyle", a => a.GetStyle, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "helperText", a => a.HelperText, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getHelperText", a => a.GetHelperText, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -15073,61 +15073,61 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<TaskGroup>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "helperText", a => a.HelperText, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getHelperText", a => a.GetHelperText, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "allowedTaskSizes", a => a.AllowedTaskSizes);
         }
@@ -15242,11 +15242,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<MenuRoot>()
 .AddAttribute(0, "title", a => a.Title, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getTitle", a => a.GetTitle, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "itemSize", a => a.ItemSize);
         }
@@ -15364,11 +15364,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<CustomUI>()
 .AddAttribute(0, "onLoad", a => a.OnLoad, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "loadImage", a => a.LoadImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -15551,27 +15551,27 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<Item>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -15881,106 +15881,106 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<VisibleButton>()
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -16300,110 +16300,110 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<VisibleToggleButton>()
 .AddAttribute(0, "getPressed", a => a.GetPressed, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -16523,36 +16523,36 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<Separator>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -16949,84 +16949,84 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLeng
             builder.AddElement<Group>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "autoScale", a => a.AutoScale)
 .AddAttribute(0, "centerVertically", a => a.CenterVertically);
@@ -17392,108 +17392,108 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<ControlCloneQat>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.IdQ, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "size", a => a.Size)
 .AddAttribute(0, "getSize", a => a.GetSize, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showImage", a => a.ShowImage)
 .AddAttribute(0, "getShowImage", a => a.GetShowImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -17893,56 +17893,56 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<Tab>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -18043,13 +18043,13 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<TabSet>()
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -18126,16 +18126,16 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<Command>()
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -18440,7 +18440,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcNam
             builder.AddElement<ContextMenu>()
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -18572,15 +18572,15 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcNam
             builder.AddElement<BackstageItemType>()
                            .AddAttribute(0, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+                               aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
                            })
                            .AddAttribute(0, "label", a => a.Label, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+                               aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
                            })
                            .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+                               aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
                            });
         }
     }
@@ -18807,74 +18807,74 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcNam
             builder.AddElement<BackstageRegularButton>()
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "isDefinitive", a => a.IsDefinitive)
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -19115,69 +19115,69 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<BackstagePrimaryMenu>()
 .AddAttribute(0, "screentip", a => a.Screentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getScreentip", a => a.GetScreentip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "supertip", a => a.Supertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getSupertip", a => a.GetSupertip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -19317,23 +19317,23 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<BackstageMenuGroup>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "itemSize", a => a.ItemSize);
         }
@@ -19873,48 +19873,48 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<TaskGroupCategory>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -20181,86 +20181,86 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<TaskGroupTask>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "isDefinitive", a => a.IsDefinitive)
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -20441,48 +20441,48 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<TaskFormGroupCategory>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -20760,81 +20760,81 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<TaskFormGroupTask>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "description", a => a.Description, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getDescription", a => a.GetDescription, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -21032,45 +21032,45 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<TaskFormGroup>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "helperText", a => a.HelperText, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (4096L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (4096L) });
 })
 .AddAttribute(0, "getHelperText", a => a.GetHelperText, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "showLabel", a => a.ShowLabel)
 .AddAttribute(0, "getShowLabel", a => a.GetShowLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "allowedTaskSizes", a => a.AllowedTaskSizes);
         }
@@ -21524,89 +21524,89 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<BackstageTab>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "title", a => a.Title, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getTitle", a => a.GetTitle, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "columnWidthPercent", a => a.ColumnWidthPercent, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (99L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (99L), IsPositive = (true) });
 })
 .AddAttribute(0, "firstColumnMinWidth", a => a.FirstColumnMinWidth, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (10000L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (10000L), IsPositive = (true) });
 })
 .AddAttribute(0, "firstColumnMaxWidth", a => a.FirstColumnMaxWidth, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (10000L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (10000L), IsPositive = (true) });
 })
 .AddAttribute(0, "secondColumnMinWidth", a => a.SecondColumnMinWidth, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (10000L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (10000L), IsPositive = (true) });
 })
 .AddAttribute(0, "secondColumnMaxWidth", a => a.SecondColumnMaxWidth, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (10000L), IsPositive = (true) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (10000L), IsPositive = (true) });
 });
         }
 
@@ -21880,78 +21880,78 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxI
             builder.AddElement<BackstageFastCommandButton>()
 .AddAttribute(0, "idMso", a => a.IdMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterMso", a => a.InsertAfterMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeMso", a => a.InsertBeforeMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertAfterQ", a => a.InsertAfterQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "insertBeforeQ", a => a.InsertBeforeQulifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "idQ", a => a.QualifiedId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsQName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "tag", a => a.Tag, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onAction", a => a.OnAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "isDefinitive", a => a.IsDefinitive)
 .AddAttribute(0, "enabled", a => a.Enabled)
 .AddAttribute(0, "getEnabled", a => a.GetEnabled, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "label", a => a.Label, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getLabel", a => a.GetLabel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "visible", a => a.Visible)
 .AddAttribute(0, "getVisible", a => a.GetVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "keytip", a => a.Keytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), MinLength = (1L), MaxLength = (3L) });
 })
 .AddAttribute(0, "getKeytip", a => a.GetKeytip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "image", a => a.Image, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "imageMso", a => a.ImageMso, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "getImage", a => a.GetImage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 
@@ -22217,11 +22217,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLeng
             builder.AddElement<Backstage>()
 .AddAttribute(0, "onShow", a => a.OnShow, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 })
 .AddAttribute(0, "onHide", a => a.OnHide, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (1024L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2007_8_2_chart.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2007_8_2_chart.g.cs
@@ -355,7 +355,7 @@ namespace DocumentFormat.OpenXml.Office2010.Drawing.Charts
             builder.AddElement<Style>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (101L), MaxInclusive = (148L) });
 });
         }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2007_8_2_chart.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2007_8_2_chart.g.cs
@@ -355,8 +355,8 @@ namespace DocumentFormat.OpenXml.Office2010.Drawing.Charts
             builder.AddElement<Style>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (101L), MaxInclusive = (148L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (101L), MaxInclusive = (148L) });
 });
         }
 
@@ -455,7 +455,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (101L), Ma
             builder.AddElement<ShapeProperties>()
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2008_diagram.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2008_diagram.g.cs
@@ -276,11 +276,11 @@ aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)
@@ -1479,10 +1479,10 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<Shape>()
 .AddAttribute(0, "modelId", a => a.ModelId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator<Int32Value>(NumberValidator.Instance);
 union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
 });

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2008_diagram.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2008_diagram.g.cs
@@ -162,7 +162,7 @@ namespace DocumentFormat.OpenXml.Office.Drawing
 .AddAttribute(0, "relId", a => a.RelId)
 .AddAttribute(0, "minVer", a => a.MinVer, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 });
         }
 
@@ -276,11 +276,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)
@@ -623,7 +623,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ShapeProperties>()
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -1357,7 +1357,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<GroupShapeProperties>()
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -1479,11 +1479,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Shape>()
 .AddAttribute(0, "modelId", a => a.ModelId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
 });
         }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2010_chartDrawing.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2010_chartDrawing.g.cs
@@ -96,11 +96,11 @@ namespace DocumentFormat.OpenXml.Office2010.Drawing.ChartDrawing
             builder.AddElement<ContentPart>()
 .AddAttribute(19, "id", a => a.RelationshipId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -277,11 +277,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2010_chartDrawing.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2010_chartDrawing.g.cs
@@ -96,7 +96,7 @@ namespace DocumentFormat.OpenXml.Office2010.Drawing.ChartDrawing
             builder.AddElement<ContentPart>()
 .AddAttribute(19, "id", a => a.RelationshipId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
@@ -277,11 +277,11 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2010_compatibility.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2010_compatibility.g.cs
@@ -45,8 +45,8 @@ namespace DocumentFormat.OpenXml.Office2010.Drawing.LegacyCompatibility
             builder.AddElement<CompatibilityShape>()
 .AddAttribute(0, "spid", a => a.ShapeId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2010_compatibility.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2010_compatibility.g.cs
@@ -45,7 +45,7 @@ namespace DocumentFormat.OpenXml.Office2010.Drawing.LegacyCompatibility
             builder.AddElement<CompatibilityShape>()
 .AddAttribute(0, "spid", a => a.ShapeId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2010_diagram.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2010_diagram.g.cs
@@ -120,11 +120,11 @@ namespace DocumentFormat.OpenXml.Office2010.Drawing.Diagram
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2010_diagram.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2010_diagram.g.cs
@@ -120,11 +120,11 @@ namespace DocumentFormat.OpenXml.Office2010.Drawing.Diagram
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2010_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2010_main.g.cs
@@ -143,7 +143,7 @@ namespace DocumentFormat.OpenXml.Office2010.Drawing
             builder.AddElement<IsCanvas>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -235,7 +235,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(19, "id", a => a.RelationshipId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -1536,22 +1536,22 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<ForegroundMark>()
 .AddAttribute(0, "x1", a => a.FirstXCoordinate, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "y1", a => a.FirstYCoordinate, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "x2", a => a.SecondXCoordinate, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "y2", a => a.SecondYCoordinate, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 });
         }
@@ -1622,22 +1622,22 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<BackgroundMark>()
 .AddAttribute(0, "x1", a => a.FirstXCoordinate, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "y1", a => a.FirstYCoordinate, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "x2", a => a.SecondXCoordinate, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "y2", a => a.SecondYCoordinate, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 });
         }
@@ -2915,22 +2915,22 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<BackgroundRemoval>()
 .AddAttribute(0, "t", a => a.MarqueeTop, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "b", a => a.MarqueeBottom, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "l", a => a.MarqueeLeft, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "r", a => a.MarqueeRight, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 });
         }
@@ -3810,11 +3810,11 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxIncl
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2010_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2010_main.g.cs
@@ -143,7 +143,7 @@ namespace DocumentFormat.OpenXml.Office2010.Drawing
             builder.AddElement<IsCanvas>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -231,11 +231,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<GvmlContentPart>()
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(19, "id", a => a.RelationshipId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -605,19 +605,19 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<HiddenLineProperties>()
 .AddAttribute(0, "w", a => a.Width, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (20116800L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (20116800L) });
 })
 .AddAttribute(0, "cap", a => a.CapType, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "cmpd", a => a.CompoundLineType, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "algn", a => a.Alignment, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -984,19 +984,19 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<HiddenShape3D>()
 .AddAttribute(0, "z", a => a.Z, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "extrusionH", a => a.ExtrusionHeight, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(0, "contourW", a => a.ContourWidth, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(0, "prstMaterial", a => a.PresetMaterial, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -1536,23 +1536,23 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<ForegroundMark>()
 .AddAttribute(0, "x1", a => a.FirstXCoordinate, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "y1", a => a.FirstYCoordinate, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "x2", a => a.SecondXCoordinate, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "y2", a => a.SecondYCoordinate, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 });
         }
 
@@ -1622,23 +1622,23 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<BackgroundMark>()
 .AddAttribute(0, "x1", a => a.FirstXCoordinate, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "y1", a => a.FirstYCoordinate, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "x2", a => a.SecondXCoordinate, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "y2", a => a.SecondYCoordinate, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 });
         }
 
@@ -1678,7 +1678,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<ArtisticBlur>()
 .AddAttribute(0, "radius", a => a.Radius, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100L) });
 });
         }
 
@@ -1728,11 +1728,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<ArtisticCement>()
 .AddAttribute(0, "trans", a => a.Transparancy, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "crackSpacing", a => a.CrackSpacing, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100L) });
 });
         }
 
@@ -1782,11 +1782,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<ArtisticChalkSketch>()
 .AddAttribute(0, "trans", a => a.Transparancy, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "pressure", a => a.Pressure, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (4L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (4L) });
 });
         }
 
@@ -1836,11 +1836,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<ArtisticCrisscrossEtching>()
 .AddAttribute(0, "trans", a => a.Transparancy, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "pressure", a => a.Pressure, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100L) });
 });
         }
 
@@ -1890,11 +1890,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<ArtisticCutout>()
 .AddAttribute(0, "trans", a => a.Transparancy, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "numberOfShades", a => a.NumberOfShades, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (6L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (6L) });
 });
         }
 
@@ -1944,11 +1944,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<ArtisticFilmGrain>()
 .AddAttribute(0, "trans", a => a.Transparancy, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "grainSize", a => a.GrainSize, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100L) });
 });
         }
 
@@ -1998,11 +1998,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<ArtisticGlass>()
 .AddAttribute(0, "trans", a => a.Transparancy, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "scaling", a => a.Scaling, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100L) });
 });
         }
 
@@ -2052,11 +2052,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<ArtisticGlowDiffused>()
 .AddAttribute(0, "trans", a => a.Transparancy, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "intensity", a => a.Intensity, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (10L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (10L) });
 });
         }
 
@@ -2106,11 +2106,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<ArtisticGlowEdges>()
 .AddAttribute(0, "trans", a => a.Transparancy, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "smoothness", a => a.Smoothness, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (10L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (10L) });
 });
         }
 
@@ -2160,11 +2160,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<ArtisticLightScreen>()
 .AddAttribute(0, "trans", a => a.Transparancy, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "gridSize", a => a.GridSize, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (10L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (10L) });
 });
         }
 
@@ -2214,11 +2214,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<ArtisticLineDrawing>()
 .AddAttribute(0, "trans", a => a.Transparancy, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "pencilSize", a => a.PencilSize, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100L) });
 });
         }
 
@@ -2268,11 +2268,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<ArtisticMarker>()
 .AddAttribute(0, "trans", a => a.Transparancy, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "size", a => a.Size, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100L) });
 });
         }
 
@@ -2322,11 +2322,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<ArtisticMosaicBubbles>()
 .AddAttribute(0, "trans", a => a.Transparancy, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "pressure", a => a.Pressure, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100L) });
 });
         }
 
@@ -2376,11 +2376,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<ArtisticPaintStrokes>()
 .AddAttribute(0, "trans", a => a.Transparancy, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "intensity", a => a.Intensity, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (10L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (10L) });
 });
         }
 
@@ -2430,11 +2430,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<ArtisticPaintBrush>()
 .AddAttribute(0, "trans", a => a.Transparancy, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "brushSize", a => a.BrushSize, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (10L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (10L) });
 });
         }
 
@@ -2484,11 +2484,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<ArtisticPastelsSmooth>()
 .AddAttribute(0, "trans", a => a.Transparancy, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "scaling", a => a.BrushSize, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100L) });
 });
         }
 
@@ -2538,11 +2538,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<ArtisticPencilGrayscale>()
 .AddAttribute(0, "trans", a => a.Transparancy, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "pencilSize", a => a.BrushSize, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100L) });
 });
         }
 
@@ -2592,11 +2592,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<ArtisticPencilSketch>()
 .AddAttribute(0, "trans", a => a.Transparancy, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "pressure", a => a.Pressure, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100L) });
 });
         }
 
@@ -2646,11 +2646,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<ArtisticPhotocopy>()
 .AddAttribute(0, "trans", a => a.Transparancy, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "detail", a => a.Detail, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (10L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (10L) });
 });
         }
 
@@ -2700,11 +2700,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<ArtisticPlasticWrap>()
 .AddAttribute(0, "trans", a => a.Transparancy, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "smoothness", a => a.Smoothness, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (10L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (10L) });
 });
         }
 
@@ -2754,11 +2754,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<ArtisticTexturizer>()
 .AddAttribute(0, "trans", a => a.Transparancy, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "scaling", a => a.Scaling, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100L) });
 });
         }
 
@@ -2808,11 +2808,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<ArtisticWatercolorSponge>()
 .AddAttribute(0, "trans", a => a.Transparancy, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "brushSize", a => a.BrushSize, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (10L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (10L) });
 });
         }
 
@@ -2915,23 +2915,23 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<BackgroundRemoval>()
 .AddAttribute(0, "t", a => a.MarqueeTop, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "b", a => a.MarqueeBottom, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "l", a => a.MarqueeLeft, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "r", a => a.MarqueeRight, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 });
         }
 
@@ -2989,11 +2989,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<BrightnessContrast>()
 .AddAttribute(0, "bright", a => a.Bright, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "contrast", a => a.Contrast, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
 });
         }
 
@@ -3033,7 +3033,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-100000L)
             builder.AddElement<ColorTemperature>()
 .AddAttribute(0, "colorTemp", a => a.ColorTemperatureValue, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1500L), MaxInclusive = (11500L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1500L), MaxInclusive = (11500L) });
 });
         }
 
@@ -3073,7 +3073,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1500L), M
             builder.AddElement<Saturation>()
 .AddAttribute(0, "sat", a => a.SaturationAmount, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (400000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (400000L) });
 });
         }
 
@@ -3113,7 +3113,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<SharpenSoften>()
 .AddAttribute(0, "amount", a => a.Amount, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
 });
         }
 
@@ -3810,11 +3810,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-100000L)
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2010_slicer.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2010_slicer.g.cs
@@ -77,7 +77,7 @@ namespace DocumentFormat.OpenXml.Office2010.Drawing.Slicer
             builder.AddElement<Slicer>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2010_slicer.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2010_slicer.g.cs
@@ -77,7 +77,7 @@ namespace DocumentFormat.OpenXml.Office2010.Drawing.Slicer
             builder.AddElement<Slicer>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2012_chart.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2012_chart.g.cs
@@ -164,7 +164,7 @@ namespace DocumentFormat.OpenXml.Office2013.Drawing.Chart
             builder.AddElement<NumberingFormat>()
 .AddAttribute(0, "formatCode", a => a.FormatCode, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "sourceLinked", a => a.SourceLinked);
         }
@@ -3942,7 +3942,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<Explosion>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2012_chart.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2012_chart.g.cs
@@ -164,7 +164,7 @@ namespace DocumentFormat.OpenXml.Office2013.Drawing.Chart
             builder.AddElement<NumberingFormat>()
 .AddAttribute(0, "formatCode", a => a.FormatCode, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "sourceLinked", a => a.SourceLinked);
         }
@@ -264,7 +264,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ShapeProperties>()
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -3942,7 +3942,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Explosion>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2012_chartStyle.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2012_chartStyle.g.cs
@@ -100,11 +100,11 @@ namespace DocumentFormat.OpenXml.Office2013.Drawing.ChartStyle
             builder.AddElement<ColorStyle>()
 .AddAttribute(0, "meth", a => a.Method, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Office2013.Drawing.ChartStyle.ColorStyleMethodEnum>>(new EnumValidator());
-union.AddValidator(new StringValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Office2013.Drawing.ChartStyle.ColorStyleMethodEnum>>(EnumValidator.Instance);
+union.AddValidator(StringValidator.Instance);
 });
 })
 .AddAttribute(0, "id", a => a.Id);
@@ -1118,9 +1118,9 @@ union.AddValidator(new StringValidator());
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<UInt32Value>(new NumberValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Office2013.Drawing.ChartStyle.StyleColorEnum>>(new EnumValidator());
-union.AddValidator(new StringValidator());
+union.AddValidator<UInt32Value>(NumberValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Office2013.Drawing.ChartStyle.StyleColorEnum>>(EnumValidator.Instance);
+union.AddValidator(StringValidator.Instance);
 });
 });
         }
@@ -1492,7 +1492,7 @@ union.AddValidator(new StringValidator());
             builder.AddElement<StyleReference>()
 .AddAttribute(0, "idx", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "mods", a => a.Modifiers);
         }
@@ -1528,7 +1528,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<DoubleValue>(new NumberValidator());
+            builder.AddValidator<DoubleValue>(NumberValidator.Instance);
             builder.SetSchema(65, "lineWidthScale");
             builder.Availability = FileFormatVersions.Office2013;
         }
@@ -1622,7 +1622,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<FontReference>()
 .AddAttribute(0, "idx", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "mods", a => a.Modifiers);

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2012_chartStyle.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2012_chartStyle.g.cs
@@ -100,11 +100,11 @@ namespace DocumentFormat.OpenXml.Office2013.Drawing.ChartStyle
             builder.AddElement<ColorStyle>()
 .AddAttribute(0, "meth", a => a.Method, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Office2013.Drawing.ChartStyle.ColorStyleMethodEnum>>(new EnumValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Office2013.Drawing.ChartStyle.ColorStyleMethodEnum>>(new EnumValidator());
+union.AddValidator(new StringValidator());
 });
 })
 .AddAttribute(0, "id", a => a.Id);
@@ -1118,9 +1118,9 @@ union.AddValidator(new StringValidatorAttribute());
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<UInt32Value>(new NumberValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Office2013.Drawing.ChartStyle.StyleColorEnum>>(new EnumValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<UInt32Value>(new NumberValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Office2013.Drawing.ChartStyle.StyleColorEnum>>(new EnumValidator());
+union.AddValidator(new StringValidator());
 });
 });
         }
@@ -1492,7 +1492,7 @@ union.AddValidator(new StringValidatorAttribute());
             builder.AddElement<StyleReference>()
 .AddAttribute(0, "idx", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "mods", a => a.Modifiers);
         }
@@ -1528,7 +1528,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<DoubleValue>(new NumberValidatorAttribute());
+            builder.AddValidator<DoubleValue>(new NumberValidator());
             builder.SetSchema(65, "lineWidthScale");
             builder.Availability = FileFormatVersions.Office2013;
         }
@@ -1622,8 +1622,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<FontReference>()
 .AddAttribute(0, "idx", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "mods", a => a.Modifiers);
         }
@@ -1742,7 +1742,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<ShapeProperties>()
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -2090,29 +2090,29 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "altLang", a => a.AlternativeLanguage)
 .AddAttribute(0, "sz", a => a.FontSize, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (100L), MaxInclusive = (400000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (100L), MaxInclusive = (400000L) });
 })
 .AddAttribute(0, "b", a => a.Bold)
 .AddAttribute(0, "i", a => a.Italic)
 .AddAttribute(0, "u", a => a.Underline, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "strike", a => a.Strike, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "kern", a => a.Kerning, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (400000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (400000L) });
 })
 .AddAttribute(0, "cap", a => a.Capital, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "spc", a => a.Spacing, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-400000L), MaxInclusive = (400000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-400000L), MaxInclusive = (400000L) });
 })
 .AddAttribute(0, "normalizeH", a => a.NormalizeHeight)
 .AddAttribute(0, "baseline", a => a.Baseline)
@@ -2452,19 +2452,19 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-400000L)
 .AddAttribute(0, "spcFirstLastPara", a => a.UseParagraphSpacing)
 .AddAttribute(0, "vertOverflow", a => a.VerticalOverflow, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "horzOverflow", a => a.HorizontalOverflow, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "vert", a => a.Vertical, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "wrap", a => a.Wrap, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "lIns", a => a.LeftInset)
 .AddAttribute(0, "tIns", a => a.TopInset)
@@ -2472,17 +2472,17 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "bIns", a => a.BottomInset)
 .AddAttribute(0, "numCol", a => a.ColumnCount, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (16L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (16L) });
 })
 .AddAttribute(0, "spcCol", a => a.ColumnSpacing, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 })
 .AddAttribute(0, "rtlCol", a => a.RightToLeftColumns)
 .AddAttribute(0, "fromWordArt", a => a.FromWordArt)
 .AddAttribute(0, "anchor", a => a.Anchor, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "anchorCtr", a => a.AnchorCenter)
 .AddAttribute(0, "forceAA", a => a.ForceAntiAlias)
@@ -2698,31 +2698,31 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<AxisProperties>()
                            .AddAttribute(0, "visible", a => a.Visible, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+                               aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                            })
                            .AddAttribute(0, "majorTick", a => a.MajorTick, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+                               aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                            })
                            .AddAttribute(0, "minorTick", a => a.MinorTickProp, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+                               aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                            })
                            .AddAttribute(0, "labelPosition", a => a.LabelPosition, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+                               aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                            })
                            .AddAttribute(0, "majorGridlines", a => a.MajorGridlines, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+                               aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                            })
                            .AddAttribute(0, "minorGridlines", a => a.MinorGridlinesProp, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+                               aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                            })
                            .AddAttribute(0, "title", a => a.TitleProp, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+                               aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                            });
         }
     }
@@ -2829,35 +2829,35 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<DataSeries>()
 .AddAttribute(0, "overlap", a => a.Overlap, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-100L), MaxInclusive = (100L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100L), MaxInclusive = (100L) });
 })
 .AddAttribute(0, "gapWidth", a => a.GapWidth, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (500L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (500L) });
 })
 .AddAttribute(0, "gapDepth", a => a.GapDepth, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (500L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (500L) });
 })
 .AddAttribute(0, "doughnutHoleSize", a => a.DoughnutHoleSize, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (10L), MaxInclusive = (90L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (10L), MaxInclusive = (90L) });
 })
 .AddAttribute(0, "markerVisible", a => a.MarkerVisible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "hiloLines", a => a.HiloLines, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "dropLines", a => a.DropLines, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "seriesLines", a => a.SeriesLines, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -2947,27 +2947,27 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<DataLabels>()
 .AddAttribute(0, "position", a => a.Position, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "value", a => a.Value, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "seriesName", a => a.SeriesName, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "categoryName", a => a.CategoryName, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "legendKey", a => a.LegendKey, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "percentage", a => a.Percentage, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -3037,19 +3037,19 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<DataTable>()
 .AddAttribute(0, "legendKeys", a => a.LegendKeys, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "horizontalBorder", a => a.HorizontalBorder, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "verticalBorder", a => a.VerticalBorder, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "outlineBorder", a => a.OutlineBorder, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -3109,15 +3109,15 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Legend>()
 .AddAttribute(0, "visible", a => a.Visible, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "includeInLayout", a => a.IncludeInLayout, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "position", a => a.Position, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -3157,7 +3157,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Title>()
 .AddAttribute(0, "position", a => a.Position, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -3217,15 +3217,15 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Trendline>()
 .AddAttribute(0, "add", a => a.Add, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "equation", a => a.Equation, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "rsquared", a => a.RSquared, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -3315,27 +3315,27 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<View3DProperties>()
 .AddAttribute(0, "rotX", a => a.RotX, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-90L), MaxInclusive = (90L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-90L), MaxInclusive = (90L) });
 })
 .AddAttribute(0, "rotY", a => a.RotY, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (360L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (360L) });
 })
 .AddAttribute(0, "rAngAx", a => a.RightAngleAxes, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "perspective", a => a.Perspective, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (240L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (240L) });
 })
 .AddAttribute(0, "heightPercent", a => a.HeightPercent, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (5L), MaxInclusive = (500L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (5L), MaxInclusive = (500L) });
 })
 .AddAttribute(0, "depthPercent", a => a.DepthPercent, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (20L), MaxInclusive = (2000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (20L), MaxInclusive = (2000L) });
 });
         }
 
@@ -5921,11 +5921,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (20L), Max
             builder.AddElement<MarkerLayoutProperties>()
 .AddAttribute(0, "symbol", a => a.Symbol, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "size", a => a.Size, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (2L), MaxInclusive = (72L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (2L), MaxInclusive = (72L) });
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2012_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2012_main.g.cs
@@ -75,19 +75,19 @@ namespace DocumentFormat.OpenXml.Office2013.Drawing
             builder.AddElement<BackgroundProperties>()
 .AddAttribute(0, "bwMode", a => a.Mode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "bwPure", a => a.Pure, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "bwNormal", a => a.Normal, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "targetScreenSize", a => a.TargetScreenSize, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -334,11 +334,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "isSignatureLine", a => a.IsSignatureLine)
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "provId", a => a.ProviderId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "signingInstructionsSet", a => a.SigningInstructionsSet)
 .AddAttribute(0, "allowComments", a => a.AllowComments)

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2012_timeslicer.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2012_timeslicer.g.cs
@@ -76,7 +76,7 @@ namespace DocumentFormat.OpenXml.Office2013.Drawing.TimeSlicer
             builder.AddElement<TimeSlicer>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2012_timeslicer.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2012_timeslicer.g.cs
@@ -76,7 +76,7 @@ namespace DocumentFormat.OpenXml.Office2013.Drawing.TimeSlicer
             builder.AddElement<TimeSlicer>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2014_chart.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2014_chart.g.cs
@@ -105,7 +105,7 @@ namespace DocumentFormat.OpenXml.Office2016.Drawing.Charts
             builder.AddElement<ShapeProperties>()
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -197,7 +197,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<UnsignedIntegerType>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -829,7 +829,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<UniqueIDChart>()
                            .AddAttribute(0, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -1528,7 +1528,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<LiteralDataChart>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -1603,7 +1603,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<UInt32Value>(new NumberValidatorAttribute());
+            builder.AddValidator<UInt32Value>(new NumberValidator());
             builder.SetSchema(82, "ptidx");
             builder.Availability = FileFormatVersions.Office2016;
         }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2014_chart.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2014_chart.g.cs
@@ -197,7 +197,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<UnsignedIntegerType>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -829,7 +829,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<UniqueIDChart>()
                            .AddAttribute(0, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -1528,7 +1528,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<LiteralDataChart>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -1603,7 +1603,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<UInt32Value>(new NumberValidator());
+            builder.AddValidator<UInt32Value>(NumberValidator.Instance);
             builder.SetSchema(82, "ptidx");
             builder.Availability = FileFormatVersions.Office2016;
         }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2014_chartex.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2014_chartex.g.cs
@@ -247,7 +247,7 @@ namespace DocumentFormat.OpenXml.Office2016.Drawing.ChartDrawing
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<UInt32Value>(new NumberValidatorAttribute());
+            builder.AddValidator<UInt32Value>(new NumberValidator());
             builder.SetSchema(80, "binCount");
             builder.Availability = FileFormatVersions.Office2016;
         }
@@ -312,7 +312,7 @@ namespace DocumentFormat.OpenXml.Office2016.Drawing.ChartDrawing
             builder.AddElement<Extension2>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -372,7 +372,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<ChartStringValue>()
 .AddAttribute(0, "idx", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -425,7 +425,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<NumericValue>()
 .AddAttribute(0, "idx", a => a.Idx, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -498,7 +498,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<NumericDimension>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -582,7 +582,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<StringDimension>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -712,11 +712,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ExternalData>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(80, "autoUpdate", a => a.AutoUpdate, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2016));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2016));
 });
         }
 
@@ -791,7 +791,7 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<Data>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -1279,7 +1279,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ShapeProperties>()
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -1497,8 +1497,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<DoubleValue>(new NumberValidatorAttribute() { MinInclusive = (0L) });
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<DoubleValue>(new NumberValidator() { MinInclusive = (0L) });
+union.AddValidator(new StringValidator());
 });
 });
         }
@@ -1571,32 +1571,32 @@ union.AddValidator(new StringValidatorAttribute());
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<DoubleValue>(new NumberValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<DoubleValue>(new NumberValidator());
+union.AddValidator(new StringValidator());
 });
 })
 .AddAttribute(0, "min", a => a.Min, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<DoubleValue>(new NumberValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<DoubleValue>(new NumberValidator());
+union.AddValidator(new StringValidator());
 });
 })
 .AddAttribute(0, "majorUnit", a => a.MajorUnit, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<DoubleValue>(new NumberValidatorAttribute() { MinExclusive = (0L) });
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<DoubleValue>(new NumberValidator() { MinExclusive = (0L) });
+union.AddValidator(new StringValidator());
 });
 })
 .AddAttribute(0, "minorUnit", a => a.MinorUnit, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<DoubleValue>(new NumberValidatorAttribute() { MinExclusive = (0L) });
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<DoubleValue>(new NumberValidator() { MinExclusive = (0L) });
+union.AddValidator(new StringValidator());
 });
 });
         }
@@ -2358,7 +2358,7 @@ union.AddValidator(new StringValidatorAttribute());
             builder.AddElement<NumberFormat>()
 .AddAttribute(0, "formatCode", a => a.FormatCode, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "sourceLinked", a => a.SourceLinked);
         }
@@ -2397,7 +2397,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<DoubleValue>(new NumberValidatorAttribute());
+            builder.AddValidator<DoubleValue>(new NumberValidator());
             builder.SetSchema(80, "binSize");
             builder.Availability = FileFormatVersions.Office2016;
         }
@@ -2438,7 +2438,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ParentLabelLayout>()
 .AddAttribute(0, "val", a => a.ParentLabelLayoutVal, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -2640,16 +2640,16 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<DoubleValue>(new NumberValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<DoubleValue>(new NumberValidator());
+union.AddValidator(new StringValidator());
 });
 })
 .AddAttribute(0, "overflow", a => a.Overflow, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<DoubleValue>(new NumberValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<DoubleValue>(new NumberValidator());
+union.AddValidator(new StringValidator());
 });
 });
         }
@@ -3238,7 +3238,7 @@ union.AddValidator(new StringValidatorAttribute());
             builder.AddElement<DataLabel>()
 .AddAttribute(0, "idx", a => a.Idx, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "pos", a => a.Pos);
         }
@@ -3369,7 +3369,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<DataLabelHidden>()
 .AddAttribute(0, "idx", a => a.Idx, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -3442,7 +3442,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<DataPoint>()
 .AddAttribute(0, "idx", a => a.Idx, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -3677,7 +3677,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<DataId>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -3825,7 +3825,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<UInt32Value>(new NumberValidatorAttribute());
+            builder.AddValidator<UInt32Value>(new NumberValidator());
             builder.SetSchema(80, "axisId");
             builder.Availability = FileFormatVersions.Office2016;
         }
@@ -4043,7 +4043,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Series>()
 .AddAttribute(0, "layoutId", a => a.LayoutId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "hidden", a => a.Hidden)
 .AddAttribute(0, "ownerIdx", a => a.OwnerIdx)
@@ -4274,7 +4274,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Axis>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "hidden", a => a.Hidden);
         }
@@ -4962,27 +4962,27 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<PageMargins>()
 .AddAttribute(0, "l", a => a.L, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "r", a => a.R, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "t", a => a.T, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "b", a => a.B, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "header", a => a.Header, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "footer", a => a.Footer, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -5494,63 +5494,63 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ColorMappingType>()
 .AddAttribute(0, "bg1", a => a.Background1, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "tx1", a => a.Text1, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "bg2", a => a.Background2, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "tx2", a => a.Text2, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent1", a => a.Accent1, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent2", a => a.Accent2, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent3", a => a.Accent3, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent4", a => a.Accent4, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent5", a => a.Accent5, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent6", a => a.Accent6, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "hlink", a => a.Hyperlink, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "folHlink", a => a.FollowedHyperlink, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -5799,7 +5799,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<StringLevel>()
 .AddAttribute(0, "ptCount", a => a.PtCount, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -5887,7 +5887,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<NumericLevel>()
 .AddAttribute(0, "ptCount", a => a.PtCount, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "formatCode", a => a.FormatCode);
         }
@@ -5935,7 +5935,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<UnsignedIntegerType>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2014_chartex.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2014_chartex.g.cs
@@ -247,7 +247,7 @@ namespace DocumentFormat.OpenXml.Office2016.Drawing.ChartDrawing
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<UInt32Value>(new NumberValidator());
+            builder.AddValidator<UInt32Value>(NumberValidator.Instance);
             builder.SetSchema(80, "binCount");
             builder.Availability = FileFormatVersions.Office2016;
         }
@@ -372,7 +372,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<ChartStringValue>()
 .AddAttribute(0, "idx", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -425,7 +425,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<NumericValue>()
 .AddAttribute(0, "idx", a => a.Idx, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -498,7 +498,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<NumericDimension>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -582,7 +582,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<StringDimension>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -712,7 +712,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ExternalData>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(80, "autoUpdate", a => a.AutoUpdate, aBuilder =>
 {
@@ -791,7 +791,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2016))
             builder.AddElement<Data>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -1498,7 +1498,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<DoubleValue>(new NumberValidator() { MinInclusive = (0L) });
-union.AddValidator(new StringValidator());
+union.AddValidator(StringValidator.Instance);
 });
 });
         }
@@ -1571,16 +1571,16 @@ union.AddValidator(new StringValidator());
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<DoubleValue>(new NumberValidator());
-union.AddValidator(new StringValidator());
+union.AddValidator<DoubleValue>(NumberValidator.Instance);
+union.AddValidator(StringValidator.Instance);
 });
 })
 .AddAttribute(0, "min", a => a.Min, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<DoubleValue>(new NumberValidator());
-union.AddValidator(new StringValidator());
+union.AddValidator<DoubleValue>(NumberValidator.Instance);
+union.AddValidator(StringValidator.Instance);
 });
 })
 .AddAttribute(0, "majorUnit", a => a.MajorUnit, aBuilder =>
@@ -1588,7 +1588,7 @@ union.AddValidator(new StringValidator());
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<DoubleValue>(new NumberValidator() { MinExclusive = (0L) });
-union.AddValidator(new StringValidator());
+union.AddValidator(StringValidator.Instance);
 });
 })
 .AddAttribute(0, "minorUnit", a => a.MinorUnit, aBuilder =>
@@ -1596,7 +1596,7 @@ union.AddValidator(new StringValidator());
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<DoubleValue>(new NumberValidator() { MinExclusive = (0L) });
-union.AddValidator(new StringValidator());
+union.AddValidator(StringValidator.Instance);
 });
 });
         }
@@ -2358,7 +2358,7 @@ union.AddValidator(new StringValidator());
             builder.AddElement<NumberFormat>()
 .AddAttribute(0, "formatCode", a => a.FormatCode, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "sourceLinked", a => a.SourceLinked);
         }
@@ -2397,7 +2397,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<DoubleValue>(new NumberValidator());
+            builder.AddValidator<DoubleValue>(NumberValidator.Instance);
             builder.SetSchema(80, "binSize");
             builder.Availability = FileFormatVersions.Office2016;
         }
@@ -2438,7 +2438,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ParentLabelLayout>()
 .AddAttribute(0, "val", a => a.ParentLabelLayoutVal, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -2640,16 +2640,16 @@ aBuilder.AddValidator(new RequiredValidator());
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<DoubleValue>(new NumberValidator());
-union.AddValidator(new StringValidator());
+union.AddValidator<DoubleValue>(NumberValidator.Instance);
+union.AddValidator(StringValidator.Instance);
 });
 })
 .AddAttribute(0, "overflow", a => a.Overflow, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<DoubleValue>(new NumberValidator());
-union.AddValidator(new StringValidator());
+union.AddValidator<DoubleValue>(NumberValidator.Instance);
+union.AddValidator(StringValidator.Instance);
 });
 });
         }
@@ -3238,7 +3238,7 @@ union.AddValidator(new StringValidator());
             builder.AddElement<DataLabel>()
 .AddAttribute(0, "idx", a => a.Idx, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "pos", a => a.Pos);
         }
@@ -3369,7 +3369,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<DataLabelHidden>()
 .AddAttribute(0, "idx", a => a.Idx, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -3442,7 +3442,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<DataPoint>()
 .AddAttribute(0, "idx", a => a.Idx, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -3677,7 +3677,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<DataId>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -3825,7 +3825,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<UInt32Value>(new NumberValidator());
+            builder.AddValidator<UInt32Value>(NumberValidator.Instance);
             builder.SetSchema(80, "axisId");
             builder.Availability = FileFormatVersions.Office2016;
         }
@@ -4043,7 +4043,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Series>()
 .AddAttribute(0, "layoutId", a => a.LayoutId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "hidden", a => a.Hidden)
 .AddAttribute(0, "ownerIdx", a => a.OwnerIdx)
@@ -4274,7 +4274,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Axis>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "hidden", a => a.Hidden);
         }
@@ -4962,27 +4962,27 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<PageMargins>()
 .AddAttribute(0, "l", a => a.L, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "r", a => a.R, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "t", a => a.T, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "b", a => a.B, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "header", a => a.Header, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "footer", a => a.Footer, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -5494,62 +5494,62 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ColorMappingType>()
 .AddAttribute(0, "bg1", a => a.Background1, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "tx1", a => a.Text1, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "bg2", a => a.Background2, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "tx2", a => a.Text2, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent1", a => a.Accent1, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent2", a => a.Accent2, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent3", a => a.Accent3, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent4", a => a.Accent4, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent5", a => a.Accent5, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent6", a => a.Accent6, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "hlink", a => a.Hyperlink, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "folHlink", a => a.FollowedHyperlink, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -5799,7 +5799,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<StringLevel>()
 .AddAttribute(0, "ptCount", a => a.PtCount, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -5887,7 +5887,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<NumericLevel>()
 .AddAttribute(0, "ptCount", a => a.PtCount, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "formatCode", a => a.FormatCode);
         }
@@ -5935,7 +5935,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<UnsignedIntegerType>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2014_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2014_main.g.cs
@@ -45,7 +45,7 @@ namespace DocumentFormat.OpenXml.Office2016.Drawing
             builder.AddElement<CreationId>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
 
@@ -85,7 +85,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<PredecessorDrawingElementReference>()
 .AddAttribute(0, "pred", a => a.Pred, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
 
@@ -135,11 +135,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<ConnectableReferences>()
 .AddAttribute(0, "st", a => a.St, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "end", a => a.End, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
 
@@ -227,7 +227,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<OpenXmlIdentifierElement>()
                            .AddAttribute(0, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2014_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2014_main.g.cs
@@ -227,7 +227,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<OpenXmlIdentifierElement>()
                            .AddAttribute(0, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_excel_2006_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_excel_2006_main.g.cs
@@ -388,7 +388,7 @@ namespace DocumentFormat.OpenXml.Office.Excel
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<ListValue<StringValue>>(new NumberValidator());
+            builder.AddValidator<ListValue<StringValue>>(NumberValidator.Instance);
             builder.SetSchema(32, "sqref");
             builder.Availability = FileFormatVersions.Office2010;
         }
@@ -507,7 +507,7 @@ namespace DocumentFormat.OpenXml.Office.Excel
             builder.AddElement<RowSortMap>()
 .AddAttribute(0, "ref", a => a.Ref, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "count", a => a.Count, aBuilder =>
 {
@@ -598,7 +598,7 @@ aBuilder.AddValidator(new NumberValidator() { MaxInclusive = (536870910L) });
             builder.AddElement<ColumnSortMap>()
 .AddAttribute(0, "ref", a => a.Ref, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "count", a => a.Count, aBuilder =>
 {
@@ -705,11 +705,11 @@ aBuilder.AddValidator(new NumberValidator() { MaxInclusive = (536870910L) });
             builder.AddElement<SortMapItemType>()
                            .AddAttribute(0, "newVal", a => a.NewVal, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            })
                            .AddAttribute(0, "oldVal", a => a.OldVal, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_excel_2006_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_excel_2006_main.g.cs
@@ -388,7 +388,7 @@ namespace DocumentFormat.OpenXml.Office.Excel
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<ListValue<StringValue>>(new NumberValidatorAttribute());
+            builder.AddValidator<ListValue<StringValue>>(new NumberValidator());
             builder.SetSchema(32, "sqref");
             builder.Availability = FileFormatVersions.Office2010;
         }
@@ -507,11 +507,11 @@ namespace DocumentFormat.OpenXml.Office.Excel
             builder.AddElement<RowSortMap>()
 .AddAttribute(0, "ref", a => a.Ref, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "count", a => a.Count, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MaxInclusive = (536870910L) });
+aBuilder.AddValidator(new NumberValidator() { MaxInclusive = (536870910L) });
 });
         }
 
@@ -598,11 +598,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MaxInclusive = (536870910
             builder.AddElement<ColumnSortMap>()
 .AddAttribute(0, "ref", a => a.Ref, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "count", a => a.Count, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MaxInclusive = (536870910L) });
+aBuilder.AddValidator(new NumberValidator() { MaxInclusive = (536870910L) });
 });
         }
 
@@ -705,11 +705,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MaxInclusive = (536870910
             builder.AddElement<SortMapItemType>()
                            .AddAttribute(0, "newVal", a => a.NewVal, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            })
                            .AddAttribute(0, "oldVal", a => a.OldVal, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_excel_2010_spreadsheetDrawing.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_excel_2010_spreadsheetDrawing.g.cs
@@ -96,7 +96,7 @@ namespace DocumentFormat.OpenXml.Office2010.Excel.Drawing
             builder.AddElement<ContentPart>()
 .AddAttribute(19, "id", a => a.RelationshipId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
@@ -277,11 +277,11 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_excel_2010_spreadsheetDrawing.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_excel_2010_spreadsheetDrawing.g.cs
@@ -96,11 +96,11 @@ namespace DocumentFormat.OpenXml.Office2010.Excel.Drawing
             builder.AddElement<ContentPart>()
 .AddAttribute(19, "id", a => a.RelationshipId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -277,11 +277,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_powerpoint_2010_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_powerpoint_2010_main.g.cs
@@ -571,7 +571,7 @@ namespace DocumentFormat.OpenXml.Office2010.PowerPoint
             builder.AddElement<SideDirectionTransitionType>()
                            .AddAttribute(0, "dir", a => a.Direction, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+                               aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                            });
         }
     }
@@ -731,7 +731,7 @@ namespace DocumentFormat.OpenXml.Office2010.PowerPoint
             builder.AddElement<LeftRightDirectionTransitionType>()
                            .AddAttribute(0, "dir", a => a.Direction, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+                               aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                            });
         }
     }
@@ -770,8 +770,8 @@ namespace DocumentFormat.OpenXml.Office2010.PowerPoint
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.TransitionCornerDirectionValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Office2010.PowerPoint.TransitionCenterDirectionTypeValues>>(new EnumValidatorAttribute());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.TransitionCornerDirectionValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Office2010.PowerPoint.TransitionCenterDirectionTypeValues>>(new EnumValidator());
 });
 });
         }
@@ -902,7 +902,7 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.Office2010.PowerPoint.Transi
             builder.AddElement<PrismTransition>()
 .AddAttribute(0, "dir", a => a.Direction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "isContent", a => a.IsContent)
 .AddAttribute(0, "isInverted", a => a.IsInverted);
@@ -992,7 +992,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<OrientationTransitionType>()
                            .AddAttribute(0, "dir", a => a.Direction, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+                               aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                            });
         }
     }
@@ -1039,11 +1039,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<GlitterTransition>()
 .AddAttribute(0, "dir", a => a.Direction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "pattern", a => a.Pattern, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -1083,7 +1083,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<WarpTransition>()
 .AddAttribute(0, "dir", a => a.Direction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -1133,7 +1133,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<FlythroughTransition>()
 .AddAttribute(0, "dir", a => a.Direction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "hasBounce", a => a.HasBounce);
         }
@@ -1184,11 +1184,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<ShredTransition>()
 .AddAttribute(0, "pattern", a => a.Pattern, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "dir", a => a.Direction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -1239,7 +1239,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "thruBlk", a => a.ThroughBlack)
 .AddAttribute(0, "dir", a => a.Direction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -1326,11 +1326,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<BookmarkTarget>()
 .AddAttribute(0, "spid", a => a.ShapeId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "bmkName", a => a.BookmarkName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -1695,7 +1695,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<DefaultImageDpi>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -1735,7 +1735,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<DiscardImageEditData>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -1775,7 +1775,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ShowMediaControls>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -1926,7 +1926,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RandomIdType>()
                            .AddAttribute(0, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -2213,11 +2213,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)
@@ -2873,11 +2873,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "name", a => a.Name)
 .AddAttribute(0, "slideIdLst", a => a.SlideIdList, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (2147483648L), MinInclusive = (256L) });
+aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (2147483648L), MinInclusive = (256L) });
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
 
@@ -2937,8 +2937,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<SectionSlideIdListEntry>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (2147483648L), MinInclusive = (256L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (2147483648L), MinInclusive = (256L) });
 });
         }
 
@@ -3085,7 +3085,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (214748364
 .AddAttribute(0, "name", a => a.Name)
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
 
@@ -3179,17 +3179,17 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<TracePoint>()
 .AddAttribute(0, "t", a => a.Time, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "x", a => a.XCoordinate, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "y", a => a.YCoordinate, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 });
         }
 
@@ -3312,16 +3312,16 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042
             builder.AddElement<TriggerEventRecord>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "time", a => a.Time, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "objId", a => a.ObjectId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -3469,11 +3469,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<MediaPlaybackEventRecordType>()
                            .AddAttribute(0, "time", a => a.Time, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            })
                            .AddAttribute(0, "objId", a => a.ObjectId, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -3530,15 +3530,15 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<SeekEventRecord>()
 .AddAttribute(0, "time", a => a.Time, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "objId", a => a.ObjectId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "seek", a => a.Seek, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -3588,11 +3588,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<NullEventRecord>()
 .AddAttribute(0, "time", a => a.Time, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "objId", a => a.ObjectId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_powerpoint_2010_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_powerpoint_2010_main.g.cs
@@ -770,8 +770,8 @@ namespace DocumentFormat.OpenXml.Office2010.PowerPoint
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.TransitionCornerDirectionValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Office2010.PowerPoint.TransitionCenterDirectionTypeValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.TransitionCornerDirectionValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Office2010.PowerPoint.TransitionCenterDirectionTypeValues>>(EnumValidator.Instance);
 });
 });
         }
@@ -1326,11 +1326,11 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<BookmarkTarget>()
 .AddAttribute(0, "spid", a => a.ShapeId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "bmkName", a => a.BookmarkName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -1695,7 +1695,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<DefaultImageDpi>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -1735,7 +1735,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<DiscardImageEditData>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -1775,7 +1775,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ShowMediaControls>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -1926,7 +1926,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RandomIdType>()
                            .AddAttribute(0, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -2213,11 +2213,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)
@@ -2937,7 +2937,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<SectionSlideIdListEntry>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (2147483648L), MinInclusive = (256L) });
 });
         }
@@ -3179,16 +3179,16 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<TracePoint>()
 .AddAttribute(0, "t", a => a.Time, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "x", a => a.XCoordinate, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "y", a => a.YCoordinate, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 });
         }
@@ -3312,16 +3312,16 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L),
             builder.AddElement<TriggerEventRecord>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "time", a => a.Time, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "objId", a => a.ObjectId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -3469,11 +3469,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<MediaPlaybackEventRecordType>()
                            .AddAttribute(0, "time", a => a.Time, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            })
                            .AddAttribute(0, "objId", a => a.ObjectId, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -3530,15 +3530,15 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<SeekEventRecord>()
 .AddAttribute(0, "time", a => a.Time, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "objId", a => a.ObjectId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "seek", a => a.Seek, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -3588,11 +3588,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<NullEventRecord>()
 .AddAttribute(0, "time", a => a.Time, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "objId", a => a.ObjectId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_powerpoint_2012_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_powerpoint_2012_main.g.cs
@@ -116,11 +116,11 @@ namespace DocumentFormat.OpenXml.Office2013.PowerPoint
             builder.AddElement<PresenceInfo>()
 .AddAttribute(0, "userId", a => a.UserId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "providerId", a => a.ProviderId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -436,7 +436,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ChartTrackingReferenceBased>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -828,7 +828,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ExtendedGuide>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name)
 .AddAttribute(0, "orient", a => a.Orientation, aBuilder =>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_powerpoint_2012_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_powerpoint_2012_main.g.cs
@@ -116,11 +116,11 @@ namespace DocumentFormat.OpenXml.Office2013.PowerPoint
             builder.AddElement<PresenceInfo>()
 .AddAttribute(0, "userId", a => a.UserId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "providerId", a => a.ProviderId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -436,7 +436,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ChartTrackingReferenceBased>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -828,12 +828,12 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ExtendedGuide>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name)
 .AddAttribute(0, "orient", a => a.Orientation, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "pos", a => a.Position)
 .AddAttribute(0, "userDrawn", a => a.IsUserDrawn);

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2009_9_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2009_9_main.g.cs
@@ -1616,7 +1616,7 @@ namespace DocumentFormat.OpenXml.Office2010.Excel
             builder.AddElement<SlicerStyles>()
 .AddAttribute(0, "defaultSlicerStyle", a => a.DefaultSlicerStyle, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -1805,7 +1805,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<OleItem>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "icon", a => a.Icon)
 .AddAttribute(0, "advise", a => a.Advise)
@@ -1940,7 +1940,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+            builder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
             builder.SetSchema(53, "id");
             builder.Availability = FileFormatVersions.Office2010;
         }
@@ -1991,11 +1991,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<IconFilter>()
 .AddAttribute(0, "iconSet", a => a.IconSet, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "iconId", a => a.IconId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -2209,7 +2209,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "sortBy", a => a.SortBy)
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "customList", a => a.CustomList)
 .AddAttribute(0, "dxfId", a => a.FormatId)
@@ -2261,7 +2261,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<SourceConnection>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -2332,7 +2332,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<DatastoreItem>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -2762,17 +2762,17 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<FormControlProperties>()
 .AddAttribute(0, "objectType", a => a.ObjectType, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "checked", a => a.Checked, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "colored", a => a.Colored)
 .AddAttribute(0, "dropLines", a => a.DropLines)
 .AddAttribute(0, "dropStyle", a => a.DropStyle, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "dx", a => a.ScrollBarWidth)
 .AddAttribute(0, "firstButton", a => a.FirstButton)
@@ -2793,7 +2793,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "sel", a => a.Selected)
 .AddAttribute(0, "seltype", a => a.SelectionType, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "textHAlign", a => a.TextHorizontalAlign)
 .AddAttribute(0, "textVAlign", a => a.TextVerticalAlign)
@@ -2801,7 +2801,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "widthMin", a => a.MinimumWidth)
 .AddAttribute(0, "editVal", a => a.EditVal, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "multiLine", a => a.MultipleLines)
 .AddAttribute(0, "verticalBar", a => a.VerticalBar)
@@ -3058,11 +3058,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<SlicerCacheDefinition>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "sourceName", a => a.SourceName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -3446,7 +3446,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "activePresent", a => a.ActivePresent)
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
 
@@ -4865,7 +4865,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
                            .AddAttribute(0, "indexed", a => a.Indexed)
                            .AddAttribute(0, "rgb", a => a.Rgb, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+                               aBuilder.AddValidator(new StringValidator() { Length = (4L) });
                            })
                            .AddAttribute(0, "theme", a => a.Theme)
                            .AddAttribute(0, "tint", a => a.Tint);
@@ -5062,7 +5062,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<SlicerRef>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -5111,7 +5111,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<SlicerCache>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -5188,7 +5188,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<DefinedName>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -5342,7 +5342,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ArgumentDescription>()
 .AddAttribute(0, "index", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -5802,7 +5802,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<SetLevel>()
 .AddAttribute(0, "hierarchy", a => a.Hierarchy, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -6511,7 +6511,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ConditionalFormattingValueObject>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "gte", a => a.GreaterThanOrEqual);
         }
@@ -6596,11 +6596,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ConditionalFormattingIcon>()
 .AddAttribute(0, "iconSet", a => a.IconSet, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "iconId", a => a.IconId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -7570,7 +7570,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<PivotEditValue>()
 .AddAttribute(0, "valueType", a => a.ValueType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -7869,8 +7869,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "priority", a => a.Priority)
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
 
@@ -8058,7 +8058,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<SlicerStyle>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -8136,7 +8136,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<SlicerStyleElement>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "dxfId", a => a.FormatId);
         }
@@ -8451,7 +8451,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ProtectedRange>()
 .AddAttribute(0, "password", a => a.Password, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
+aBuilder.AddValidator(new StringValidator() { Length = (2L) });
 })
 .AddAttribute(0, "algorithmName", a => a.AlgorithmName)
 .AddAttribute(0, "hashValue", a => a.HashValue)
@@ -8459,7 +8459,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
 .AddAttribute(0, "spinCount", a => a.SpinCount)
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "securityDescriptor", a => a.SecurityDescriptor);
         }
@@ -8576,7 +8576,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ListItem>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -8803,11 +8803,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Slicer>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "cache", a => a.Cache, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "caption", a => a.Caption)
 .AddAttribute(0, "startItem", a => a.StartItem)
@@ -8818,7 +8818,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "lockedPosition", a => a.LockedPosition)
 .AddAttribute(0, "rowHeight", a => a.RowHeight, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -8922,7 +8922,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<OlapSlicerCache>()
 .AddAttribute(0, "pivotCacheId", a => a.PivotCacheId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -9083,7 +9083,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TabularSlicerCache>()
 .AddAttribute(0, "pivotCacheId", a => a.PivotCacheId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "sortOrder", a => a.SortOrder)
 .AddAttribute(0, "customListSort", a => a.CustomListSort)
@@ -9171,11 +9171,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<SlicerCachePivotTable>()
 .AddAttribute(0, "tabId", a => a.TabId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -9221,7 +9221,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<OlapSlicerCacheItemParent>()
 .AddAttribute(0, "n", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -9312,7 +9312,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<OlapSlicerCacheItem>()
 .AddAttribute(0, "n", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "c", a => a.DisplayName)
 .AddAttribute(0, "nd", a => a.NonDisplay);
@@ -9392,7 +9392,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<OlapSlicerCacheRange>()
 .AddAttribute(0, "startItem", a => a.StartItem, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -9579,12 +9579,12 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<OlapSlicerCacheLevelData>()
 .AddAttribute(0, "uniqueName", a => a.UniqueName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "sourceCaption", a => a.SourceCaption)
 .AddAttribute(0, "count", a => a.Count, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "sortOrder", a => a.SortOrder)
 .AddAttribute(0, "crossFilter", a => a.CrossFilter);
@@ -9833,7 +9833,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<OlapSlicerCacheSelection>()
 .AddAttribute(0, "n", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -9975,7 +9975,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TabularSlicerCacheItem>()
 .AddAttribute(0, "x", a => a.Atom, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "s", a => a.IsSelected)
 .AddAttribute(0, "nd", a => a.NonDisplay);

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2009_9_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2009_9_main.g.cs
@@ -1616,7 +1616,7 @@ namespace DocumentFormat.OpenXml.Office2010.Excel
             builder.AddElement<SlicerStyles>()
 .AddAttribute(0, "defaultSlicerStyle", a => a.DefaultSlicerStyle, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -1805,7 +1805,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<OleItem>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "icon", a => a.Icon)
 .AddAttribute(0, "advise", a => a.Advise)
@@ -1991,11 +1991,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<IconFilter>()
 .AddAttribute(0, "iconSet", a => a.IconSet, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "iconId", a => a.IconId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -2209,7 +2209,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "sortBy", a => a.SortBy)
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "customList", a => a.CustomList)
 .AddAttribute(0, "dxfId", a => a.FormatId)
@@ -2261,7 +2261,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<SourceConnection>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -2332,7 +2332,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<DatastoreItem>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -3058,11 +3058,11 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<SlicerCacheDefinition>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "sourceName", a => a.SourceName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -5062,7 +5062,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<SlicerRef>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -5111,7 +5111,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<SlicerCache>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -5188,7 +5188,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<DefinedName>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -5342,7 +5342,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ArgumentDescription>()
 .AddAttribute(0, "index", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -5802,7 +5802,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<SetLevel>()
 .AddAttribute(0, "hierarchy", a => a.Hierarchy, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -6511,7 +6511,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ConditionalFormattingValueObject>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "gte", a => a.GreaterThanOrEqual);
         }
@@ -6596,11 +6596,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ConditionalFormattingIcon>()
 .AddAttribute(0, "iconSet", a => a.IconSet, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "iconId", a => a.IconId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -7570,7 +7570,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<PivotEditValue>()
 .AddAttribute(0, "valueType", a => a.ValueType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -7869,7 +7869,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "priority", a => a.Priority)
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
@@ -8058,7 +8058,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<SlicerStyle>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -8136,7 +8136,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<SlicerStyleElement>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "dxfId", a => a.FormatId);
         }
@@ -8459,7 +8459,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (2L) });
 .AddAttribute(0, "spinCount", a => a.SpinCount)
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "securityDescriptor", a => a.SecurityDescriptor);
         }
@@ -8576,7 +8576,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ListItem>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -8803,11 +8803,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Slicer>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "cache", a => a.Cache, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "caption", a => a.Caption)
 .AddAttribute(0, "startItem", a => a.StartItem)
@@ -8818,7 +8818,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "lockedPosition", a => a.LockedPosition)
 .AddAttribute(0, "rowHeight", a => a.RowHeight, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -8922,7 +8922,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<OlapSlicerCache>()
 .AddAttribute(0, "pivotCacheId", a => a.PivotCacheId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -9083,7 +9083,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<TabularSlicerCache>()
 .AddAttribute(0, "pivotCacheId", a => a.PivotCacheId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "sortOrder", a => a.SortOrder)
 .AddAttribute(0, "customListSort", a => a.CustomListSort)
@@ -9171,11 +9171,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<SlicerCachePivotTable>()
 .AddAttribute(0, "tabId", a => a.TabId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -9221,7 +9221,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<OlapSlicerCacheItemParent>()
 .AddAttribute(0, "n", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -9312,7 +9312,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<OlapSlicerCacheItem>()
 .AddAttribute(0, "n", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "c", a => a.DisplayName)
 .AddAttribute(0, "nd", a => a.NonDisplay);
@@ -9392,7 +9392,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<OlapSlicerCacheRange>()
 .AddAttribute(0, "startItem", a => a.StartItem, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -9579,12 +9579,12 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<OlapSlicerCacheLevelData>()
 .AddAttribute(0, "uniqueName", a => a.UniqueName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "sourceCaption", a => a.SourceCaption)
 .AddAttribute(0, "count", a => a.Count, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "sortOrder", a => a.SortOrder)
 .AddAttribute(0, "crossFilter", a => a.CrossFilter);
@@ -9833,7 +9833,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<OlapSlicerCacheSelection>()
 .AddAttribute(0, "n", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -9975,7 +9975,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<TabularSlicerCacheItem>()
 .AddAttribute(0, "x", a => a.Atom, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "s", a => a.IsSelected)
 .AddAttribute(0, "nd", a => a.NonDisplay);

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2010_11_ac.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2010_11_ac.g.cs
@@ -46,7 +46,7 @@ namespace DocumentFormat.OpenXml.Office2013.ExcelAc
             builder.AddElement<AbsolutePath>()
 .AddAttribute(0, "url", a => a.Url, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2010_11_ac.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2010_11_ac.g.cs
@@ -46,7 +46,7 @@ namespace DocumentFormat.OpenXml.Office2013.ExcelAc
             builder.AddElement<AbsolutePath>()
 .AddAttribute(0, "url", a => a.Url, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2010_11_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2010_11_main.g.cs
@@ -602,7 +602,7 @@ namespace DocumentFormat.OpenXml.Office2013.Excel
             builder.AddElement<TimelineStyles>()
 .AddAttribute(0, "defaultTimelineStyle", a => a.DefaultTimelineStyle, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -803,7 +803,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Connection>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "model", a => a.Model)
 .AddAttribute(0, "excludeFromRefreshAll", a => a.ExcludeFromRefreshAll)
@@ -1071,7 +1071,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<PivotFilter>()
 .AddAttribute(0, "useWholeDay", a => a.UseWholeDay, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -1174,7 +1174,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<CacheHierarchy>()
 .AddAttribute(0, "aggregatedColumn", a => a.AggregatedColumn, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -1261,11 +1261,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<PivotCacheIdVersion>()
 .AddAttribute(0, "cacheIdSupportedVersion", a => a.CacheIdSupportedVersion, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "cacheIdCreatedVersion", a => a.CacheIdCreatedVersion, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -1478,7 +1478,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "columnCount", a => a.ColumnCount)
 .AddAttribute(0, "cacheId", a => a.CacheId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -1642,23 +1642,23 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<MovingPeriodState>()
 .AddAttribute(0, "referenceDateBegin", a => a.ReferenceDateBegin, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "referencePeriod", a => a.ReferencePeriod, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "referenceMultiple", a => a.ReferenceMultiple, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "movingPeriod", a => a.MovingPeriod, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "movingMultiple", a => a.MovingMultiple, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -1832,11 +1832,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<TableSlicerCache>()
 .AddAttribute(0, "tableId", a => a.TableId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "column", a => a.Column, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "sortOrder", a => a.SortOrder)
 .AddAttribute(0, "customListSort", a => a.CustomListSort)
@@ -2106,11 +2106,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Survey>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "guid", a => a.Guid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "title", a => a.Title)
@@ -2368,11 +2368,11 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<TimelineCacheDefinition>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "sourceName", a => a.SourceName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -2494,7 +2494,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<PivotTableReference>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -2565,7 +2565,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<WebExtension>()
 .AddAttribute(0, "appRef", a => a.ApplicationReference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -2628,7 +2628,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<TimelineCacheReference>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -2671,7 +2671,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<TimelineReference>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -2742,7 +2742,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<TimelineStyle>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -2812,7 +2812,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<TimelineStyleElement>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "dxfId", a => a.FormatId);
         }
@@ -2916,7 +2916,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<DbTable>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -3019,7 +3019,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<DbCommand>()
 .AddAttribute(0, "text", a => a.Text, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -3349,7 +3349,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RangeProperties>()
 .AddAttribute(0, "sourceName", a => a.SourceName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -3524,7 +3524,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<DataFeedProperties>()
 .AddAttribute(0, "connection", a => a.Connection, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -3594,7 +3594,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<FieldListActiveTabTopLevelEntity>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "type", a => a.Type);
         }
@@ -3714,11 +3714,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<CachedUniqueName>()
 .AddAttribute(0, "index", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -3778,15 +3778,15 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ModelTable>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "connection", a => a.Connection, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -3856,19 +3856,19 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ModelRelationship>()
 .AddAttribute(0, "fromTable", a => a.FromTable, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "fromColumn", a => a.FromColumn, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "toTable", a => a.ToTable, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "toColumn", a => a.ToColumn, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -4327,7 +4327,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
             builder.AddElement<PivotTableServerFormats>()
 .AddAttribute(0, "count", a => a.Count, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -4432,11 +4432,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<SlicerCacheOlapLevelName>()
 .AddAttribute(0, "uniqueName", a => a.UniqueName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "count", a => a.Count, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -5131,7 +5131,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<SurveyQuestion>()
 .AddAttribute(0, "binding", a => a.Binding, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "text", a => a.Text)
 .AddAttribute(0, "type", a => a.Type)
@@ -5344,11 +5344,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Timeline>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "cache", a => a.Cache, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "caption", a => a.Caption)
 .AddAttribute(0, "showHeader", a => a.ShowHeader)
@@ -5357,11 +5357,11 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "showHorizontalScrollbar", a => a.ShowHorizontalScrollbar)
 .AddAttribute(0, "level", a => a.Level, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "selectionLevel", a => a.SelectionLevel, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "scrollPosition", a => a.ScrollPosition)
 .AddAttribute(0, "style", a => a.Style);
@@ -5439,11 +5439,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<TimelineCachePivotTable>()
 .AddAttribute(0, "tabId", a => a.TabId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -5541,11 +5541,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<TimelineRange>()
                            .AddAttribute(0, "startDate", a => a.StartDate, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            })
                            .AddAttribute(0, "endDate", a => a.EndDate, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -5834,19 +5834,19 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "singleRangeFilterState", a => a.SingleRangeFilterState)
 .AddAttribute(0, "minimalRefreshVersion", a => a.MinimalRefreshVersion, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "lastRefreshVersion", a => a.LastRefreshVersion, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "pivotCacheId", a => a.PivotCacheId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "filterType", a => a.FilterType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "filterId", a => a.FilterId)
 .AddAttribute(0, "filterTabId", a => a.FilterTabId)
@@ -5993,7 +5993,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "r", a => a.Reference)
 .AddAttribute(0, "count", a => a.Count, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2010_11_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2010_11_main.g.cs
@@ -602,7 +602,7 @@ namespace DocumentFormat.OpenXml.Office2013.Excel
             builder.AddElement<TimelineStyles>()
 .AddAttribute(0, "defaultTimelineStyle", a => a.DefaultTimelineStyle, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -803,7 +803,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Connection>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "model", a => a.Model)
 .AddAttribute(0, "excludeFromRefreshAll", a => a.ExcludeFromRefreshAll)
@@ -1071,7 +1071,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<PivotFilter>()
 .AddAttribute(0, "useWholeDay", a => a.UseWholeDay, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -1174,7 +1174,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<CacheHierarchy>()
 .AddAttribute(0, "aggregatedColumn", a => a.AggregatedColumn, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -1261,11 +1261,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<PivotCacheIdVersion>()
 .AddAttribute(0, "cacheIdSupportedVersion", a => a.CacheIdSupportedVersion, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "cacheIdCreatedVersion", a => a.CacheIdCreatedVersion, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -1478,7 +1478,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "columnCount", a => a.ColumnCount)
 .AddAttribute(0, "cacheId", a => a.CacheId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -1642,23 +1642,23 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<MovingPeriodState>()
 .AddAttribute(0, "referenceDateBegin", a => a.ReferenceDateBegin, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "referencePeriod", a => a.ReferencePeriod, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "referenceMultiple", a => a.ReferenceMultiple, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "movingPeriod", a => a.MovingPeriod, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "movingMultiple", a => a.MovingMultiple, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -1832,11 +1832,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TableSlicerCache>()
 .AddAttribute(0, "tableId", a => a.TableId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "column", a => a.Column, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "sortOrder", a => a.SortOrder)
 .AddAttribute(0, "customListSort", a => a.CustomListSort)
@@ -2106,12 +2106,12 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Survey>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "guid", a => a.Guid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "title", a => a.Title)
 .AddAttribute(0, "description", a => a.Description);
@@ -2368,11 +2368,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<TimelineCacheDefinition>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "sourceName", a => a.SourceName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -2494,7 +2494,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<PivotTableReference>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -2565,7 +2565,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<WebExtension>()
 .AddAttribute(0, "appRef", a => a.ApplicationReference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -2628,7 +2628,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TimelineCacheReference>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -2671,7 +2671,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TimelineReference>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -2742,7 +2742,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TimelineStyle>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -2812,7 +2812,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TimelineStyleElement>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "dxfId", a => a.FormatId);
         }
@@ -2916,7 +2916,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<DbTable>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -3019,7 +3019,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<DbCommand>()
 .AddAttribute(0, "text", a => a.Text, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -3349,7 +3349,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RangeProperties>()
 .AddAttribute(0, "sourceName", a => a.SourceName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -3524,7 +3524,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<DataFeedProperties>()
 .AddAttribute(0, "connection", a => a.Connection, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -3594,7 +3594,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<FieldListActiveTabTopLevelEntity>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "type", a => a.Type);
         }
@@ -3714,11 +3714,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<CachedUniqueName>()
 .AddAttribute(0, "index", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -3778,15 +3778,15 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ModelTable>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "connection", a => a.Connection, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -3856,19 +3856,19 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ModelRelationship>()
 .AddAttribute(0, "fromTable", a => a.FromTable, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "fromColumn", a => a.FromColumn, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "toTable", a => a.ToTable, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "toColumn", a => a.ToColumn, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -4248,11 +4248,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "in", a => a.FormatIndex)
 .AddAttribute(0, "bc", a => a.BackgroundColor, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(0, "fc", a => a.ForegroundColor, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(0, "i", a => a.Italic)
 .AddAttribute(0, "un", a => a.Underline)
@@ -4327,7 +4327,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
             builder.AddElement<PivotTableServerFormats>()
 .AddAttribute(0, "count", a => a.Count, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -4432,11 +4432,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<SlicerCacheOlapLevelName>()
 .AddAttribute(0, "uniqueName", a => a.UniqueName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "count", a => a.Count, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -5131,7 +5131,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<SurveyQuestion>()
 .AddAttribute(0, "binding", a => a.Binding, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "text", a => a.Text)
 .AddAttribute(0, "type", a => a.Type)
@@ -5344,11 +5344,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Timeline>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "cache", a => a.Cache, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "caption", a => a.Caption)
 .AddAttribute(0, "showHeader", a => a.ShowHeader)
@@ -5357,11 +5357,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "showHorizontalScrollbar", a => a.ShowHorizontalScrollbar)
 .AddAttribute(0, "level", a => a.Level, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "selectionLevel", a => a.SelectionLevel, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "scrollPosition", a => a.ScrollPosition)
 .AddAttribute(0, "style", a => a.Style);
@@ -5439,11 +5439,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TimelineCachePivotTable>()
 .AddAttribute(0, "tabId", a => a.TabId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -5541,11 +5541,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TimelineRange>()
                            .AddAttribute(0, "startDate", a => a.StartDate, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            })
                            .AddAttribute(0, "endDate", a => a.EndDate, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -5834,19 +5834,19 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "singleRangeFilterState", a => a.SingleRangeFilterState)
 .AddAttribute(0, "minimalRefreshVersion", a => a.MinimalRefreshVersion, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "lastRefreshVersion", a => a.LastRefreshVersion, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "pivotCacheId", a => a.PivotCacheId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "filterType", a => a.FilterType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "filterId", a => a.FilterId)
 .AddAttribute(0, "filterTabId", a => a.FilterTabId)
@@ -5993,7 +5993,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "r", a => a.Reference)
 .AddAttribute(0, "count", a => a.Count, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2014_11_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2014_11_main.g.cs
@@ -159,15 +159,15 @@ namespace DocumentFormat.OpenXml.Office2016.ExcelAc
             builder.AddElement<ModelTimeGrouping>()
 .AddAttribute(0, "tableName", a => a.TableName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "columnName", a => a.ColumnName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "columnId", a => a.ColumnId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -244,19 +244,19 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<CalculatedTimeColumn>()
 .AddAttribute(0, "columnName", a => a.ColumnName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "columnId", a => a.ColumnId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "contentType", a => a.ContentType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "isSelected", a => a.IsSelected, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2014_11_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2014_11_main.g.cs
@@ -159,15 +159,15 @@ namespace DocumentFormat.OpenXml.Office2016.ExcelAc
             builder.AddElement<ModelTimeGrouping>()
 .AddAttribute(0, "tableName", a => a.TableName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "columnName", a => a.ColumnName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "columnId", a => a.ColumnId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -244,19 +244,19 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<CalculatedTimeColumn>()
 .AddAttribute(0, "columnName", a => a.ColumnName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "columnId", a => a.ColumnId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "contentType", a => a.ContentType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "isSelected", a => a.IsSelected, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2014_revision.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2014_revision.g.cs
@@ -110,19 +110,19 @@ namespace DocumentFormat.OpenXml.Office2016.Excel
             builder.AddElement<RevExHeaders>()
 .AddAttribute(0, "minRev", a => a.MinRev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "maxRev", a => a.MaxRev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "docId", a => a.DocId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "endpointId", a => a.EndpointId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -453,11 +453,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RevisionPtr>()
 .AddAttribute(0, "revIDLastSave", a => a.RevIDLastSave, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "documentId", a => a.DocumentId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -686,13 +686,13 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RevExHeader>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "minRev", a => a.MinRev)
 .AddAttribute(0, "maxRev", a => a.MaxRev)
 .AddAttribute(0, "time", a => a.Time, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -813,21 +813,21 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RevExFuture>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "ctx", a => a.Ctx)
 .AddAttribute(0, "sti", a => a.Sti);
@@ -916,21 +916,21 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<RevExUnsupported>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "ctx", a => a.Ctx);
         }
@@ -1011,21 +1011,21 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<RevExTrimmed>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "ctx", a => a.Ctx);
         }
@@ -1136,31 +1136,31 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<RevExRowColumn>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "ctx", a => a.Ctx)
 .AddAttribute(0, "eol", a => a.Eol)
 .AddAttribute(0, "ref", a => a.Ref, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "action", a => a.Action, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -1270,34 +1270,34 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RevExMove>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "ctx", a => a.Ctx)
 .AddAttribute(0, "src", a => a.Src, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "dst", a => a.Dst, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "srcSh", a => a.SrcSh, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
 
@@ -1460,30 +1460,30 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<RevExChangeCell>()
 .AddAttribute(0, "listUid", a => a.ListUid, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "ctx", a => a.Ctx)
 .AddAttribute(0, "r", a => a.R, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "t", a => a.T)
 .AddAttribute(0, "x", a => a.X)
@@ -1747,21 +1747,21 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RevExFormatting>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "ctx", a => a.Ctx)
 .AddAttribute(0, "numFmtId", a => a.NumFmtId)
@@ -1769,13 +1769,13 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
 .AddAttribute(0, "style", a => a.Style)
 .AddAttribute(0, "sqref", a => a.Sqref, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "start", a => a.Start)
 .AddAttribute(0, "length", a => a.Length)
 .AddAttribute(0, "styleUid", a => a.StyleUid, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "fBlankCell", a => a.FBlankCell)
 .AddAttribute(0, "applyNumberFormat", a => a.ApplyNumberFormat)
@@ -2039,27 +2039,27 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<RevExDefinedName>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "ctx", a => a.Ctx)
 .AddAttribute(0, "customView", a => a.CustomView)
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "function", a => a.Function)
 .AddAttribute(0, "functionGroupId", a => a.FunctionGroupId)
@@ -2213,21 +2213,21 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RevExDelObj>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "ctx", a => a.Ctx);
         }
@@ -2363,21 +2363,21 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<RevExChgObj>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "ctx", a => a.Ctx);
         }
@@ -2523,26 +2523,26 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<RevExSheetOp>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "ctx", a => a.Ctx)
 .AddAttribute(0, "op", a => a.Op, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name)
 .AddAttribute(0, "idOrig", a => a.IdOrig)
@@ -2705,21 +2705,21 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RevisionList>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "ctx", a => a.Ctx)
 .AddAttribute(0, "Data", a => a.Data)
@@ -2728,13 +2728,13 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
 .AddAttribute(0, "Fake", a => a.Fake)
 .AddAttribute(0, "ref", a => a.Ref, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "Headers", a => a.Headers)
 .AddAttribute(0, "InsDelHeaders", a => a.InsDelHeaders)
 .AddAttribute(0, "rId", a => a.RId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -2834,31 +2834,31 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RevListAutoExpandRw>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "ctx", a => a.Ctx)
 .AddAttribute(0, "refAdded", a => a.RefAdded, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "listGuid", a => a.ListGuid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
 
@@ -2993,21 +2993,21 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<RevGroup>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "ctx", a => a.Ctx);
         }
@@ -3306,7 +3306,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<ChangeCellSubEdit>()
 .AddAttribute(0, "r", a => a.R, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "t", a => a.T)
 .AddAttribute(0, "x", a => a.X)
@@ -3572,12 +3572,12 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<StateBasedHeader>()
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "eft", a => a.Eft, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "eftx", a => a.Eftx)
 .AddAttribute(0, "seft", a => a.Seft)
@@ -3643,7 +3643,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RevisionStateLink>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -3928,11 +3928,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RowColVisualOps>()
 .AddAttribute(0, "action", a => a.Action, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "isRow", a => a.IsRow, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "size", a => a.Size)
 .AddAttribute(0, "userSized", a => a.UserSized);
@@ -3974,7 +3974,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<HideUnhideSheet>()
 .AddAttribute(0, "hide", a => a.Hide, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -4024,11 +4024,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ShowGridlinesHeadings>()
 .AddAttribute(0, "showGridLines", a => a.ShowGridLines, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "showRowCol", a => a.ShowRowCol, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -4068,7 +4068,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<FreezePanes>()
 .AddAttribute(0, "sheetViewUid", a => a.SheetViewUid, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
 
@@ -4139,7 +4139,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<Outlines>()
 .AddAttribute(0, "isRow", a => a.IsRow, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -4196,11 +4196,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Outline>()
 .AddAttribute(0, "isCollapsed", a => a.IsCollapsed, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "level", a => a.Level, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -4423,25 +4423,25 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RefCell>()
 .AddAttribute(0, "n", a => a.N, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "ajt", a => a.Ajt, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "ajtx", a => a.Ajtx)
 .AddAttribute(0, "homeRef", a => a.HomeRef)
 .AddAttribute(0, "r", a => a.R, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidLast", a => a.UidLast, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
 
@@ -4521,18 +4521,18 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<SheetXluid>()
 .AddAttribute(0, "n", a => a.N, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "ajt", a => a.Ajt, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "ajtx", a => a.Ajtx)
 .AddAttribute(0, "homeRef", a => a.HomeRef)
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
 
@@ -4702,50 +4702,50 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<RefOartAnchor>()
 .AddAttribute(0, "n", a => a.N, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "ajt", a => a.Ajt, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "ajtx", a => a.Ajtx)
 .AddAttribute(0, "homeRef", a => a.HomeRef)
 .AddAttribute(0, "r", a => a.R)
 .AddAttribute(0, "fromRowOff", a => a.FromRowOff, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "fromColOff", a => a.FromColOff, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "toRowOff", a => a.ToRowOff, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "toColOff", a => a.ToColOff, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "cx", a => a.Cx, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(0, "cy", a => a.Cy, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(0, "x", a => a.X, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "y", a => a.Y, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "oat", a => a.Oat, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -4840,11 +4840,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RefTest>()
 .AddAttribute(0, "n", a => a.N, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "ajt", a => a.Ajt, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "ajtx", a => a.Ajtx)
 .AddAttribute(0, "homeRef", a => a.HomeRef);
@@ -5053,7 +5053,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "prompt", a => a.Prompt)
 .AddAttribute(0, "sqref", a => a.SequenceOfReferences, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -5184,7 +5184,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Hyperlink>()
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(19, "id", a => a.Id)
 .AddAttribute(0, "location", a => a.Location)
@@ -6558,11 +6558,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<pivotTableDefinition>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "cacheId", a => a.CacheId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "dataOnRows", a => a.DataOnRows)
 .AddAttribute(0, "dataPosition", a => a.DataPosition)
@@ -6575,7 +6575,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "applyWidthHeightFormats", a => a.ApplyWidthHeightFormats)
 .AddAttribute(0, "dataCaption", a => a.DataCaption, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "grandTotalCaption", a => a.GrandTotalCaption)
 .AddAttribute(0, "errorCaption", a => a.ErrorCaption)

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2014_revision.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2014_revision.g.cs
@@ -110,19 +110,19 @@ namespace DocumentFormat.OpenXml.Office2016.Excel
             builder.AddElement<RevExHeaders>()
 .AddAttribute(0, "minRev", a => a.MinRev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "maxRev", a => a.MaxRev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "docId", a => a.DocId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "endpointId", a => a.EndpointId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -453,11 +453,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RevisionPtr>()
 .AddAttribute(0, "revIDLastSave", a => a.RevIDLastSave, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "documentId", a => a.DocumentId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -686,13 +686,13 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RevExHeader>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "minRev", a => a.MinRev)
 .AddAttribute(0, "maxRev", a => a.MaxRev)
 .AddAttribute(0, "time", a => a.Time, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -813,16 +813,16 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RevExFuture>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
@@ -916,16 +916,16 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<RevExUnsupported>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
@@ -1011,16 +1011,16 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<RevExTrimmed>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
@@ -1136,16 +1136,16 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<RevExRowColumn>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
@@ -1156,11 +1156,11 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
 .AddAttribute(0, "eol", a => a.Eol)
 .AddAttribute(0, "ref", a => a.Ref, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "action", a => a.Action, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -1270,16 +1270,16 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RevExMove>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
@@ -1289,11 +1289,11 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
 .AddAttribute(0, "ctx", a => a.Ctx)
 .AddAttribute(0, "src", a => a.Src, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "dst", a => a.Dst, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "srcSh", a => a.SrcSh, aBuilder =>
 {
@@ -1464,16 +1464,16 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
 })
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
@@ -1483,7 +1483,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
 .AddAttribute(0, "ctx", a => a.Ctx)
 .AddAttribute(0, "r", a => a.R, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "t", a => a.T)
 .AddAttribute(0, "x", a => a.X)
@@ -1747,16 +1747,16 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RevExFormatting>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
@@ -1769,7 +1769,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
 .AddAttribute(0, "style", a => a.Style)
 .AddAttribute(0, "sqref", a => a.Sqref, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "start", a => a.Start)
 .AddAttribute(0, "length", a => a.Length)
@@ -2039,16 +2039,16 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<RevExDefinedName>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
@@ -2059,7 +2059,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
 .AddAttribute(0, "customView", a => a.CustomView)
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "function", a => a.Function)
 .AddAttribute(0, "functionGroupId", a => a.FunctionGroupId)
@@ -2213,16 +2213,16 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RevExDelObj>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
@@ -2363,16 +2363,16 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<RevExChgObj>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
@@ -2523,16 +2523,16 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<RevExSheetOp>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
@@ -2542,7 +2542,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
 .AddAttribute(0, "ctx", a => a.Ctx)
 .AddAttribute(0, "op", a => a.Op, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name)
 .AddAttribute(0, "idOrig", a => a.IdOrig)
@@ -2705,16 +2705,16 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RevisionList>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
@@ -2728,13 +2728,13 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
 .AddAttribute(0, "Fake", a => a.Fake)
 .AddAttribute(0, "ref", a => a.Ref, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "Headers", a => a.Headers)
 .AddAttribute(0, "InsDelHeaders", a => a.InsDelHeaders)
 .AddAttribute(0, "rId", a => a.RId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -2834,16 +2834,16 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RevListAutoExpandRw>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
@@ -2853,11 +2853,11 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
 .AddAttribute(0, "ctx", a => a.Ctx)
 .AddAttribute(0, "refAdded", a => a.RefAdded, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "listGuid", a => a.ListGuid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
@@ -2993,16 +2993,16 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<RevGroup>()
 .AddAttribute(0, "rev", a => a.Rev, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "sh", a => a.Sh, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "uidp", a => a.Uidp, aBuilder =>
@@ -3306,7 +3306,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<ChangeCellSubEdit>()
 .AddAttribute(0, "r", a => a.R, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "t", a => a.T)
 .AddAttribute(0, "x", a => a.X)
@@ -3572,12 +3572,12 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<StateBasedHeader>()
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "eft", a => a.Eft, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "eftx", a => a.Eftx)
 .AddAttribute(0, "seft", a => a.Seft)
@@ -3643,7 +3643,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RevisionStateLink>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -3928,11 +3928,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RowColVisualOps>()
 .AddAttribute(0, "action", a => a.Action, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "isRow", a => a.IsRow, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "size", a => a.Size)
 .AddAttribute(0, "userSized", a => a.UserSized);
@@ -3974,7 +3974,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<HideUnhideSheet>()
 .AddAttribute(0, "hide", a => a.Hide, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -4024,11 +4024,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ShowGridlinesHeadings>()
 .AddAttribute(0, "showGridLines", a => a.ShowGridLines, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "showRowCol", a => a.ShowRowCol, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -4139,7 +4139,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<Outlines>()
 .AddAttribute(0, "isRow", a => a.IsRow, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -4196,11 +4196,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Outline>()
 .AddAttribute(0, "isCollapsed", a => a.IsCollapsed, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "level", a => a.Level, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -4423,17 +4423,17 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RefCell>()
 .AddAttribute(0, "n", a => a.N, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "ajt", a => a.Ajt, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "ajtx", a => a.Ajtx)
 .AddAttribute(0, "homeRef", a => a.HomeRef)
 .AddAttribute(0, "r", a => a.R, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
@@ -4521,17 +4521,17 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<SheetXluid>()
 .AddAttribute(0, "n", a => a.N, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "ajt", a => a.Ajt, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "ajtx", a => a.Ajtx)
 .AddAttribute(0, "homeRef", a => a.HomeRef)
 .AddAttribute(0, "uid", a => a.Uid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
@@ -4702,11 +4702,11 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<RefOartAnchor>()
 .AddAttribute(0, "n", a => a.N, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "ajt", a => a.Ajt, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "ajtx", a => a.Ajtx)
 .AddAttribute(0, "homeRef", a => a.HomeRef)
@@ -4745,7 +4745,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L),
 })
 .AddAttribute(0, "oat", a => a.Oat, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -4840,11 +4840,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RefTest>()
 .AddAttribute(0, "n", a => a.N, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "ajt", a => a.Ajt, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "ajtx", a => a.Ajtx)
 .AddAttribute(0, "homeRef", a => a.HomeRef);
@@ -5053,7 +5053,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "prompt", a => a.Prompt)
 .AddAttribute(0, "sqref", a => a.SequenceOfReferences, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -5184,7 +5184,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Hyperlink>()
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(19, "id", a => a.Id)
 .AddAttribute(0, "location", a => a.Location)
@@ -6558,11 +6558,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<pivotTableDefinition>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "cacheId", a => a.CacheId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "dataOnRows", a => a.DataOnRows)
 .AddAttribute(0, "dataPosition", a => a.DataPosition)
@@ -6575,7 +6575,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "applyWidthHeightFormats", a => a.ApplyWidthHeightFormats)
 .AddAttribute(0, "dataCaption", a => a.DataCaption, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "grandTotalCaption", a => a.GrandTotalCaption)
 .AddAttribute(0, "errorCaption", a => a.ErrorCaption)

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_thememl_2012_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_thememl_2012_main.g.cs
@@ -97,16 +97,16 @@ namespace DocumentFormat.OpenXml.Office2013.Theme
             builder.AddElement<ThemeFamily>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "vid", a => a.Vid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
@@ -316,26 +316,26 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<ThemeVariant>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "vid", a => a.Vid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "cx", a => a.X, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "cy", a => a.Y, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_thememl_2012_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_thememl_2012_main.g.cs
@@ -97,17 +97,17 @@ namespace DocumentFormat.OpenXml.Office2013.Theme
             builder.AddElement<ThemeFamily>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "vid", a => a.Vid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
 
@@ -316,26 +316,26 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<ThemeVariant>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "vid", a => a.Vid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "cx", a => a.X, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "cy", a => a.Y, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_webextensions_taskpanes_2010_11.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_webextensions_taskpanes_2010_11.g.cs
@@ -144,7 +144,7 @@ namespace DocumentFormat.OpenXml.Office2013.WebExtentionPane
             builder.AddElement<WebExtensionPartReference>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -332,19 +332,19 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<WebExtensionTaskpane>()
 .AddAttribute(0, "dockstate", a => a.DockState, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "visibility", a => a.Visibility, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "width", a => a.Width, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "row", a => a.Row, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "locked", a => a.Locked);
         }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_webextensions_taskpanes_2010_11.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_webextensions_taskpanes_2010_11.g.cs
@@ -144,7 +144,7 @@ namespace DocumentFormat.OpenXml.Office2013.WebExtentionPane
             builder.AddElement<WebExtensionPartReference>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -332,19 +332,19 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<WebExtensionTaskpane>()
 .AddAttribute(0, "dockstate", a => a.DockState, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "visibility", a => a.Visibility, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "width", a => a.Width, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "row", a => a.Row, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "locked", a => a.Locked);
         }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_webextensions_webextension_2010_11.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_webextensions_webextension_2010_11.g.cs
@@ -97,7 +97,7 @@ namespace DocumentFormat.OpenXml.Office2013.WebExtension
             builder.AddElement<WebExtension>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "frozen", a => a.Frozen);
         }
@@ -268,7 +268,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<WebExtensionReference>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -318,11 +318,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<WebExtensionProperty>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "value", a => a.Value, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -482,15 +482,15 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<WebExtensionBinding>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "appref", a => a.AppReference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -611,11 +611,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<WebExtensionStoreReference>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "version", a => a.Version, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "store", a => a.Store)
 .AddAttribute(0, "storeType", a => a.StoreType);

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_webextensions_webextension_2010_11.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_webextensions_webextension_2010_11.g.cs
@@ -97,7 +97,7 @@ namespace DocumentFormat.OpenXml.Office2013.WebExtension
             builder.AddElement<WebExtension>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "frozen", a => a.Frozen);
         }
@@ -268,7 +268,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<WebExtensionReference>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -318,11 +318,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<WebExtensionProperty>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "value", a => a.Value, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -482,15 +482,15 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<WebExtensionBinding>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "appref", a => a.AppReference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -611,11 +611,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<WebExtensionStoreReference>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "version", a => a.Version, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "store", a => a.Store)
 .AddAttribute(0, "storeType", a => a.StoreType);
@@ -965,7 +965,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(19, "link", a => a.Link)
 .AddAttribute(0, "cstate", a => a.CompressionState, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2006_wordml.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2006_wordml.g.cs
@@ -422,11 +422,11 @@ namespace DocumentFormat.OpenXml.Office.Word
 .AddAttribute(33, "fciName", a => a.CommandName)
 .AddAttribute(33, "fciIndex", a => a.CommandIndex, aBuilder =>
 {
-   aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
+   aBuilder.AddValidator(new StringValidator() { Length = (2L) });
 })
 .AddAttribute(33, "swArg", a => a.Argument, aBuilder =>
 {
-   aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
+   aBuilder.AddValidator(new StringValidator() { Length = (2L) });
 });
         }
 
@@ -634,8 +634,8 @@ namespace DocumentFormat.OpenXml.Office.Word
             builder.AddElement<CharacterInsertion>()
 .AddAttribute(33, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 });
         }
 
@@ -768,19 +768,19 @@ namespace DocumentFormat.OpenXml.Office.Word
             builder.AddElement<KeyMapEntry>()
 .AddAttribute(33, "chmPrimary", a => a.CharacterMapPrimary, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
+aBuilder.AddValidator(new StringValidator() { Length = (2L) });
 })
 .AddAttribute(33, "chmSecondary", a => a.CharacterMapSecondary, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
+aBuilder.AddValidator(new StringValidator() { Length = (2L) });
 })
 .AddAttribute(33, "kcmPrimary", a => a.KeyCodePrimary, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
+aBuilder.AddValidator(new StringValidator() { Length = (2L) });
 })
 .AddAttribute(33, "kcmSecondary", a => a.KeyCodeSecondary, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
+aBuilder.AddValidator(new StringValidator() { Length = (2L) });
 })
 .AddAttribute(33, "mask", a => a.Mask);
         }
@@ -940,7 +940,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
 .AddAttribute(33, "fciBasedOn", a => a.CommandBasedOn)
 .AddAttribute(33, "fciIndexBasedOn", a => a.CommandIndexBasedOn, aBuilder =>
 {
-   aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
+   aBuilder.AddValidator(new StringValidator() { Length = (2L) });
 })
 .AddAttribute(33, "acdName", a => a.AcceleratorName);
         }
@@ -1038,11 +1038,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
 .AddAttribute(33, "menuHelp", a => a.MenuHelp)
 .AddAttribute(33, "bEncrypt", a => a.BEncrypt, aBuilder =>
 {
-   aBuilder.AddValidator(new StringValidatorAttribute() { Length = (1L) });
+   aBuilder.AddValidator(new StringValidator() { Length = (1L) });
 })
 .AddAttribute(33, "cmg", a => a.Cmg, aBuilder =>
 {
-   aBuilder.AddValidator(new StringValidatorAttribute() { Length = (1L) });
+   aBuilder.AddValidator(new StringValidator() { Length = (1L) });
 });
         }
 
@@ -1902,7 +1902,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
             builder.AddElement<ToolbarData>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -2283,7 +2283,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RecordHashCode>()
 .AddAttribute(33, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2006_wordml.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2006_wordml.g.cs
@@ -634,7 +634,7 @@ namespace DocumentFormat.OpenXml.Office.Word
             builder.AddElement<CharacterInsertion>()
 .AddAttribute(33, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 });
         }
@@ -1902,7 +1902,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (2L) });
             builder.AddElement<ToolbarData>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -2283,7 +2283,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RecordHashCode>()
 .AddAttribute(33, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2010_wordml.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2010_wordml.g.cs
@@ -722,13 +722,13 @@ namespace DocumentFormat.OpenXml.Office2010.Word
             builder.AddElement<RunTrackChangeType>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
@@ -897,13 +897,13 @@ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
             builder.AddElement<TrackChangeType>()
                            .AddAttribute(23, "author", a => a.Author, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
                            })
                            .AddAttribute(23, "date", a => a.Date)
                            .AddAttribute(23, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddUnion(union =>
                                {
                                    union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
@@ -1021,7 +1021,7 @@ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
             builder.AddElement<PositiveFixedPercentageType>()
                            .AddAttribute(52, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
                            });
@@ -1063,7 +1063,7 @@ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
             builder.AddElement<HueModulation>()
 .AddAttribute(52, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 });
@@ -1256,7 +1256,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
             builder.AddElement<PercentageType>()
                            .AddAttribute(52, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
                            });
         }
@@ -1346,7 +1346,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
             builder.AddElement<RgbColorModelHex>()
 .AddAttribute(52, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 aBuilder.AddValidator(new StringValidator() { Length = (3L) });
 });
@@ -1462,7 +1462,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (3L) });
             builder.AddElement<SchemeColor>()
 .AddAttribute(52, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
@@ -3244,7 +3244,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<Ligatures>()
 .AddAttribute(52, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
@@ -3288,7 +3288,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
             builder.AddElement<NumberingFormat>()
 .AddAttribute(52, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
@@ -3332,7 +3332,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
             builder.AddElement<NumberSpacing>()
 .AddAttribute(52, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
@@ -3630,7 +3630,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(19, "id", a => a.RelationshipId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -3721,7 +3721,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<DocumentId>()
 .AddAttribute(52, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 });
@@ -3820,7 +3820,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
             builder.AddElement<MarkupType>()
                            .AddAttribute(23, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddUnion(union =>
                                {
                                    union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
@@ -3865,7 +3865,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
             builder.AddElement<DefaultImageDpi>()
 .AddAttribute(52, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
@@ -4050,7 +4050,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
             builder.AddElement<GradientStop>()
 .AddAttribute(52, "pos", a => a.StopPosition, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 });
@@ -4318,19 +4318,19 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
             builder.AddElement<SphereCoordinates>()
 .AddAttribute(52, "lat", a => a.Lattitude, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 })
 .AddAttribute(52, "lon", a => a.Longitude, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 })
 .AddAttribute(52, "rev", a => a.Revolution, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 });
@@ -4375,7 +4375,7 @@ aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInc
             builder.AddElement<Camera>()
 .AddAttribute(52, "prst", a => a.PresetCameraType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
@@ -4464,13 +4464,13 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<LightRig>()
 .AddAttribute(52, "rig", a => a.LightRigType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(52, "dir", a => a.LightDirectionType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
@@ -4892,7 +4892,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<StyleSet>()
 .AddAttribute(52, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(52, "val", a => a.Val, aBuilder =>
@@ -5124,11 +5124,11 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2010_wordml.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2010_wordml.g.cs
@@ -722,17 +722,17 @@ namespace DocumentFormat.OpenXml.Office2010.Word
             builder.AddElement<RunTrackChangeType>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-2L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
 });
 });
         }
@@ -897,17 +897,17 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
             builder.AddElement<TrackChangeType>()
                            .AddAttribute(23, "author", a => a.Author, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
                            })
                            .AddAttribute(23, "date", a => a.Date)
                            .AddAttribute(23, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                                aBuilder.AddUnion(union =>
                                {
-                                   union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
-                                   union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-2L) });
+                                   union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
+                                   union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
                                });
                            });
         }
@@ -1021,9 +1021,9 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
             builder.AddElement<PositiveFixedPercentageType>()
                            .AddAttribute(52, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
                            });
         }
     }
@@ -1063,9 +1063,9 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
             builder.AddElement<HueModulation>()
 .AddAttribute(52, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 });
         }
 
@@ -1256,8 +1256,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
             builder.AddElement<PercentageType>()
                            .AddAttribute(52, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
                            });
         }
     }
@@ -1346,9 +1346,9 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
             builder.AddElement<RgbColorModelHex>()
 .AddAttribute(52, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (3L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new StringValidator() { Length = (3L) });
 });
         }
 
@@ -1462,8 +1462,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (3L) });
             builder.AddElement<SchemeColor>()
 .AddAttribute(52, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -1541,12 +1541,12 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<LinearShadeProperties>()
 .AddAttribute(52, "ang", a => a.Angle, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (21600000L), MinInclusive = (0L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 })
 .AddAttribute(52, "scaled", a => a.Scaled, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -1620,7 +1620,7 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<PathShadeProperties>()
 .AddAttribute(52, "path", a => a.Path, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -1989,7 +1989,7 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<PresetLineDashProperties>()
 .AddAttribute(52, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -2032,8 +2032,8 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<LineJoinMiterProperties>()
 .AddAttribute(52, "lim", a => a.Limit, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 });
         }
 
@@ -2109,8 +2109,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
             builder.AddElement<Glow>()
 .AddAttribute(52, "rad", a => a.GlowRadius, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 });
         }
 
@@ -2317,40 +2317,40 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<Shadow>()
 .AddAttribute(52, "blurRad", a => a.BlurRadius, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(52, "dist", a => a.DistanceFromText, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(52, "dir", a => a.DirectionAngle, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (21600000L), MinInclusive = (0L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 })
 .AddAttribute(52, "sx", a => a.HorizontalScalingFactor, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(52, "sy", a => a.VerticalScalingFactor, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(52, "kx", a => a.HorizontalSkewAngle, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinExclusive = (-5400000L), MaxExclusive = (5400000L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinExclusive = (-5400000L), MaxExclusive = (5400000L) });
 })
 .AddAttribute(52, "ky", a => a.VerticalSkewAngle, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinExclusive = (-5400000L), MaxExclusive = (5400000L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinExclusive = (-5400000L), MaxExclusive = (5400000L) });
 })
 .AddAttribute(52, "algn", a => a.Alignment, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -2589,65 +2589,65 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<Reflection>()
 .AddAttribute(52, "blurRad", a => a.BlurRadius, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(52, "stA", a => a.StartingOpacity, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(52, "stPos", a => a.StartPosition, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(52, "endA", a => a.EndingOpacity, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(52, "endPos", a => a.EndPosition, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(52, "dist", a => a.DistanceFromText, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(52, "dir", a => a.DirectionAngle, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (21600000L), MinInclusive = (0L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 })
 .AddAttribute(52, "fadeDir", a => a.FadeDirection, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (21600000L), MinInclusive = (0L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 })
 .AddAttribute(52, "sx", a => a.HorizontalScalingFactor, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(52, "sy", a => a.VerticalScalingFactor, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(52, "kx", a => a.HorizontalSkewAngle, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinExclusive = (-5400000L), MaxExclusive = (5400000L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinExclusive = (-5400000L), MaxExclusive = (5400000L) });
 })
 .AddAttribute(52, "ky", a => a.VerticalSkewAngle, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinExclusive = (-5400000L), MaxExclusive = (5400000L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinExclusive = (-5400000L), MaxExclusive = (5400000L) });
 })
 .AddAttribute(52, "algn", a => a.Alignment, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -2772,20 +2772,20 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<TextOutlineEffect>()
 .AddAttribute(52, "w", a => a.LineWidth, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (20116800L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (20116800L) });
 })
 .AddAttribute(52, "cap", a => a.CapType, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(52, "cmpd", a => a.Compound, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(52, "algn", a => a.Alignment, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -3128,18 +3128,18 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<Properties3D>()
 .AddAttribute(52, "extrusionH", a => a.ExtrusionHeight, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(52, "contourW", a => a.ContourWidth, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(52, "prstMaterial", a => a.PresetMaterialType, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -3244,8 +3244,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Ligatures>()
 .AddAttribute(52, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -3288,8 +3288,8 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<NumberingFormat>()
 .AddAttribute(52, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -3332,8 +3332,8 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<NumberSpacing>()
 .AddAttribute(52, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -3537,7 +3537,7 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<OnOffType>()
                            .AddAttribute(52, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+                               aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
                            });
         }
     }
@@ -3625,12 +3625,12 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<ContentPart>()
 .AddAttribute(52, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(19, "id", a => a.RelationshipId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -3721,9 +3721,9 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<DocumentId>()
 .AddAttribute(52, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 });
         }
 
@@ -3820,11 +3820,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
             builder.AddElement<MarkupType>()
                            .AddAttribute(23, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                                aBuilder.AddUnion(union =>
                                {
-                                   union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
-                                   union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-2L) });
+                                   union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
+                                   union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
                                });
                            });
         }
@@ -3865,8 +3865,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
             builder.AddElement<DefaultImageDpi>()
 .AddAttribute(52, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -4050,9 +4050,9 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<GradientStop>()
 .AddAttribute(52, "pos", a => a.StopPosition, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 });
         }
 
@@ -4174,19 +4174,19 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<FillToRectangle>()
 .AddAttribute(52, "l", a => a.Left, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(52, "t", a => a.Top, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(52, "r", a => a.Right, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(52, "b", a => a.Bottom, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -4318,21 +4318,21 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<SphereCoordinates>()
 .AddAttribute(52, "lat", a => a.Lattitude, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (21600000L), MinInclusive = (0L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 })
 .AddAttribute(52, "lon", a => a.Longitude, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (21600000L), MinInclusive = (0L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 })
 .AddAttribute(52, "rev", a => a.Revolution, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (21600000L), MinInclusive = (0L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 });
         }
 
@@ -4375,9 +4375,9 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (21600000L
             builder.AddElement<Camera>()
 .AddAttribute(52, "prst", a => a.PresetCameraType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -4464,15 +4464,15 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<LightRig>()
 .AddAttribute(52, "rig", a => a.LightRigType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(52, "dir", a => a.LightDirectionType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -4609,18 +4609,18 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<BevelType>()
                            .AddAttribute(52, "w", a => a.Width, aBuilder =>
                            {
-                               aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+                               aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
                            })
                            .AddAttribute(52, "h", a => a.Height, aBuilder =>
                            {
-                               aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+                               aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
                            })
                            .AddAttribute(52, "prst", a => a.PresetProfileType, aBuilder =>
                            {
-                               aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-                               aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+                               aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+                               aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                            });
         }
     }
@@ -4892,12 +4892,12 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<StyleSet>()
 .AddAttribute(52, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(52, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -5007,12 +5007,12 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<CheckBoxSymbolType>()
                            .AddAttribute(52, "font", a => a.Font, aBuilder =>
                            {
-                               aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+                               aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
                            })
                            .AddAttribute(52, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-                               aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
+                               aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+                               aBuilder.AddValidator(new StringValidator() { Length = (2L) });
                            });
         }
     }
@@ -5124,11 +5124,11 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2010_wordprocessingDrawing.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2010_wordprocessingDrawing.g.cs
@@ -43,7 +43,7 @@ namespace DocumentFormat.OpenXml.Office2010.Word.Drawing
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidatorAttribute());
+            builder.AddValidator<Int32Value>(new NumberValidator());
             builder.SetSchema(51, "pctPosHOffset");
             builder.Availability = FileFormatVersions.Office2010;
         }
@@ -82,7 +82,7 @@ namespace DocumentFormat.OpenXml.Office2010.Word.Drawing
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidatorAttribute());
+            builder.AddValidator<Int32Value>(new NumberValidator());
             builder.SetSchema(51, "pctPosVOffset");
             builder.Availability = FileFormatVersions.Office2010;
         }
@@ -154,8 +154,8 @@ namespace DocumentFormat.OpenXml.Office2010.Word.Drawing
             builder.AddElement<RelativeWidth>()
 .AddAttribute(0, "relativeFrom", a => a.ObjectId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -246,8 +246,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<RelativeHeight>()
 .AddAttribute(0, "relativeFrom", a => a.RelativeFrom, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -305,7 +305,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
+            builder.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
             builder.SetSchema(51, "pctWidth");
             builder.Availability = FileFormatVersions.Office2010;
         }
@@ -344,7 +344,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
+            builder.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
             builder.SetSchema(51, "pctHeight");
             builder.Availability = FileFormatVersions.Office2010;
         }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2010_wordprocessingDrawing.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2010_wordprocessingDrawing.g.cs
@@ -43,7 +43,7 @@ namespace DocumentFormat.OpenXml.Office2010.Word.Drawing
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidator());
+            builder.AddValidator<Int32Value>(NumberValidator.Instance);
             builder.SetSchema(51, "pctPosHOffset");
             builder.Availability = FileFormatVersions.Office2010;
         }
@@ -82,7 +82,7 @@ namespace DocumentFormat.OpenXml.Office2010.Word.Drawing
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidator());
+            builder.AddValidator<Int32Value>(NumberValidator.Instance);
             builder.SetSchema(51, "pctPosVOffset");
             builder.Availability = FileFormatVersions.Office2010;
         }
@@ -154,7 +154,7 @@ namespace DocumentFormat.OpenXml.Office2010.Word.Drawing
             builder.AddElement<RelativeWidth>()
 .AddAttribute(0, "relativeFrom", a => a.ObjectId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -246,7 +246,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<RelativeHeight>()
 .AddAttribute(0, "relativeFrom", a => a.RelativeFrom, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2010_wordprocessingGroup.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2010_wordprocessingGroup.g.cs
@@ -391,11 +391,11 @@ namespace DocumentFormat.OpenXml.Office2010.Word.DrawingGroup
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2010_wordprocessingGroup.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2010_wordprocessingGroup.g.cs
@@ -391,11 +391,11 @@ namespace DocumentFormat.OpenXml.Office2010.Word.DrawingGroup
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)
@@ -916,7 +916,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<GroupShapeProperties>()
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2010_wordprocessingShape.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2010_wordprocessingShape.g.cs
@@ -308,11 +308,11 @@ namespace DocumentFormat.OpenXml.Office2010.Word.DrawingShape
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)
@@ -1051,11 +1051,11 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<LinkedTextBox>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "seq", a => a.Sequence, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2010_wordprocessingShape.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2010_wordprocessingShape.g.cs
@@ -308,11 +308,11 @@ namespace DocumentFormat.OpenXml.Office2010.Word.DrawingShape
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)
@@ -690,7 +690,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ShapeProperties>()
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -1051,11 +1051,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<LinkedTextBox>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "seq", a => a.Sequence, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -1342,19 +1342,19 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "spcFirstLastPara", a => a.UseParagraphSpacing)
 .AddAttribute(0, "vertOverflow", a => a.VerticalOverflow, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "horzOverflow", a => a.HorizontalOverflow, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "vert", a => a.Vertical, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "wrap", a => a.Wrap, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "lIns", a => a.LeftInset)
 .AddAttribute(0, "tIns", a => a.TopInset)
@@ -1362,17 +1362,17 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "bIns", a => a.BottomInset)
 .AddAttribute(0, "numCol", a => a.ColumnCount, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (16L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (16L) });
 })
 .AddAttribute(0, "spcCol", a => a.ColumnSpacing, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 })
 .AddAttribute(0, "rtlCol", a => a.RightToLeftColumns)
 .AddAttribute(0, "fromWordArt", a => a.FromWordArt)
 .AddAttribute(0, "anchor", a => a.Anchor, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "anchorCtr", a => a.AnchorCenter)
 .AddAttribute(0, "forceAA", a => a.ForceAntiAlias)

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2012_wordml.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2012_wordml.g.cs
@@ -88,21 +88,21 @@ namespace DocumentFormat.OpenXml.Office2013.Word
             builder.AddElement<Color>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(new EnumValidatorAttribute());
-union.AddValidator<HexBinaryValue>(new StringValidatorAttribute() { Length = (3L) });
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(new EnumValidator());
+union.AddValidator<HexBinaryValue>(new StringValidator() { Length = (3L) });
 });
 })
 .AddAttribute(23, "themeColor", a => a.ThemeColor)
 .AddAttribute(23, "themeTint", a => a.ThemeTint, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
+aBuilder.AddValidator(new StringValidator() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
 })
 .AddAttribute(23, "themeShade", a => a.ThemeShade, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
+aBuilder.AddValidator(new StringValidator() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
 });
         }
 
@@ -172,11 +172,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9a-fA-F]*"
 .AddAttribute(23, "prefixMappings", a => a.PrefixMappings)
 .AddAttribute(23, "xpath", a => a.XPath, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(23, "storeItemID", a => a.StoreItemId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -219,7 +219,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Appearance>()
 .AddAttribute(69, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2013));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2013));
 });
         }
 
@@ -727,8 +727,8 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<PersistentDocumentId>()
 .AddAttribute(69, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2013));
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2013));
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
 
@@ -771,7 +771,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<FootnoteColumns>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -840,18 +840,18 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<CommentEx>()
 .AddAttribute(69, "paraId", a => a.ParaId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2013));
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2013));
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(69, "paraIdParent", a => a.ParaIdParent, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2013));
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2013));
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(69, "done", a => a.Done, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2013));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2013));
 });
         }
 
@@ -945,13 +945,13 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<Person>()
 .AddAttribute(69, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2013));
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2013));
 })
 .AddAttribute(69, "contact", a => a.Contact, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2013));
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2013));
 });
         }
 
@@ -1027,13 +1027,13 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<PresenceInfo>()
 .AddAttribute(69, "providerId", a => a.ProviderId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2013));
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2013));
 })
 .AddAttribute(69, "userId", a => a.UserId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2013));
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2013));
 });
         }
 
@@ -1083,7 +1083,7 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<SectionTitle>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2012_wordml.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2012_wordml.g.cs
@@ -88,10 +88,10 @@ namespace DocumentFormat.OpenXml.Office2013.Word
             builder.AddElement<Color>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(EnumValidator.Instance);
 union.AddValidator<HexBinaryValue>(new StringValidator() { Length = (3L) });
 });
 })
@@ -172,11 +172,11 @@ aBuilder.AddValidator(new StringValidator() { Pattern = ("[0-9a-fA-F]*"), MinLen
 .AddAttribute(23, "prefixMappings", a => a.PrefixMappings)
 .AddAttribute(23, "xpath", a => a.XPath, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(23, "storeItemID", a => a.StoreItemId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -771,7 +771,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<FootnoteColumns>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -840,7 +840,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<CommentEx>()
 .AddAttribute(69, "paraId", a => a.ParaId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2013));
 aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
@@ -945,12 +945,12 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2013))
             builder.AddElement<Person>()
 .AddAttribute(69, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2013));
 })
 .AddAttribute(69, "contact", a => a.Contact, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2013));
 });
         }
@@ -1027,12 +1027,12 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2013))
             builder.AddElement<PresenceInfo>()
 .AddAttribute(69, "providerId", a => a.ProviderId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2013));
 })
 .AddAttribute(69, "userId", a => a.UserId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2013));
 });
         }
@@ -1083,7 +1083,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2013))
             builder.AddElement<SectionTitle>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2015_wordml_symex.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2015_wordml_symex.g.cs
@@ -61,12 +61,12 @@ namespace DocumentFormat.OpenXml.Office2016.Word.Symex
             builder.AddElement<SymEx>()
 .AddAttribute(86, "font", a => a.Font, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2016));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2016));
 })
 .AddAttribute(86, "char", a => a.Char, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2016));
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2016));
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_chart.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_chart.g.cs
@@ -58,7 +58,7 @@ namespace DocumentFormat.OpenXml.Drawing.Charts
             builder.AddElement<NumberingFormat>()
 .AddAttribute(0, "formatCode", a => a.FormatCode, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "sourceLinked", a => a.SourceLinked);
         }
@@ -453,7 +453,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<DataLabelPosition>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -2465,7 +2465,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<UnsignedIntegerType>()
                            .AddAttribute(0, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -2938,7 +2938,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<BarDirection>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -3950,7 +3950,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<AxisPosition>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -4260,7 +4260,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Crosses>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -4641,7 +4641,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<DoubleType>()
                            .AddAttribute(0, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -5036,7 +5036,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RelationshipIdType>()
                            .AddAttribute(19, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -5516,7 +5516,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<NumericPoint>()
 .AddAttribute(0, "idx", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "formatCode", a => a.FormatCode);
         }
@@ -7020,7 +7020,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<Symbol>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -7396,7 +7396,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<PolynomialOrder>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
  aBuilder.AddValidator(new NumberValidator() { MinInclusive = (2L), MaxInclusive = (6L) });
 });
         }
@@ -7436,7 +7436,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Period>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (2L) });
 });
         }
@@ -7631,7 +7631,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (2L) });
             builder.AddElement<ErrorDirection>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -7670,7 +7670,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ErrorBarType>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -7709,7 +7709,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ErrorBarValueType>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -8426,7 +8426,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<OfPieType>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -8465,7 +8465,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<SplitType>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -8696,7 +8696,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (5L), MaxInclusive 
             builder.AddElement<PictureFormat>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -8735,7 +8735,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<PictureStackUnit>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 });
         }
@@ -8934,7 +8934,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
             builder.AddElement<LogBase>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (2L), MaxInclusive = (1000L) });
 });
         }
@@ -10339,27 +10339,27 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (2L), MaxInclusive 
             builder.AddElement<PageMargins>()
 .AddAttribute(0, "l", a => a.Left, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "r", a => a.Right, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "t", a => a.Top, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "b", a => a.Bottom, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "header", a => a.Header, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "footer", a => a.Footer, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -14014,7 +14014,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<HoleSize>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (90L) });
 });
         }
@@ -14085,7 +14085,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive 
             builder.AddElement<StringPoint>()
 .AddAttribute(0, "idx", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -14220,7 +14220,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<StockChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -14299,7 +14299,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<PieChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -14378,7 +14378,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<Pie3DChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -14461,7 +14461,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<NumRefExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -14542,7 +14542,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<StrDataExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -14625,7 +14625,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<StrRefExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -14710,7 +14710,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<MultiLvlStrRefExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -14799,7 +14799,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<DLblExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -14894,7 +14894,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<DLblsExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -14985,7 +14985,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<LineSerExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -15073,7 +15073,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<ScatterSerExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -15161,7 +15161,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<RadarSerExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -15249,7 +15249,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<AreaSerExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -15337,7 +15337,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<PieSerExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -15423,7 +15423,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<SurfaceSerExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -15504,7 +15504,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<LineChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -15583,7 +15583,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<Line3DChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -15662,7 +15662,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<ScatterChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -15741,7 +15741,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<RadarChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -15820,7 +15820,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<BarChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -15899,7 +15899,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<Bar3DChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -15978,7 +15978,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<AreaChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -16057,7 +16057,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<Area3DChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -16136,7 +16136,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<BubbleChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -16215,7 +16215,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<SurfaceChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -16294,7 +16294,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<Surface3DChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -16373,7 +16373,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<CatAxExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -16452,7 +16452,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<DateAxExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -16531,7 +16531,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<SerAxExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -16610,7 +16610,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<ValAxExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -18652,7 +18652,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<BarSerExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -18927,7 +18927,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<BubbleSerExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -19431,7 +19431,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<RadarStyle>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -20444,7 +20444,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<LabelAlignment>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -20569,7 +20569,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<SkipType>()
                            .AddAttribute(0, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L) });
                            });
         }
@@ -20819,7 +20819,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<AxisUnitType>()
                            .AddAttribute(0, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinExclusive = (0L) });
                            });
         }
@@ -20980,7 +20980,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<CrossBetween>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -21155,7 +21155,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<EditingLanguage>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -21374,62 +21374,62 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ColorMapOverride>()
 .AddAttribute(0, "bg1", a => a.Background1, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "tx1", a => a.Text1, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "bg2", a => a.Background2, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "tx2", a => a.Text2, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent1", a => a.Accent1, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent2", a => a.Accent2, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent3", a => a.Accent3, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent4", a => a.Accent4, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent5", a => a.Accent5, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent6", a => a.Accent6, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "hlink", a => a.Hyperlink, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "folHlink", a => a.FollowedHyperlink, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -22036,7 +22036,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<ExternalData>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -22321,7 +22321,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ChartSpaceExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_chart.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_chart.g.cs
@@ -58,7 +58,7 @@ namespace DocumentFormat.OpenXml.Drawing.Charts
             builder.AddElement<NumberingFormat>()
 .AddAttribute(0, "formatCode", a => a.FormatCode, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "sourceLinked", a => a.SourceLinked);
         }
@@ -155,7 +155,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ChartShapeProperties>()
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -453,7 +453,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<DataLabelPosition>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -2465,7 +2465,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<UnsignedIntegerType>()
                            .AddAttribute(0, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -2938,7 +2938,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<BarDirection>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -3950,7 +3950,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<AxisPosition>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
+ aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -4260,7 +4260,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Crosses>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -4641,7 +4641,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<DoubleType>()
                            .AddAttribute(0, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -5036,7 +5036,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RelationshipIdType>()
                            .AddAttribute(19, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -5096,7 +5096,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Extension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-   aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+   aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -5516,7 +5516,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<NumericPoint>()
 .AddAttribute(0, "idx", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "formatCode", a => a.FormatCode);
         }
@@ -6825,7 +6825,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RotateX>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-90L), MaxInclusive = (90L) });
+  aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-90L), MaxInclusive = (90L) });
 });
         }
 
@@ -6864,7 +6864,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<HeightPercent>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (5L), MaxInclusive = (500L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (5L), MaxInclusive = (500L) });
 });
         }
 
@@ -6903,7 +6903,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (5L), MaxI
             builder.AddElement<RotateY>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (360L) });
+  aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (360L) });
 });
         }
 
@@ -6942,7 +6942,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (5L), MaxI
             builder.AddElement<DepthPercent>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (20L), MaxInclusive = (2000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (20L), MaxInclusive = (2000L) });
 });
         }
 
@@ -6981,7 +6981,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (20L), Max
             builder.AddElement<Perspective>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (240L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (240L) });
 });
         }
 
@@ -7020,7 +7020,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<Symbol>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -7059,7 +7059,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Size>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (2L), MaxInclusive = (72L) });
+  aBuilder.AddValidator(new NumberValidator() { MinInclusive = (2L), MaxInclusive = (72L) });
 });
         }
 
@@ -7396,8 +7396,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<PolynomialOrder>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
- aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (2L), MaxInclusive = (6L) });
+ aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (2L), MaxInclusive = (6L) });
 });
         }
 
@@ -7436,8 +7436,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Period>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (2L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (2L) });
 });
         }
 
@@ -7631,7 +7631,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (2L) });
             builder.AddElement<ErrorDirection>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -7670,7 +7670,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ErrorBarType>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -7709,7 +7709,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ErrorBarValueType>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -8204,7 +8204,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<GapAmountType>()
                            .AddAttribute(0, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (500L) });
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (500L) });
                            });
         }
     }
@@ -8426,7 +8426,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<OfPieType>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -8465,7 +8465,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<SplitType>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -8566,7 +8566,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<SecondPieSize>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (5L), MaxInclusive = (200L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (5L), MaxInclusive = (200L) });
 });
         }
 
@@ -8696,7 +8696,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (5L), MaxI
             builder.AddElement<PictureFormat>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -8735,8 +8735,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<PictureStackUnit>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 });
         }
 
@@ -8934,8 +8934,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
             builder.AddElement<LogBase>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (2L), MaxInclusive = (1000L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (2L), MaxInclusive = (1000L) });
 });
         }
 
@@ -10339,27 +10339,27 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (2L), MaxI
             builder.AddElement<PageMargins>()
 .AddAttribute(0, "l", a => a.Left, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "r", a => a.Right, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "t", a => a.Top, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "b", a => a.Bottom, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "header", a => a.Header, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "footer", a => a.Footer, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -10599,7 +10599,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ShapeProperties>()
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -13975,7 +13975,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<FirstSliceAngle>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (360L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (360L) });
 });
         }
 
@@ -14014,8 +14014,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<HoleSize>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (90L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (90L) });
 });
         }
 
@@ -14085,7 +14085,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxI
             builder.AddElement<StringPoint>()
 .AddAttribute(0, "idx", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -14150,7 +14150,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Thickness>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100L) });
 });
         }
 
@@ -14220,8 +14220,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<StockChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -14299,8 +14299,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<PieChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -14378,8 +14378,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Pie3DChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -14461,8 +14461,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<NumRefExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -14542,8 +14542,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<StrDataExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -14625,8 +14625,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<StrRefExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -14710,8 +14710,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<MultiLvlStrRefExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -14799,8 +14799,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<DLblExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -14894,8 +14894,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<DLblsExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -14985,8 +14985,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<LineSerExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -15073,8 +15073,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<ScatterSerExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -15161,8 +15161,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<RadarSerExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -15249,8 +15249,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<AreaSerExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -15337,8 +15337,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<PieSerExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -15423,8 +15423,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<SurfaceSerExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -15504,8 +15504,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<LineChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -15583,8 +15583,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Line3DChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -15662,8 +15662,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<ScatterChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -15741,8 +15741,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<RadarChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -15820,8 +15820,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<BarChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -15899,8 +15899,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Bar3DChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -15978,8 +15978,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<AreaChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -16057,8 +16057,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Area3DChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -16136,8 +16136,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<BubbleChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -16215,8 +16215,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<SurfaceChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -16294,8 +16294,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Surface3DChartExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -16373,8 +16373,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<CatAxExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -16452,8 +16452,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<DateAxExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -16531,8 +16531,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<SerAxExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -16610,8 +16610,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<ValAxExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -18652,8 +18652,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<BarSerExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -18927,8 +18927,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<BubbleSerExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -19431,7 +19431,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<RadarStyle>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -19708,7 +19708,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Overlap>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-100L), MaxInclusive = (100L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100L), MaxInclusive = (100L) });
 });
         }
 
@@ -20183,7 +20183,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-100L), M
             builder.AddElement<BubbleScale>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (300L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (300L) });
 });
         }
 
@@ -20444,7 +20444,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<LabelAlignment>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -20483,7 +20483,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<LabelOffset>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (1000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (1000L) });
 });
         }
 
@@ -20569,8 +20569,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<SkipType>()
                            .AddAttribute(0, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L) });
                            });
         }
     }
@@ -20819,8 +20819,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<AxisUnitType>()
                            .AddAttribute(0, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinExclusive = (0L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinExclusive = (0L) });
                            });
         }
     }
@@ -20980,7 +20980,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<CrossBetween>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -21155,7 +21155,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<EditingLanguage>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -21194,7 +21194,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Style>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (48L) });
+ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (48L) });
 });
         }
 
@@ -21374,63 +21374,63 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ColorMapOverride>()
 .AddAttribute(0, "bg1", a => a.Background1, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "tx1", a => a.Text1, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "bg2", a => a.Background2, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "tx2", a => a.Text2, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent1", a => a.Accent1, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent2", a => a.Accent2, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent3", a => a.Accent3, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent4", a => a.Accent4, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent5", a => a.Accent5, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent6", a => a.Accent6, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "hlink", a => a.Hyperlink, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "folHlink", a => a.FollowedHyperlink, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -22036,7 +22036,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<ExternalData>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -22321,8 +22321,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ChartSpaceExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_chartDrawing.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_chartDrawing.g.cs
@@ -1067,11 +1067,11 @@ namespace DocumentFormat.OpenXml.Drawing.ChartDrawing
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)
@@ -2951,12 +2951,12 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<Extent>()
 .AddAttribute(0, "cx", a => a.Cx, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(0, "cy", a => a.Cy, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 });
         }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_chartDrawing.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_chartDrawing.g.cs
@@ -1067,11 +1067,11 @@ namespace DocumentFormat.OpenXml.Drawing.ChartDrawing
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)
@@ -1420,7 +1420,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ShapeProperties>()
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -2659,7 +2659,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<DoubleValue>(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (1L) });
+            builder.AddValidator<DoubleValue>(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (1L) });
             builder.SetSchema(12, "x");
         }
 
@@ -2697,7 +2697,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<DoubleValue>(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (1L) });
+            builder.AddValidator<DoubleValue>(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (1L) });
             builder.SetSchema(12, "y");
         }
 
@@ -2951,13 +2951,13 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Extent>()
 .AddAttribute(0, "cx", a => a.Cx, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(0, "cy", a => a.Cy, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 });
         }
 
@@ -3138,7 +3138,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<GroupShapeProperties>()
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_compatibility.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_compatibility.g.cs
@@ -45,7 +45,7 @@ namespace DocumentFormat.OpenXml.Drawing.LegacyCompatibility
             builder.AddElement<LegacyDrawing>()
 .AddAttribute(0, "spid", a => a.ShapeId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_compatibility.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_compatibility.g.cs
@@ -45,8 +45,8 @@ namespace DocumentFormat.OpenXml.Drawing.LegacyCompatibility
             builder.AddElement<LegacyDrawing>()
 .AddAttribute(0, "spid", a => a.ShapeId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_diagram.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_diagram.g.cs
@@ -236,7 +236,7 @@ namespace DocumentFormat.OpenXml.Drawing.Diagrams
             builder.AddElement<ColorsDefinitionHeader>()
 .AddAttribute(0, "uniqueId", a => a.UniqueId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "minVer", a => a.MinVersion)
 .AddAttribute(0, "resId", a => a.ResourceId);
@@ -734,7 +734,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<LayoutDefinitionHeader>()
 .AddAttribute(0, "uniqueId", a => a.UniqueId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "minVer", a => a.MinVersion)
 .AddAttribute(0, "defStyle", a => a.DefaultStyle)
@@ -890,19 +890,19 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RelationshipIds>()
 .AddAttribute(19, "dm", a => a.DataPart, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(19, "lo", a => a.LayoutPart, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(19, "qs", a => a.StylePart, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(19, "cs", a => a.ColorPart, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -1139,7 +1139,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<StyleDefinitionHeader>()
 .AddAttribute(0, "uniqueId", a => a.UniqueId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "minVer", a => a.MinVersion)
 .AddAttribute(0, "resId", a => a.ResourceId);
@@ -1262,12 +1262,12 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ColorTransformCategory>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 })
 .AddAttribute(0, "pri", a => a.Priority, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -1937,7 +1937,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 .AddAttribute(0, "lang", a => a.Language)
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -1987,7 +1987,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 .AddAttribute(0, "lang", a => a.Language)
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -2131,7 +2131,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<ColorTransformStyleLabel>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -2331,10 +2331,10 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Point>()
 .AddAttribute(0, "modelId", a => a.ModelId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator<Int32Value>(NumberValidator.Instance);
 union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
 })
@@ -2346,7 +2346,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator<Int32Value>(NumberValidator.Instance);
 union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
 });
@@ -2560,10 +2560,10 @@ union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4
             builder.AddElement<Connection>()
 .AddAttribute(0, "modelId", a => a.ModelId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator<Int32Value>(NumberValidator.Instance);
 union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
 })
@@ -2573,35 +2573,35 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "srcId", a => a.SourceId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator<Int32Value>(NumberValidator.Instance);
 union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
 })
 .AddAttribute(0, "destId", a => a.DestinationId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator<Int32Value>(NumberValidator.Instance);
 union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
 })
 .AddAttribute(0, "srcOrd", a => a.SourcePosition, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "destOrd", a => a.DestinationPosition, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "parTransId", a => a.ParentTransitionId, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator<Int32Value>(NumberValidator.Instance);
 union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
 })
@@ -2609,7 +2609,7 @@ union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator<Int32Value>(NumberValidator.Instance);
 union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
 })
@@ -2809,7 +2809,7 @@ union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4
             builder.AddElement<Constraint>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "for", a => a.For, aBuilder =>
@@ -2988,7 +2988,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<Rule>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "for", a => a.For, aBuilder =>
@@ -3070,12 +3070,12 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<Adjust>()
 .AddAttribute(0, "idx", a => a.Index, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L) });
 })
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -3186,49 +3186,49 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<Parameter>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
  aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
  aBuilder.AddUnion(union =>
  {
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.HorizontalAlignmentValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.VerticalAlignmentValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ChildDirectionValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ChildAlignmentValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.SecondaryChildAlignmentValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.LinearDirectionValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.SecondaryLinearDirectionValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.StartingElementValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.BendPointValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ConnectorRoutingValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ArrowheadStyleValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ConnectorDimensionValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.RotationPathValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.CenterShapeMappingValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.NodeHorizontalAlignmentValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.NodeVerticalAlignmentValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.FallbackDimensionValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.TextDirectionValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.PyramidAccentPositionValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.PyramidAccentTextMarginValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.TextBlockDirectionValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.TextAnchorHorizontalValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.TextAnchorVerticalValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.TextAlignmentValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.AutoTextRotationValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.GrowDirectionValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.FlowDirectionValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ContinueDirectionValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.BreakpointValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.OffsetValues>>(new EnumValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.HierarchyAlignmentValues>>(new EnumValidator());
-     union.AddValidator<Int32Value>(new NumberValidator());
-     union.AddValidator<DoubleValue>(new NumberValidator());
-     union.AddValidator<BooleanValue>(new NumberValidator());
-     union.AddValidator(new StringValidator());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ConnectorPointValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.HorizontalAlignmentValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.VerticalAlignmentValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ChildDirectionValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ChildAlignmentValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.SecondaryChildAlignmentValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.LinearDirectionValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.SecondaryLinearDirectionValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.StartingElementValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.BendPointValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ConnectorRoutingValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ArrowheadStyleValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ConnectorDimensionValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.RotationPathValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.CenterShapeMappingValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.NodeHorizontalAlignmentValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.NodeVerticalAlignmentValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.FallbackDimensionValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.TextDirectionValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.PyramidAccentPositionValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.PyramidAccentTextMarginValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.TextBlockDirectionValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.TextAnchorHorizontalValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.TextAnchorVerticalValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.TextAlignmentValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.AutoTextRotationValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.GrowDirectionValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.FlowDirectionValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ContinueDirectionValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.BreakpointValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.OffsetValues>>(EnumValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.HierarchyAlignmentValues>>(EnumValidator.Instance);
+     union.AddValidator<Int32Value>(NumberValidator.Instance);
+     union.AddValidator<DoubleValue>(NumberValidator.Instance);
+     union.AddValidator<BooleanValue>(NumberValidator.Instance);
+     union.AddValidator(StringValidator.Instance);
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ConnectorPointValues>>(EnumValidator.Instance);
  });
 });
         }
@@ -3311,7 +3311,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<Algorithm>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "rev", a => a.Revision);
@@ -3459,8 +3459,8 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.ShapeTypeValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.OutputShapeValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.ShapeTypeValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.OutputShapeValues>>(EnumValidator.Instance);
 });
 })
 .AddAttribute(19, "blip", a => a.Blip)
@@ -4711,33 +4711,33 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 .AddAttribute(0, "step", a => a.Step)
 .AddAttribute(0, "func", a => a.Function, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "arg", a => a.Argument, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.VariableValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.VariableValues>>(EnumValidator.Instance);
 });
 })
 .AddAttribute(0, "op", a => a.Operator, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidator());
-union.AddValidator<BooleanValue>(new NumberValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.DirectionValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.HierarchyBranchStyleValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.AnimateOneByOneValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.AnimationLevelStringValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ResizeHandlesStringValues>>(new EnumValidator());
+union.AddValidator<Int32Value>(NumberValidator.Instance);
+union.AddValidator<BooleanValue>(NumberValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.DirectionValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.HierarchyBranchStyleValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.AnimateOneByOneValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.AnimationLevelStringValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ResizeHandlesStringValues>>(EnumValidator.Instance);
 });
 });
         }
@@ -5051,12 +5051,12 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ResizeHandl
             builder.AddElement<Category>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 })
 .AddAttribute(0, "pri", a => a.Priority, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -5106,7 +5106,7 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ResizeHandl
 .AddAttribute(0, "lang", a => a.Language)
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -5156,7 +5156,7 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ResizeHandl
 .AddAttribute(0, "lang", a => a.Language)
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -5994,12 +5994,12 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<StyleDisplayCategory>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 })
 .AddAttribute(0, "pri", a => a.Priority, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -6465,7 +6465,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 .AddAttribute(0, "lang", a => a.Language)
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -6515,7 +6515,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 .AddAttribute(0, "lang", a => a.Language)
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -6655,7 +6655,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<StyleLabel>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -7443,7 +7443,7 @@ aBuilder.AddValidator(new RequiredValidator());
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator<Int32Value>(NumberValidator.Instance);
 union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
 })

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_diagram.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_diagram.g.cs
@@ -236,7 +236,7 @@ namespace DocumentFormat.OpenXml.Drawing.Diagrams
             builder.AddElement<ColorsDefinitionHeader>()
 .AddAttribute(0, "uniqueId", a => a.UniqueId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "minVer", a => a.MinVersion)
 .AddAttribute(0, "resId", a => a.ResourceId);
@@ -734,7 +734,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<LayoutDefinitionHeader>()
 .AddAttribute(0, "uniqueId", a => a.UniqueId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "minVer", a => a.MinVersion)
 .AddAttribute(0, "defStyle", a => a.DefaultStyle)
@@ -890,19 +890,19 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RelationshipIds>()
 .AddAttribute(19, "dm", a => a.DataPart, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(19, "lo", a => a.LayoutPart, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(19, "qs", a => a.StylePart, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(19, "cs", a => a.ColorPart, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -1139,7 +1139,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<StyleDefinitionHeader>()
 .AddAttribute(0, "uniqueId", a => a.UniqueId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "minVer", a => a.MinVersion)
 .AddAttribute(0, "resId", a => a.ResourceId);
@@ -1262,12 +1262,12 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ColorTransformCategory>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 })
 .AddAttribute(0, "pri", a => a.Priority, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -1818,11 +1818,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ColorsType>()
 .AddAttribute(0, "meth", a => a.Method, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "hueDir", a => a.HueDirection, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
     }
@@ -1937,7 +1937,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "lang", a => a.Language)
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
+ aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -1987,7 +1987,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "lang", a => a.Language)
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -2131,7 +2131,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<ColorTransformStyleLabel>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -2331,23 +2331,23 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Point>()
 .AddAttribute(0, "modelId", a => a.ModelId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
 })
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "cxnId", a => a.ConnectionId, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
 });
         }
@@ -2560,57 +2560,57 @@ union.AddValidator(new StringValidatorAttribute() { Pattern = ("\\{[0-9A-F]{8}-[
             builder.AddElement<Connection>()
 .AddAttribute(0, "modelId", a => a.ModelId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
 })
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "srcId", a => a.SourceId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
 })
 .AddAttribute(0, "destId", a => a.DestinationId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
 })
 .AddAttribute(0, "srcOrd", a => a.SourcePosition, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "destOrd", a => a.DestinationPosition, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "parTransId", a => a.ParentTransitionId, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
 })
 .AddAttribute(0, "sibTransId", a => a.SiblingTransitionId, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
 })
 .AddAttribute(0, "presId", a => a.PresentationId);
@@ -2809,34 +2809,34 @@ union.AddValidator(new StringValidatorAttribute() { Pattern = ("\\{[0-9A-F]{8}-[
             builder.AddElement<Constraint>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "for", a => a.For, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "forName", a => a.ForName)
 .AddAttribute(0, "ptType", a => a.PointType, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "refType", a => a.ReferenceType, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "refFor", a => a.ReferenceFor, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "refForName", a => a.ReferenceForName)
 .AddAttribute(0, "refPtType", a => a.ReferencePointType, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "op", a => a.Operator, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "val", a => a.Val)
 .AddAttribute(0, "fact", a => a.Fact);
@@ -2988,17 +2988,17 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Rule>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "for", a => a.For, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "forName", a => a.ForName)
 .AddAttribute(0, "ptType", a => a.PointType, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "val", a => a.Val)
 .AddAttribute(0, "fact", a => a.Fact)
@@ -3070,12 +3070,12 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Adjust>()
 .AddAttribute(0, "idx", a => a.Index, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L) });
 })
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -3186,49 +3186,49 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Parameter>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
- aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+ aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
  aBuilder.AddUnion(union =>
  {
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.HorizontalAlignmentValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.VerticalAlignmentValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ChildDirectionValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ChildAlignmentValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.SecondaryChildAlignmentValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.LinearDirectionValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.SecondaryLinearDirectionValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.StartingElementValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.BendPointValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ConnectorRoutingValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ArrowheadStyleValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ConnectorDimensionValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.RotationPathValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.CenterShapeMappingValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.NodeHorizontalAlignmentValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.NodeVerticalAlignmentValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.FallbackDimensionValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.TextDirectionValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.PyramidAccentPositionValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.PyramidAccentTextMarginValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.TextBlockDirectionValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.TextAnchorHorizontalValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.TextAnchorVerticalValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.TextAlignmentValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.AutoTextRotationValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.GrowDirectionValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.FlowDirectionValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ContinueDirectionValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.BreakpointValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.OffsetValues>>(new EnumValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.HierarchyAlignmentValues>>(new EnumValidatorAttribute());
-     union.AddValidator<Int32Value>(new NumberValidatorAttribute());
-     union.AddValidator<DoubleValue>(new NumberValidatorAttribute());
-     union.AddValidator<BooleanValue>(new NumberValidatorAttribute());
-     union.AddValidator(new StringValidatorAttribute());
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ConnectorPointValues>>(new EnumValidatorAttribute());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.HorizontalAlignmentValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.VerticalAlignmentValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ChildDirectionValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ChildAlignmentValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.SecondaryChildAlignmentValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.LinearDirectionValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.SecondaryLinearDirectionValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.StartingElementValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.BendPointValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ConnectorRoutingValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ArrowheadStyleValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ConnectorDimensionValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.RotationPathValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.CenterShapeMappingValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.NodeHorizontalAlignmentValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.NodeVerticalAlignmentValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.FallbackDimensionValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.TextDirectionValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.PyramidAccentPositionValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.PyramidAccentTextMarginValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.TextBlockDirectionValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.TextAnchorHorizontalValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.TextAnchorVerticalValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.TextAlignmentValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.AutoTextRotationValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.GrowDirectionValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.FlowDirectionValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ContinueDirectionValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.BreakpointValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.OffsetValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.HierarchyAlignmentValues>>(new EnumValidator());
+     union.AddValidator<Int32Value>(new NumberValidator());
+     union.AddValidator<DoubleValue>(new NumberValidator());
+     union.AddValidator<BooleanValue>(new NumberValidator());
+     union.AddValidator(new StringValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ConnectorPointValues>>(new EnumValidator());
  });
 });
         }
@@ -3311,8 +3311,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Algorithm>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "rev", a => a.Revision);
         }
@@ -3459,8 +3459,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.ShapeTypeValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.OutputShapeValues>>(new EnumValidatorAttribute());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.ShapeTypeValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.OutputShapeValues>>(new EnumValidator());
 });
 })
 .AddAttribute(19, "blip", a => a.Blip)
@@ -4412,7 +4412,7 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.OutputShape
 .AddAttribute(0, "styleLbl", a => a.StyleLabel)
 .AddAttribute(0, "chOrder", a => a.ChildOrder, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "moveWith", a => a.MoveWith);
         }
@@ -4711,33 +4711,33 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "step", a => a.Step)
 .AddAttribute(0, "func", a => a.Function, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "arg", a => a.Argument, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.VariableValues>>(new EnumValidatorAttribute());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.VariableValues>>(new EnumValidator());
 });
 })
 .AddAttribute(0, "op", a => a.Operator, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute());
-union.AddValidator<BooleanValue>(new NumberValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.DirectionValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.HierarchyBranchStyleValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.AnimateOneByOneValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.AnimationLevelStringValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ResizeHandlesStringValues>>(new EnumValidatorAttribute());
+union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator<BooleanValue>(new NumberValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.DirectionValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.HierarchyBranchStyleValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.AnimateOneByOneValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.AnimationLevelStringValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ResizeHandlesStringValues>>(new EnumValidator());
 });
 });
         }
@@ -5051,12 +5051,12 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ResizeHandl
             builder.AddElement<Category>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 })
 .AddAttribute(0, "pri", a => a.Priority, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -5106,7 +5106,7 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ResizeHandl
 .AddAttribute(0, "lang", a => a.Language)
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
+ aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -5156,7 +5156,7 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ResizeHandl
 .AddAttribute(0, "lang", a => a.Language)
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -5675,7 +5675,7 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ResizeHandl
             builder.AddElement<MaxNumberOfChildren>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-1L) });
+ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-1L) });
 });
         }
 
@@ -5714,7 +5714,7 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ResizeHandl
             builder.AddElement<PreferredNumberOfChildren>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-1L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-1L) });
 });
         }
 
@@ -5789,7 +5789,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-1L) });
             builder.AddElement<Direction>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+   aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -5828,7 +5828,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-1L) });
             builder.AddElement<HierarchyBranch>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -5867,7 +5867,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<AnimateOneByOne>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -5906,7 +5906,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<AnimationLevel>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -5945,7 +5945,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<ResizeHandles>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -5994,12 +5994,12 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<StyleDisplayCategory>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 })
 .AddAttribute(0, "pri", a => a.Priority, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -6230,19 +6230,19 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Shape3D>()
 .AddAttribute(0, "z", a => a.Z, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "extrusionH", a => a.ExtrusionHeight, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(0, "contourW", a => a.ContourWidth, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(0, "prstMaterial", a => a.PresetMaterial, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -6465,7 +6465,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "lang", a => a.Language)
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
+ aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -6515,7 +6515,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "lang", a => a.Language)
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -6655,7 +6655,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<StyleLabel>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -7443,8 +7443,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
 })
 .AddAttribute(0, "presName", a => a.PresentationName)
@@ -7604,7 +7604,7 @@ union.AddValidator(new StringValidatorAttribute() { Pattern = ("\\{[0-9A-F]{8}-[
             builder.AddElement<ShapeProperties>()
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_main.g.cs
@@ -227,7 +227,7 @@ namespace DocumentFormat.OpenXml.Drawing
             builder.AddElement<EmbeddedWavAudioFileType>()
                            .AddAttribute(19, "embed", a => a.Embed, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            })
                            .AddAttribute(0, "name", a => a.Name)
                            .AddAttribute(0, "builtIn", a => a.BuiltIn);
@@ -299,7 +299,7 @@ namespace DocumentFormat.OpenXml.Drawing
             builder.AddElement<AudioFromFile>()
 .AddAttribute(19, "link", a => a.Link, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -392,7 +392,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<VideoFromFile>()
 .AddAttribute(19, "link", a => a.Link, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -485,7 +485,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<QuickTimeFromFile>()
 .AddAttribute(19, "link", a => a.Link, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -615,8 +615,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<PositiveFixedPercentageType>()
                            .AddAttribute(0, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
                            });
         }
     }
@@ -724,8 +724,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<AlphaOffset>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
 });
         }
 
@@ -811,8 +811,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-100000L)
             builder.AddElement<PositivePercentageType>()
                            .AddAttribute(0, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
                            });
         }
     }
@@ -848,8 +848,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-100000L)
             builder.AddElement<Hue>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (21600000L), MinInclusive = (0L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 });
         }
 
@@ -888,7 +888,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-100000L)
             builder.AddElement<HueOffset>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -1292,7 +1292,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<PercentageType>()
                            .AddAttribute(0, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -1400,7 +1400,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Extension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-   aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+   aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -1551,15 +1551,15 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RgbColorModelPercentage>()
 .AddAttribute(0, "r", a => a.RedPortion, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "g", a => a.GreenPortion, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "b", a => a.BluePortion, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -1736,13 +1736,13 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RgbColorModelHex>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (3L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { Length = (3L) });
 })
 .AddAttribute(48, "legacySpreadsheetColorIndex", a => a.LegacySpreadsheetColorIndex, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (80L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (80L) });
 });
         }
 
@@ -1926,16 +1926,16 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<HslColor>()
 .AddAttribute(0, "hue", a => a.HueValue, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (21600000L), MinInclusive = (0L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 })
 .AddAttribute(0, "sat", a => a.SatValue, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "lum", a => a.LumValue, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -2109,12 +2109,12 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<SystemColor>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "lastClr", a => a.LastColor, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (3L) });
+aBuilder.AddValidator(new StringValidator() { Length = (3L) });
 });
         }
 
@@ -2278,8 +2278,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (3L) });
             builder.AddElement<SchemeColor>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -2443,8 +2443,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<PresetColor>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -2592,19 +2592,19 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Shape3DType>()
 .AddAttribute(0, "z", a => a.Z, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "extrusionH", a => a.ExtrusionHeight, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(0, "contourW", a => a.ContourWidth, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(0, "prstMaterial", a => a.PresetMaterial, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -2719,7 +2719,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<FlatText>()
 .AddAttribute(0, "z", a => a.Z, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 });
         }
 
@@ -2768,7 +2768,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042
             builder.AddElement<LinearGradientFill>()
 .AddAttribute(0, "ang", a => a.Angle, aBuilder =>
 {
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (21600000L), MinInclusive = (0L) });
+   aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 })
 .AddAttribute(0, "scaled", a => a.Scaled);
         }
@@ -2839,7 +2839,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042
             builder.AddElement<PathGradientFill>()
 .AddAttribute(0, "path", a => a.Path, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -2948,21 +2948,21 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Tile>()
 .AddAttribute(0, "tx", a => a.HorizontalOffset, aBuilder =>
 {
-  aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+  aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "ty", a => a.VerticalOffset, aBuilder =>
 {
-  aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+  aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "sx", a => a.HorizontalRatio)
 .AddAttribute(0, "sy", a => a.VerticalRatio)
 .AddAttribute(0, "flip", a => a.Flip, aBuilder =>
 {
-  aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+  aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "algn", a => a.Alignment, aBuilder =>
 {
-  aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+  aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -3308,7 +3308,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<GradientFill>()
 .AddAttribute(0, "flip", a => a.Flip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "rotWithShape", a => a.RotateWithShape);
         }
@@ -3536,7 +3536,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<PatternFill>()
 .AddAttribute(0, "prst", a => a.Preset, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -3975,11 +3975,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<EffectContainerType>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
     }
@@ -4015,7 +4015,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Effect>()
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -4054,8 +4054,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<AlphaBiLevel>()
 .AddAttribute(0, "thresh", a => a.Threshold, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 });
         }
 
@@ -4378,7 +4378,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<AlphaModulationFixed>()
 .AddAttribute(0, "amt", a => a.Amount, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 });
         }
 
@@ -4417,7 +4417,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
             builder.AddElement<AlphaOutset>()
 .AddAttribute(0, "rad", a => a.Radius, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 });
         }
 
@@ -4456,8 +4456,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042
             builder.AddElement<AlphaReplace>()
 .AddAttribute(0, "a", a => a.Alpha, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 });
         }
 
@@ -4496,8 +4496,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<BiLevel>()
 .AddAttribute(0, "thresh", a => a.Threshold, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 });
         }
 
@@ -4567,8 +4567,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<Blend>()
 .AddAttribute(0, "blend", a => a.BlendMode, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -4637,7 +4637,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Blur>()
 .AddAttribute(0, "rad", a => a.Radius, aBuilder =>
 {
-  aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+  aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(0, "grow", a => a.Grow);
         }
@@ -5226,8 +5226,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<FillOverlay>()
 .AddAttribute(0, "blend", a => a.Blend, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -5403,7 +5403,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Glow>()
 .AddAttribute(0, "rad", a => a.Radius, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 });
         }
 
@@ -5582,15 +5582,15 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<Hsl>()
 .AddAttribute(0, "hue", a => a.Hue, aBuilder =>
 {
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (21600000L), MinInclusive = (0L) });
+   aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 })
 .AddAttribute(0, "sat", a => a.Saturation, aBuilder =>
 {
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
+   aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "lum", a => a.Luminance, aBuilder =>
 {
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
+   aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
 });
         }
 
@@ -5690,15 +5690,15 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<InnerShadow>()
 .AddAttribute(0, "blurRad", a => a.BlurRadius, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(0, "dist", a => a.Distance, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(0, "dir", a => a.Direction, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (21600000L), MinInclusive = (0L) });
+aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 });
         }
 
@@ -5843,11 +5843,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (21600000L
             builder.AddElement<LuminanceEffect>()
 .AddAttribute(0, "bright", a => a.Brightness, aBuilder =>
 {
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
+   aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "contrast", a => a.Contrast, aBuilder =>
 {
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
+   aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
 });
         }
 
@@ -6007,29 +6007,29 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (21600000L
             builder.AddElement<OuterShadow>()
 .AddAttribute(0, "blurRad", a => a.BlurRadius, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(0, "dist", a => a.Distance, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(0, "dir", a => a.Direction, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (21600000L), MinInclusive = (0L) });
+aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 })
 .AddAttribute(0, "sx", a => a.HorizontalRatio)
 .AddAttribute(0, "sy", a => a.VerticalRatio)
 .AddAttribute(0, "kx", a => a.HorizontalSkew, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinExclusive = (-5400000L), MaxExclusive = (5400000L) });
+aBuilder.AddValidator(new NumberValidator() { MinExclusive = (-5400000L), MaxExclusive = (5400000L) });
 })
 .AddAttribute(0, "ky", a => a.VerticalSkew, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinExclusive = (-5400000L), MaxExclusive = (5400000L) });
+aBuilder.AddValidator(new NumberValidator() { MinExclusive = (-5400000L), MaxExclusive = (5400000L) });
 })
 .AddAttribute(0, "algn", a => a.Alignment, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "rotWithShape", a => a.RotateWithShape);
         }
@@ -6226,16 +6226,16 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<PresetShadow>()
 .AddAttribute(0, "prst", a => a.Preset, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "dist", a => a.Distance, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(0, "dir", a => a.Direction, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (21600000L), MinInclusive = (0L) });
+aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 });
         }
 
@@ -6500,49 +6500,49 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (21600000L
             builder.AddElement<Reflection>()
 .AddAttribute(0, "blurRad", a => a.BlurRadius, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(0, "stA", a => a.StartOpacity, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "stPos", a => a.StartPosition, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "endA", a => a.EndAlpha, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "endPos", a => a.EndPosition, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "dist", a => a.Distance, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(0, "dir", a => a.Direction, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (21600000L), MinInclusive = (0L) });
+aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 })
 .AddAttribute(0, "fadeDir", a => a.FadeDirection, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (21600000L), MinInclusive = (0L) });
+aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 })
 .AddAttribute(0, "sx", a => a.HorizontalRatio)
 .AddAttribute(0, "sy", a => a.VerticalRatio)
 .AddAttribute(0, "kx", a => a.HorizontalSkew, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinExclusive = (-5400000L), MaxExclusive = (5400000L) });
+aBuilder.AddValidator(new NumberValidator() { MinExclusive = (-5400000L), MaxExclusive = (5400000L) });
 })
 .AddAttribute(0, "ky", a => a.VerticalSkew, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinExclusive = (-5400000L), MaxExclusive = (5400000L) });
+aBuilder.AddValidator(new NumberValidator() { MinExclusive = (-5400000L), MaxExclusive = (5400000L) });
 })
 .AddAttribute(0, "algn", a => a.Alignment, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "rotWithShape", a => a.RotateWithShape);
         }
@@ -6629,8 +6629,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<SoftEdge>()
 .AddAttribute(0, "rad", a => a.Radius, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 });
         }
 
@@ -6679,11 +6679,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<TintEffect>()
 .AddAttribute(0, "hue", a => a.Hue, aBuilder =>
 {
-  aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (21600000L), MinInclusive = (0L) });
+  aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 })
 .AddAttribute(0, "amt", a => a.Amount, aBuilder =>
 {
-  aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
+  aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
 });
         }
 
@@ -6774,19 +6774,19 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
 .AddAttribute(0, "sy", a => a.VerticalRatio)
 .AddAttribute(0, "kx", a => a.HorizontalSkew, aBuilder =>
 {
-  aBuilder.AddValidator(new NumberValidatorAttribute() { MinExclusive = (-5400000L), MaxExclusive = (5400000L) });
+  aBuilder.AddValidator(new NumberValidator() { MinExclusive = (-5400000L), MaxExclusive = (5400000L) });
 })
 .AddAttribute(0, "ky", a => a.VerticalSkew, aBuilder =>
 {
-  aBuilder.AddValidator(new NumberValidatorAttribute() { MinExclusive = (-5400000L), MaxExclusive = (5400000L) });
+  aBuilder.AddValidator(new NumberValidator() { MinExclusive = (-5400000L), MaxExclusive = (5400000L) });
 })
 .AddAttribute(0, "tx", a => a.HorizontalShift, aBuilder =>
 {
-  aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+  aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "ty", a => a.VerticalShift, aBuilder =>
 {
-  aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+  aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 });
         }
 
@@ -7198,8 +7198,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<PresetGeometry>()
 .AddAttribute(0, "prst", a => a.Preset, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -7289,8 +7289,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<PresetTextWrap>()
 .AddAttribute(0, "prst", a => a.Preset, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -7397,7 +7397,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Miter>()
 .AddAttribute(0, "lim", a => a.Limit, aBuilder =>
 {
- aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 });
         }
 
@@ -7436,7 +7436,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<PresetDash>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -7969,7 +7969,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<StyleMatrixReferenceType>()
 .AddAttribute(0, "idx", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -8526,8 +8526,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<FontReference>()
 .AddAttribute(0, "idx", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -8696,11 +8696,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<NormalAutoFit>()
 .AddAttribute(0, "fontScale", a => a.FontScale, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1000L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1000L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "lnSpcReduction", a => a.LineSpaceReduction, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (13200000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (13200000L) });
 });
         }
 
@@ -9566,8 +9566,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<BulletSizePercentage>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (25000L), MaxInclusive = (400000L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (25000L), MaxInclusive = (400000L) });
 });
         }
 
@@ -9606,8 +9606,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (25000L), 
             builder.AddElement<BulletSizePoints>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (100L), MaxInclusive = (400000L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (100L), MaxInclusive = (400000L) });
 });
         }
 
@@ -9820,7 +9820,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (100L), Ma
                            .AddAttribute(0, "typeface", a => a.Typeface)
                            .AddAttribute(0, "panose", a => a.Panose, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { Length = (10L) });
+                               aBuilder.AddValidator(new StringValidator() { Length = (10L) });
                            })
                            .AddAttribute(0, "pitchFamily", a => a.PitchFamily)
                            .AddAttribute(0, "charset", a => a.CharacterSet);
@@ -9892,12 +9892,12 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (100L), Ma
             builder.AddElement<AutoNumberedBullet>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "startAt", a => a.StartAt, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (32767L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (32767L) });
 });
         }
 
@@ -9936,7 +9936,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxI
             builder.AddElement<CharacterBullet>()
 .AddAttribute(0, "char", a => a.Char, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -10964,19 +10964,19 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<LinePropertiesType>()
 .AddAttribute(0, "w", a => a.Width, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (20116800L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (20116800L) });
 })
 .AddAttribute(0, "cap", a => a.CapType, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "cmpd", a => a.CompoundLineType, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "algn", a => a.Alignment, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
     }
@@ -11405,8 +11405,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Field>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "type", a => a.Type);
         }
@@ -11662,7 +11662,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
 .AddAttribute(19, "link", a => a.Link)
 .AddAttribute(0, "cstate", a => a.CompressionState, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -11788,8 +11788,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "name", a => a.Name)
 .AddAttribute(73, "id", a => a.ThemeId, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2013));
-aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2013));
+aBuilder.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
 
@@ -12266,8 +12266,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("\\{[0-9A-F]{8
             builder.AddElement<TableStyleList>()
 .AddAttribute(0, "def", a => a.Default, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
 
@@ -12469,7 +12469,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<AudioCDTimeType>()
                            .AddAttribute(0, "track", a => a.Track, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            })
                            .AddAttribute(0, "time", a => a.Time);
         }
@@ -12689,11 +12689,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<SupplementalFont>()
 .AddAttribute(0, "script", a => a.Script, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "typeface", a => a.Typeface, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -13277,7 +13277,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<ColorScheme>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -13539,7 +13539,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<FontScheme>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -14770,11 +14770,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RatioType>()
                            .AddAttribute(0, "n", a => a.Numerator, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            })
                            .AddAttribute(0, "d", a => a.Denominator, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -14867,13 +14867,13 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Point2DType>()
                            .AddAttribute(0, "x", a => a.X, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
                            })
                            .AddAttribute(0, "y", a => a.Y, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
                            });
         }
     }
@@ -14966,13 +14966,13 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<PositiveSize2DType>()
                            .AddAttribute(0, "cx", a => a.Cx, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
                            })
                            .AddAttribute(0, "cy", a => a.Cy, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
                            });
         }
     }
@@ -15448,11 +15448,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ConnectionType>()
                            .AddAttribute(0, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            })
                            .AddAttribute(0, "idx", a => a.Index, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -16147,8 +16147,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<GraphicData>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -16204,11 +16204,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Diagram>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-   aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+   aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "bldStep", a => a.BuildStep, aBuilder =>
 {
-   aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+   aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -16269,8 +16269,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "categoryIdx", a => a.CategoryIndex)
 .AddAttribute(0, "bldStep", a => a.BuildStep, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
- aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+ aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -16321,8 +16321,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 {
 aBuilder.AddUnion(union =>
 {
-    union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.AnimationBuildValues>>(new EnumValidatorAttribute());
-    union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.AnimationDiagramOnlyBuildValues>>(new EnumValidatorAttribute());
+    union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.AnimationBuildValues>>(new EnumValidator());
+    union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.AnimationDiagramOnlyBuildValues>>(new EnumValidator());
 });
 })
 .AddAttribute(0, "rev", a => a.ReverseAnimation);
@@ -16375,8 +16375,8 @@ aBuilder.AddUnion(union =>
 {
 aBuilder.AddUnion(union =>
 {
-  union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.AnimationBuildValues>>(new EnumValidatorAttribute());
-  union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.AnimationChartOnlyBuildValues>>(new EnumValidatorAttribute());
+  union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.AnimationBuildValues>>(new EnumValidator());
+  union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.AnimationChartOnlyBuildValues>>(new EnumValidator());
 });
 })
 .AddAttribute(0, "animBg", a => a.AnimateBackground);
@@ -16735,11 +16735,11 @@ aBuilder.AddUnion(union =>
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)
@@ -17082,7 +17082,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ShapeProperties>()
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -18084,18 +18084,18 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Rotation>()
 .AddAttribute(0, "lat", a => a.Latitude, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (21600000L), MinInclusive = (0L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 })
 .AddAttribute(0, "lon", a => a.Longitude, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (21600000L), MinInclusive = (0L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 })
 .AddAttribute(0, "rev", a => a.Revolution, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (21600000L), MinInclusive = (0L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 });
         }
 
@@ -18185,16 +18185,16 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Camera>()
 .AddAttribute(0, "prst", a => a.Preset, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "fov", a => a.FieldOfView, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (10800000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (10800000L) });
 })
 .AddAttribute(0, "zoom", a => a.Zoom, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 });
         }
 
@@ -18294,13 +18294,13 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
             builder.AddElement<LightRig>()
 .AddAttribute(0, "rig", a => a.Rig, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "dir", a => a.Direction, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -18502,18 +18502,18 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Anchor>()
 .AddAttribute(0, "x", a => a.X, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "y", a => a.Y, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "z", a => a.Z, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 });
         }
 
@@ -18619,18 +18619,18 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042
             builder.AddElement<Vector3DType>()
                            .AddAttribute(0, "dx", a => a.Dx, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
                            })
                            .AddAttribute(0, "dy", a => a.Dy, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
                            })
                            .AddAttribute(0, "dz", a => a.Dz, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
                            });
         }
     }
@@ -18757,15 +18757,15 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042
             builder.AddElement<BevelType>()
                            .AddAttribute(0, "w", a => a.Width, aBuilder =>
                            {
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
                            })
                            .AddAttribute(0, "h", a => a.Height, aBuilder =>
                            {
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
                            })
                            .AddAttribute(0, "prst", a => a.Preset, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+                               aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                            });
         }
     }
@@ -19003,8 +19003,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042
             builder.AddElement<GradientStop>()
 .AddAttribute(0, "pos", a => a.Position, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 });
         }
 
@@ -19211,12 +19211,12 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<ShapeGuide>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidatorAttribute());
-    aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+    aBuilder.AddValidator(new RequiredValidator());
+    aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "fmla", a => a.Formula, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidatorAttribute());
+    aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -19312,20 +19312,20 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<AdjustPoint2DType>()
                            .AddAttribute(0, "x", a => a.X, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                                aBuilder.AddUnion(union =>
                                {
-                                   union.AddValidator<Int64Value>(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-                                   union.AddValidator(new StringValidatorAttribute());
+                                   union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+                                   union.AddValidator(new StringValidator());
                                });
                            })
                            .AddAttribute(0, "y", a => a.Y, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                                aBuilder.AddUnion(union =>
                                {
-                                   union.AddValidator<Int64Value>(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-                                   union.AddValidator(new StringValidatorAttribute());
+                                   union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+                                   union.AddValidator(new StringValidator());
                                });
                            });
         }
@@ -19443,42 +19443,42 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<AdjustHandleXY>()
 .AddAttribute(0, "gdRefX", a => a.XAdjustmentGuide, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "minX", a => a.MinX, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int64Value>(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+union.AddValidator(new StringValidator());
 });
 })
 .AddAttribute(0, "maxX", a => a.MaxX, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int64Value>(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+union.AddValidator(new StringValidator());
 });
 })
 .AddAttribute(0, "gdRefY", a => a.YAdjustmentGuide, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "minY", a => a.MinY, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int64Value>(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+union.AddValidator(new StringValidator());
 });
 })
 .AddAttribute(0, "maxY", a => a.MaxY, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int64Value>(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+union.AddValidator(new StringValidator());
 });
 });
         }
@@ -19619,42 +19619,42 @@ union.AddValidator(new StringValidatorAttribute());
             builder.AddElement<AdjustHandlePolar>()
 .AddAttribute(0, "gdRefR", a => a.RadialAdjustmentGuide, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "minR", a => a.MinRadial, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int64Value>(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+union.AddValidator(new StringValidator());
 });
 })
 .AddAttribute(0, "maxR", a => a.MaxRadial, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int64Value>(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+union.AddValidator(new StringValidator());
 });
 })
 .AddAttribute(0, "gdRefAng", a => a.AngleAdjustmentGuide, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "minAng", a => a.MinAngle, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator(new StringValidator());
 });
 })
 .AddAttribute(0, "maxAng", a => a.MaxAngle, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator(new StringValidator());
 });
 });
         }
@@ -19745,11 +19745,11 @@ union.AddValidator(new StringValidatorAttribute());
             builder.AddElement<ConnectionSite>()
 .AddAttribute(0, "ang", a => a.Angle, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<Int32Value>(new NumberValidator());
+union.AddValidator(new StringValidator());
 });
 });
         }
@@ -20013,38 +20013,38 @@ union.AddValidator(new StringValidatorAttribute());
             builder.AddElement<ArcTo>()
 .AddAttribute(0, "wR", a => a.WidthRadius, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
+ aBuilder.AddValidator(new RequiredValidator());
  aBuilder.AddUnion(union =>
  {
-     union.AddValidator<Int64Value>(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-     union.AddValidator(new StringValidatorAttribute());
+     union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+     union.AddValidator(new StringValidator());
  });
 })
 .AddAttribute(0, "hR", a => a.HeightRadius, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
+ aBuilder.AddValidator(new RequiredValidator());
  aBuilder.AddUnion(union =>
  {
-     union.AddValidator<Int64Value>(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-     union.AddValidator(new StringValidatorAttribute());
+     union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+     union.AddValidator(new StringValidator());
  });
 })
 .AddAttribute(0, "stAng", a => a.StartAngle, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
+ aBuilder.AddValidator(new RequiredValidator());
  aBuilder.AddUnion(union =>
  {
-     union.AddValidator<Int32Value>(new NumberValidatorAttribute());
-     union.AddValidator(new StringValidatorAttribute());
+     union.AddValidator<Int32Value>(new NumberValidator());
+     union.AddValidator(new StringValidator());
  });
 })
 .AddAttribute(0, "swAng", a => a.SwingAngle, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
+ aBuilder.AddValidator(new RequiredValidator());
  aBuilder.AddUnion(union =>
  {
-     union.AddValidator<Int32Value>(new NumberValidatorAttribute());
-     union.AddValidator(new StringValidatorAttribute());
+     union.AddValidator<Int32Value>(new NumberValidator());
+     union.AddValidator(new StringValidator());
  });
 });
         }
@@ -20289,15 +20289,15 @@ union.AddValidator(new StringValidatorAttribute());
             builder.AddElement<Path>()
 .AddAttribute(0, "w", a => a.Width, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(0, "h", a => a.Height, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(0, "fill", a => a.Fill, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "stroke", a => a.Stroke)
 .AddAttribute(0, "extrusionOk", a => a.ExtrusionOk);
@@ -20680,38 +20680,38 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Rectangle>()
 .AddAttribute(0, "l", a => a.Left, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
   aBuilder.AddUnion(union =>
   {
-      union.AddValidator<Int64Value>(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-      union.AddValidator(new StringValidatorAttribute());
+      union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+      union.AddValidator(new StringValidator());
   });
 })
 .AddAttribute(0, "t", a => a.Top, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
   aBuilder.AddUnion(union =>
   {
-      union.AddValidator<Int64Value>(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-      union.AddValidator(new StringValidatorAttribute());
+      union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+      union.AddValidator(new StringValidator());
   });
 })
 .AddAttribute(0, "r", a => a.Right, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
   aBuilder.AddUnion(union =>
   {
-      union.AddValidator<Int64Value>(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-      union.AddValidator(new StringValidatorAttribute());
+      union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+      union.AddValidator(new StringValidator());
   });
 })
 .AddAttribute(0, "b", a => a.Bottom, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
   aBuilder.AddUnion(union =>
   {
-      union.AddValidator<Int64Value>(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-      union.AddValidator(new StringValidatorAttribute());
+      union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+      union.AddValidator(new StringValidator());
   });
 });
         }
@@ -20823,13 +20823,13 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<DashStop>()
 .AddAttribute(0, "d", a => a.DashLength, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidatorAttribute());
-    aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+    aBuilder.AddValidator(new RequiredValidator());
+    aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 })
 .AddAttribute(0, "sp", a => a.SpaceLength, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidatorAttribute());
-    aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+    aBuilder.AddValidator(new RequiredValidator());
+    aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 });
         }
 
@@ -20942,15 +20942,15 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<LineEndPropertiesType>()
                            .AddAttribute(0, "type", a => a.Type, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+                               aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                            })
                            .AddAttribute(0, "w", a => a.Width, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+                               aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                            })
                            .AddAttribute(0, "len", a => a.Length, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+                               aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                            });
         }
     }
@@ -21370,19 +21370,19 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "spcFirstLastPara", a => a.UseParagraphSpacing)
 .AddAttribute(0, "vertOverflow", a => a.VerticalOverflow, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "horzOverflow", a => a.HorizontalOverflow, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "vert", a => a.Vertical, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "wrap", a => a.Wrap, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "lIns", a => a.LeftInset)
 .AddAttribute(0, "tIns", a => a.TopInset)
@@ -21390,17 +21390,17 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "bIns", a => a.BottomInset)
 .AddAttribute(0, "numCol", a => a.ColumnCount, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (16L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (16L) });
 })
 .AddAttribute(0, "spcCol", a => a.ColumnSpacing, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 })
 .AddAttribute(0, "rtlCol", a => a.RightToLeftColumns)
 .AddAttribute(0, "fromWordArt", a => a.FromWordArt)
 .AddAttribute(0, "anchor", a => a.Anchor, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "anchorCtr", a => a.AnchorCenter)
 .AddAttribute(0, "forceAA", a => a.ForceAntiAlias)
@@ -22310,63 +22310,63 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<ColorMappingType>()
 .AddAttribute(0, "bg1", a => a.Background1, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "tx1", a => a.Text1, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "bg2", a => a.Background2, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "tx2", a => a.Text2, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent1", a => a.Accent1, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent2", a => a.Accent2, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent3", a => a.Accent3, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent4", a => a.Accent4, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent5", a => a.Accent5, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent6", a => a.Accent6, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "hlink", a => a.Hyperlink, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "folHlink", a => a.FollowedHyperlink, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -22664,7 +22664,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Cell3DProperties>()
 .AddAttribute(0, "prstMaterial", a => a.PresetMaterial, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -22882,16 +22882,16 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "marB", a => a.BottomMargin)
 .AddAttribute(0, "vert", a => a.Vertical, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "anchor", a => a.Anchor, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "anchorCtr", a => a.AnchorCenter)
 .AddAttribute(0, "horzOverflow", a => a.HorizontalOverflow, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -23464,12 +23464,12 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<TableStyleType>()
 .AddAttribute(0, "styleId", a => a.StyleId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "styleName", a => a.StyleName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -23699,7 +23699,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+            builder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
             builder.SetSchema(10, "tableStyleId");
         }
 
@@ -23769,8 +23769,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<GridColumn>()
 .AddAttribute(0, "w", a => a.Width, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 });
         }
 
@@ -24109,8 +24109,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042
             builder.AddElement<TableRow>()
 .AddAttribute(0, "h", a => a.Height, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 });
         }
 
@@ -25000,11 +25000,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042
             builder.AddElement<TableCellTextStyle>()
 .AddAttribute(0, "b", a => a.Bold, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "i", a => a.Italic, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -27590,30 +27590,30 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<TextParagraphPropertiesType>()
 .AddAttribute(0, "marL", a => a.LeftMargin, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (51206400L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (51206400L) });
 })
 .AddAttribute(0, "marR", a => a.RightMargin, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (51206400L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (51206400L) });
 })
 .AddAttribute(0, "lvl", a => a.Level, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (8L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (8L) });
 })
 .AddAttribute(0, "indent", a => a.Indent, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-51206400L), MaxInclusive = (51206400L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-51206400L), MaxInclusive = (51206400L) });
 })
 .AddAttribute(0, "algn", a => a.Alignment, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "defTabSz", a => a.DefaultTabSize)
 .AddAttribute(0, "rtl", a => a.RightToLeft)
 .AddAttribute(0, "eaLnBrk", a => a.EastAsianLineBreak)
 .AddAttribute(0, "fontAlgn", a => a.FontAlignment, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "latinLnBrk", a => a.LatinLineBreak)
 .AddAttribute(0, "hangingPunct", a => a.Height);
@@ -28326,29 +28326,29 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "altLang", a => a.AlternativeLanguage)
 .AddAttribute(0, "sz", a => a.FontSize, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (100L), MaxInclusive = (400000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (100L), MaxInclusive = (400000L) });
 })
 .AddAttribute(0, "b", a => a.Bold)
 .AddAttribute(0, "i", a => a.Italic)
 .AddAttribute(0, "u", a => a.Underline, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "strike", a => a.Strike, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "kern", a => a.Kerning, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (400000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (400000L) });
 })
 .AddAttribute(0, "cap", a => a.Capital, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "spc", a => a.Spacing, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-400000L), MaxInclusive = (400000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-400000L), MaxInclusive = (400000L) });
 })
 .AddAttribute(0, "normalizeH", a => a.NormalizeHeight)
 .AddAttribute(0, "baseline", a => a.Baseline)
@@ -28512,7 +28512,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-400000L)
 .AddAttribute(0, "pos", a => a.Position)
 .AddAttribute(0, "algn", a => a.Alignment, aBuilder =>
 {
-   aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+   aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -28551,8 +28551,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-400000L)
             builder.AddElement<SpacingPercent>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (13200000L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (13200000L) });
 });
         }
 
@@ -28591,8 +28591,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<SpacingPoints>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (158400L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (158400L) });
 });
         }
 
@@ -29039,8 +29039,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<ShapePropertiesExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -29123,8 +29123,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<GvmlGroupShapeExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -29375,7 +29375,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<VisualGroupShapeProperties>()
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -30191,8 +30191,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<NonVisualGroupDrawingShapePropsExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -30270,8 +30270,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<OfficeStyleSheetExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -30349,8 +30349,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<ConnectorLockingExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -30872,8 +30872,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<NonVisualDrawingPropertiesExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -31215,8 +31215,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<NonVisualPicturePropertiesExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -31577,8 +31577,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<BlipExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -32067,8 +32067,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<DataModelExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -32147,8 +32147,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<PtExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_main.g.cs
@@ -227,7 +227,7 @@ namespace DocumentFormat.OpenXml.Drawing
             builder.AddElement<EmbeddedWavAudioFileType>()
                            .AddAttribute(19, "embed", a => a.Embed, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            })
                            .AddAttribute(0, "name", a => a.Name)
                            .AddAttribute(0, "builtIn", a => a.BuiltIn);
@@ -299,7 +299,7 @@ namespace DocumentFormat.OpenXml.Drawing
             builder.AddElement<AudioFromFile>()
 .AddAttribute(19, "link", a => a.Link, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -392,7 +392,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<VideoFromFile>()
 .AddAttribute(19, "link", a => a.Link, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -485,7 +485,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<QuickTimeFromFile>()
 .AddAttribute(19, "link", a => a.Link, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -615,7 +615,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<PositiveFixedPercentageType>()
                            .AddAttribute(0, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
                            });
         }
@@ -724,7 +724,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<AlphaOffset>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
 });
         }
@@ -811,7 +811,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxIncl
             builder.AddElement<PositivePercentageType>()
                            .AddAttribute(0, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
                            });
         }
@@ -848,7 +848,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxIncl
             builder.AddElement<Hue>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 });
         }
@@ -888,7 +888,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxIncl
             builder.AddElement<HueOffset>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -1292,7 +1292,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<PercentageType>()
                            .AddAttribute(0, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -1551,15 +1551,15 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RgbColorModelPercentage>()
 .AddAttribute(0, "r", a => a.RedPortion, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "g", a => a.GreenPortion, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "b", a => a.BluePortion, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -1736,7 +1736,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RgbColorModelHex>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { Length = (3L) });
 })
 .AddAttribute(48, "legacySpreadsheetColorIndex", a => a.LegacySpreadsheetColorIndex, aBuilder =>
@@ -1926,16 +1926,16 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<HslColor>()
 .AddAttribute(0, "hue", a => a.HueValue, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 })
 .AddAttribute(0, "sat", a => a.SatValue, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "lum", a => a.LumValue, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -2109,7 +2109,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<SystemColor>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "lastClr", a => a.LastColor, aBuilder =>
@@ -2278,7 +2278,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (3L) });
             builder.AddElement<SchemeColor>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -2443,7 +2443,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<PresetColor>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -4054,7 +4054,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<AlphaBiLevel>()
 .AddAttribute(0, "thresh", a => a.Threshold, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 });
         }
@@ -4456,7 +4456,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L),
             builder.AddElement<AlphaReplace>()
 .AddAttribute(0, "a", a => a.Alpha, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 });
         }
@@ -4496,7 +4496,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<BiLevel>()
 .AddAttribute(0, "thresh", a => a.Threshold, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 });
         }
@@ -4567,7 +4567,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<Blend>()
 .AddAttribute(0, "blend", a => a.BlendMode, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -5226,7 +5226,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<FillOverlay>()
 .AddAttribute(0, "blend", a => a.Blend, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -6226,7 +6226,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<PresetShadow>()
 .AddAttribute(0, "prst", a => a.Preset, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "dist", a => a.Distance, aBuilder =>
@@ -6629,7 +6629,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<SoftEdge>()
 .AddAttribute(0, "rad", a => a.Radius, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 });
         }
@@ -7198,7 +7198,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<PresetGeometry>()
 .AddAttribute(0, "prst", a => a.Preset, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -7289,7 +7289,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<PresetTextWrap>()
 .AddAttribute(0, "prst", a => a.Preset, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -7969,7 +7969,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<StyleMatrixReferenceType>()
 .AddAttribute(0, "idx", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -8526,7 +8526,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<FontReference>()
 .AddAttribute(0, "idx", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -9566,7 +9566,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<BulletSizePercentage>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (25000L), MaxInclusive = (400000L) });
 });
         }
@@ -9606,7 +9606,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (25000L), MaxInclus
             builder.AddElement<BulletSizePoints>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (100L), MaxInclusive = (400000L) });
 });
         }
@@ -9892,7 +9892,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (100L), MaxInclusiv
             builder.AddElement<AutoNumberedBullet>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "startAt", a => a.StartAt, aBuilder =>
@@ -9936,7 +9936,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive 
             builder.AddElement<CharacterBullet>()
 .AddAttribute(0, "char", a => a.Char, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -11405,7 +11405,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<Field>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "type", a => a.Type);
@@ -12266,7 +12266,7 @@ aBuilder.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F
             builder.AddElement<TableStyleList>()
 .AddAttribute(0, "def", a => a.Default, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
@@ -12469,7 +12469,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<AudioCDTimeType>()
                            .AddAttribute(0, "track", a => a.Track, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            })
                            .AddAttribute(0, "time", a => a.Time);
         }
@@ -12689,11 +12689,11 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<SupplementalFont>()
 .AddAttribute(0, "script", a => a.Script, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "typeface", a => a.Typeface, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -13277,7 +13277,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<ColorScheme>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -13539,7 +13539,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<FontScheme>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -14770,11 +14770,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RatioType>()
                            .AddAttribute(0, "n", a => a.Numerator, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            })
                            .AddAttribute(0, "d", a => a.Denominator, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -14867,12 +14867,12 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Point2DType>()
                            .AddAttribute(0, "x", a => a.X, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
                            })
                            .AddAttribute(0, "y", a => a.Y, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
                            });
         }
@@ -14966,12 +14966,12 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<PositiveSize2DType>()
                            .AddAttribute(0, "cx", a => a.Cx, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
                            })
                            .AddAttribute(0, "cy", a => a.Cy, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
                            });
         }
@@ -15448,11 +15448,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ConnectionType>()
                            .AddAttribute(0, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            })
                            .AddAttribute(0, "idx", a => a.Index, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -16147,7 +16147,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<GraphicData>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -16269,7 +16269,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 .AddAttribute(0, "categoryIdx", a => a.CategoryIndex)
 .AddAttribute(0, "bldStep", a => a.BuildStep, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
  aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -16321,8 +16321,8 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 {
 aBuilder.AddUnion(union =>
 {
-    union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.AnimationBuildValues>>(new EnumValidator());
-    union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.AnimationDiagramOnlyBuildValues>>(new EnumValidator());
+    union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.AnimationBuildValues>>(EnumValidator.Instance);
+    union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.AnimationDiagramOnlyBuildValues>>(EnumValidator.Instance);
 });
 })
 .AddAttribute(0, "rev", a => a.ReverseAnimation);
@@ -16375,8 +16375,8 @@ aBuilder.AddUnion(union =>
 {
 aBuilder.AddUnion(union =>
 {
-  union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.AnimationBuildValues>>(new EnumValidator());
-  union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.AnimationChartOnlyBuildValues>>(new EnumValidator());
+  union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.AnimationBuildValues>>(EnumValidator.Instance);
+  union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.AnimationChartOnlyBuildValues>>(EnumValidator.Instance);
 });
 })
 .AddAttribute(0, "animBg", a => a.AnimateBackground);
@@ -16735,11 +16735,11 @@ aBuilder.AddUnion(union =>
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)
@@ -18084,17 +18084,17 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<Rotation>()
 .AddAttribute(0, "lat", a => a.Latitude, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 })
 .AddAttribute(0, "lon", a => a.Longitude, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 })
 .AddAttribute(0, "rev", a => a.Revolution, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInclusive = (0L) });
 });
         }
@@ -18185,7 +18185,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<Camera>()
 .AddAttribute(0, "prst", a => a.Preset, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "fov", a => a.FieldOfView, aBuilder =>
@@ -18294,12 +18294,12 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
             builder.AddElement<LightRig>()
 .AddAttribute(0, "rig", a => a.Rig, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "dir", a => a.Direction, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -18502,17 +18502,17 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<Anchor>()
 .AddAttribute(0, "x", a => a.X, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "y", a => a.Y, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "z", a => a.Z, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 });
         }
@@ -18619,17 +18619,17 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L),
             builder.AddElement<Vector3DType>()
                            .AddAttribute(0, "dx", a => a.Dx, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
                            })
                            .AddAttribute(0, "dy", a => a.Dy, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
                            })
                            .AddAttribute(0, "dz", a => a.Dz, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
                            });
         }
@@ -19003,7 +19003,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L),
             builder.AddElement<GradientStop>()
 .AddAttribute(0, "pos", a => a.Position, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 });
         }
@@ -19211,12 +19211,12 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<ShapeGuide>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidator());
+    aBuilder.AddValidator(RequiredValidator.Instance);
     aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "fmla", a => a.Formula, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidator());
+    aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -19312,20 +19312,20 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<AdjustPoint2DType>()
                            .AddAttribute(0, "x", a => a.X, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddUnion(union =>
                                {
                                    union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-                                   union.AddValidator(new StringValidator());
+                                   union.AddValidator(StringValidator.Instance);
                                });
                            })
                            .AddAttribute(0, "y", a => a.Y, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddUnion(union =>
                                {
                                    union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-                                   union.AddValidator(new StringValidator());
+                                   union.AddValidator(StringValidator.Instance);
                                });
                            });
         }
@@ -19450,7 +19450,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-union.AddValidator(new StringValidator());
+union.AddValidator(StringValidator.Instance);
 });
 })
 .AddAttribute(0, "maxX", a => a.MaxX, aBuilder =>
@@ -19458,7 +19458,7 @@ union.AddValidator(new StringValidator());
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-union.AddValidator(new StringValidator());
+union.AddValidator(StringValidator.Instance);
 });
 })
 .AddAttribute(0, "gdRefY", a => a.YAdjustmentGuide, aBuilder =>
@@ -19470,7 +19470,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-union.AddValidator(new StringValidator());
+union.AddValidator(StringValidator.Instance);
 });
 })
 .AddAttribute(0, "maxY", a => a.MaxY, aBuilder =>
@@ -19478,7 +19478,7 @@ union.AddValidator(new StringValidator());
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-union.AddValidator(new StringValidator());
+union.AddValidator(StringValidator.Instance);
 });
 });
         }
@@ -19626,7 +19626,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-union.AddValidator(new StringValidator());
+union.AddValidator(StringValidator.Instance);
 });
 })
 .AddAttribute(0, "maxR", a => a.MaxRadial, aBuilder =>
@@ -19634,7 +19634,7 @@ union.AddValidator(new StringValidator());
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-union.AddValidator(new StringValidator());
+union.AddValidator(StringValidator.Instance);
 });
 })
 .AddAttribute(0, "gdRefAng", a => a.AngleAdjustmentGuide, aBuilder =>
@@ -19645,16 +19645,16 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidator());
-union.AddValidator(new StringValidator());
+union.AddValidator<Int32Value>(NumberValidator.Instance);
+union.AddValidator(StringValidator.Instance);
 });
 })
 .AddAttribute(0, "maxAng", a => a.MaxAngle, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidator());
-union.AddValidator(new StringValidator());
+union.AddValidator<Int32Value>(NumberValidator.Instance);
+union.AddValidator(StringValidator.Instance);
 });
 });
         }
@@ -19745,11 +19745,11 @@ union.AddValidator(new StringValidator());
             builder.AddElement<ConnectionSite>()
 .AddAttribute(0, "ang", a => a.Angle, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidator());
-union.AddValidator(new StringValidator());
+union.AddValidator<Int32Value>(NumberValidator.Instance);
+union.AddValidator(StringValidator.Instance);
 });
 });
         }
@@ -20013,38 +20013,38 @@ union.AddValidator(new StringValidator());
             builder.AddElement<ArcTo>()
 .AddAttribute(0, "wR", a => a.WidthRadius, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
  aBuilder.AddUnion(union =>
  {
      union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-     union.AddValidator(new StringValidator());
+     union.AddValidator(StringValidator.Instance);
  });
 })
 .AddAttribute(0, "hR", a => a.HeightRadius, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
  aBuilder.AddUnion(union =>
  {
      union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-     union.AddValidator(new StringValidator());
+     union.AddValidator(StringValidator.Instance);
  });
 })
 .AddAttribute(0, "stAng", a => a.StartAngle, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
  aBuilder.AddUnion(union =>
  {
-     union.AddValidator<Int32Value>(new NumberValidator());
-     union.AddValidator(new StringValidator());
+     union.AddValidator<Int32Value>(NumberValidator.Instance);
+     union.AddValidator(StringValidator.Instance);
  });
 })
 .AddAttribute(0, "swAng", a => a.SwingAngle, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
  aBuilder.AddUnion(union =>
  {
-     union.AddValidator<Int32Value>(new NumberValidator());
-     union.AddValidator(new StringValidator());
+     union.AddValidator<Int32Value>(NumberValidator.Instance);
+     union.AddValidator(StringValidator.Instance);
  });
 });
         }
@@ -20680,38 +20680,38 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<Rectangle>()
 .AddAttribute(0, "l", a => a.Left, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
   aBuilder.AddUnion(union =>
   {
       union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-      union.AddValidator(new StringValidator());
+      union.AddValidator(StringValidator.Instance);
   });
 })
 .AddAttribute(0, "t", a => a.Top, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
   aBuilder.AddUnion(union =>
   {
       union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-      union.AddValidator(new StringValidator());
+      union.AddValidator(StringValidator.Instance);
   });
 })
 .AddAttribute(0, "r", a => a.Right, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
   aBuilder.AddUnion(union =>
   {
       union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-      union.AddValidator(new StringValidator());
+      union.AddValidator(StringValidator.Instance);
   });
 })
 .AddAttribute(0, "b", a => a.Bottom, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
   aBuilder.AddUnion(union =>
   {
       union.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
-      union.AddValidator(new StringValidator());
+      union.AddValidator(StringValidator.Instance);
   });
 });
         }
@@ -20823,12 +20823,12 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<DashStop>()
 .AddAttribute(0, "d", a => a.DashLength, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidator());
+    aBuilder.AddValidator(RequiredValidator.Instance);
     aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 })
 .AddAttribute(0, "sp", a => a.SpaceLength, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidator());
+    aBuilder.AddValidator(RequiredValidator.Instance);
     aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 });
         }
@@ -22310,62 +22310,62 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<ColorMappingType>()
 .AddAttribute(0, "bg1", a => a.Background1, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "tx1", a => a.Text1, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "bg2", a => a.Background2, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "tx2", a => a.Text2, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent1", a => a.Accent1, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent2", a => a.Accent2, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent3", a => a.Accent3, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent4", a => a.Accent4, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent5", a => a.Accent5, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent6", a => a.Accent6, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "hlink", a => a.Hyperlink, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "folHlink", a => a.FollowedHyperlink, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -23464,12 +23464,12 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<TableStyleType>()
 .AddAttribute(0, "styleId", a => a.StyleId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "styleName", a => a.StyleName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -23769,7 +23769,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<GridColumn>()
 .AddAttribute(0, "w", a => a.Width, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 });
         }
@@ -24109,7 +24109,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L),
             builder.AddElement<TableRow>()
 .AddAttribute(0, "h", a => a.Height, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 });
         }
@@ -28551,7 +28551,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-400000L), MaxIncl
             builder.AddElement<SpacingPercent>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (13200000L) });
 });
         }
@@ -28591,7 +28591,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<SpacingPoints>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (158400L) });
 });
         }
@@ -29039,7 +29039,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<ShapePropertiesExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -29123,7 +29123,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<GvmlGroupShapeExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -30191,7 +30191,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<NonVisualGroupDrawingShapePropsExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -30270,7 +30270,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<OfficeStyleSheetExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -30349,7 +30349,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<ConnectorLockingExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -30872,7 +30872,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<NonVisualDrawingPropertiesExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -31215,7 +31215,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<NonVisualPicturePropertiesExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -31577,7 +31577,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<BlipExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -32067,7 +32067,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<DataModelExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -32147,7 +32147,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<PtExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_picture.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_picture.g.cs
@@ -260,11 +260,11 @@ namespace DocumentFormat.OpenXml.Drawing.Pictures
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_picture.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_picture.g.cs
@@ -260,11 +260,11 @@ namespace DocumentFormat.OpenXml.Drawing.Pictures
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)
@@ -739,7 +739,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ShapeProperties>()
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_spreadsheetDrawing.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_spreadsheetDrawing.g.cs
@@ -1179,7 +1179,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<ContentPart>()
 .AddAttribute(19, "id", a => a.RelationshipId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
@@ -2812,12 +2812,12 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<Extent>()
 .AddAttribute(0, "cx", a => a.Cx, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(0, "cy", a => a.Cy, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 });
         }
@@ -2867,12 +2867,12 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<Position>()
 .AddAttribute(0, "x", a => a.X, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "y", a => a.Y, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 });
         }
@@ -2987,11 +2987,11 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_spreadsheetDrawing.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_spreadsheetDrawing.g.cs
@@ -93,7 +93,7 @@ namespace DocumentFormat.OpenXml.Drawing.Spreadsheet
             builder.AddElement<TwoCellAnchor>()
 .AddAttribute(0, "editAs", a => a.EditAs, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -1179,11 +1179,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<ContentPart>()
 .AddAttribute(19, "id", a => a.RelationshipId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -1539,7 +1539,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<ShapeProperties>()
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -2359,7 +2359,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
+            builder.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
             builder.SetSchema(18, "col");
         }
 
@@ -2397,7 +2397,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int64Value>(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+            builder.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
             builder.SetSchema(18, "colOff");
         }
 
@@ -2435,7 +2435,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int64Value>(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+            builder.AddValidator<Int64Value>(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
             builder.SetSchema(18, "rowOff");
         }
 
@@ -2473,7 +2473,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
+            builder.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
             builder.SetSchema(18, "row");
         }
 
@@ -2812,13 +2812,13 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Extent>()
 .AddAttribute(0, "cx", a => a.Cx, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(0, "cy", a => a.Cy, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 });
         }
 
@@ -2867,13 +2867,13 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Position>()
 .AddAttribute(0, "x", a => a.X, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "y", a => a.Y, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 });
         }
 
@@ -2987,11 +2987,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)
@@ -3740,7 +3740,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<GroupShapeProperties>()
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_wordprocessingDrawing.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_wordprocessingDrawing.g.cs
@@ -141,8 +141,8 @@ namespace DocumentFormat.OpenXml.Drawing.Wordprocessing
             builder.AddElement<WrapSquare>()
 .AddAttribute(0, "wrapText", a => a.WrapText, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "distT", a => a.DistanceFromTop)
 .AddAttribute(0, "distB", a => a.DistanceFromBottom)
@@ -256,8 +256,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<WrapTight>()
 .AddAttribute(0, "wrapText", a => a.WrapText, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "distL", a => a.DistanceFromLeft)
 .AddAttribute(0, "distR", a => a.DistanceFromRight);
@@ -369,8 +369,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<WrapThrough>()
 .AddAttribute(0, "wrapText", a => a.WrapText, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "distL", a => a.DistanceFromLeft)
 .AddAttribute(0, "distR", a => a.DistanceFromRight);
@@ -628,13 +628,13 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "distR", a => a.DistanceFromRight)
 .AddAttribute(51, "anchorId", a => a.AnchorId, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(51, "editId", a => a.EditId, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 });
         }
 
@@ -939,34 +939,34 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
 .AddAttribute(0, "simplePos", a => a.SimplePos)
 .AddAttribute(0, "relativeHeight", a => a.RelativeHeight, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "behindDoc", a => a.BehindDoc, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "locked", a => a.Locked, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "layoutInCell", a => a.LayoutInCell, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "hidden", a => a.Hidden)
 .AddAttribute(0, "allowOverlap", a => a.AllowOverlap, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(51, "editId", a => a.EditId, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(51, "anchorId", a => a.AnchorId, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 });
         }
 
@@ -1181,13 +1181,13 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
             builder.AddElement<Point2DType>()
                            .AddAttribute(0, "x", a => a.X, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
                            })
                            .AddAttribute(0, "y", a => a.Y, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
                            });
         }
     }
@@ -1253,23 +1253,23 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
             builder.AddElement<EffectExtent>()
 .AddAttribute(0, "l", a => a.LeftEdge, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "t", a => a.TopEdge, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "r", a => a.RightEdge, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "b", a => a.BottomEdge, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 });
         }
 
@@ -1433,8 +1433,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042
             builder.AddElement<HorizontalPosition>()
 .AddAttribute(0, "relativeFrom", a => a.RelativeFrom, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -1559,8 +1559,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<VerticalPosition>()
 .AddAttribute(0, "relativeFrom", a => a.RelativeFrom, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -1660,13 +1660,13 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Extent>()
 .AddAttribute(0, "cx", a => a.Cx, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(0, "cy", a => a.Cy, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 });
         }
 
@@ -1780,11 +1780,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<DocProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)
@@ -1970,8 +1970,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Wordprocessing.VerticalAlignmentValues>>(new EnumValidatorAttribute());
+            builder.AddValidator(new StringValidator() { IsToken = (true) });
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Wordprocessing.VerticalAlignmentValues>>(new EnumValidator());
             builder.SetSchema(16, "align");
         }
 
@@ -2009,7 +2009,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidatorAttribute());
+            builder.AddValidator<Int32Value>(new NumberValidator());
             builder.SetSchema(16, "posOffset");
         }
 
@@ -2047,8 +2047,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Wordprocessing.HorizontalAlignmentValues>>(new EnumValidatorAttribute());
+            builder.AddValidator(new StringValidator() { IsToken = (true) });
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Wordprocessing.HorizontalAlignmentValues>>(new EnumValidator());
             builder.SetSchema(16, "align");
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_wordprocessingDrawing.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_wordprocessingDrawing.g.cs
@@ -141,7 +141,7 @@ namespace DocumentFormat.OpenXml.Drawing.Wordprocessing
             builder.AddElement<WrapSquare>()
 .AddAttribute(0, "wrapText", a => a.WrapText, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "distT", a => a.DistanceFromTop)
@@ -256,7 +256,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<WrapTight>()
 .AddAttribute(0, "wrapText", a => a.WrapText, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "distL", a => a.DistanceFromLeft)
@@ -369,7 +369,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<WrapThrough>()
 .AddAttribute(0, "wrapText", a => a.WrapText, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "distL", a => a.DistanceFromLeft)
@@ -939,24 +939,24 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 .AddAttribute(0, "simplePos", a => a.SimplePos)
 .AddAttribute(0, "relativeHeight", a => a.RelativeHeight, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "behindDoc", a => a.BehindDoc, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "locked", a => a.Locked, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "layoutInCell", a => a.LayoutInCell, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "hidden", a => a.Hidden)
 .AddAttribute(0, "allowOverlap", a => a.AllowOverlap, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(51, "editId", a => a.EditId, aBuilder =>
 {
@@ -1181,12 +1181,12 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
             builder.AddElement<Point2DType>()
                            .AddAttribute(0, "x", a => a.X, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
                            })
                            .AddAttribute(0, "y", a => a.Y, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
                            });
         }
@@ -1253,22 +1253,22 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
             builder.AddElement<EffectExtent>()
 .AddAttribute(0, "l", a => a.LeftEdge, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "t", a => a.TopEdge, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "r", a => a.RightEdge, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 })
 .AddAttribute(0, "b", a => a.BottomEdge, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
 });
         }
@@ -1433,7 +1433,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L),
             builder.AddElement<HorizontalPosition>()
 .AddAttribute(0, "relativeFrom", a => a.RelativeFrom, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -1559,7 +1559,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<VerticalPosition>()
 .AddAttribute(0, "relativeFrom", a => a.RelativeFrom, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -1660,12 +1660,12 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<Extent>()
 .AddAttribute(0, "cx", a => a.Cx, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 })
 .AddAttribute(0, "cy", a => a.Cy, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
 });
         }
@@ -1780,11 +1780,11 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<DocProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)
@@ -1971,7 +1971,7 @@ aBuilder.AddValidator(new RequiredValidator());
         {
             base.ConfigureMetadata(builder);
             builder.AddValidator(new StringValidator() { IsToken = (true) });
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Wordprocessing.VerticalAlignmentValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Wordprocessing.VerticalAlignmentValues>>(EnumValidator.Instance);
             builder.SetSchema(16, "align");
         }
 
@@ -2009,7 +2009,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidator());
+            builder.AddValidator<Int32Value>(NumberValidator.Instance);
             builder.SetSchema(16, "posOffset");
         }
 
@@ -2048,7 +2048,7 @@ aBuilder.AddValidator(new RequiredValidator());
         {
             base.ConfigureMetadata(builder);
             builder.AddValidator(new StringValidator() { IsToken = (true) });
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Wordprocessing.HorizontalAlignmentValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Wordprocessing.HorizontalAlignmentValues>>(EnumValidator.Instance);
             builder.SetSchema(16, "align");
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_bibliography.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_bibliography.g.cs
@@ -3776,7 +3776,7 @@ aBuilder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Bibliography.DataSourceValues>>(new EnumValidator());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Bibliography.DataSourceValues>>(EnumValidator.Instance);
             builder.SetSchema(9, "SourceType");
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_bibliography.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_bibliography.g.cs
@@ -94,15 +94,15 @@ namespace DocumentFormat.OpenXml.Bibliography
             builder.AddElement<Sources>()
 .AddAttribute(0, "SelectedStyle", a => a.SelectedStyle, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
 })
 .AddAttribute(0, "StyleName", a => a.StyleName, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
 })
 .AddAttribute(0, "URI", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+aBuilder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
 });
         }
 
@@ -215,7 +215,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Last");
         }
 
@@ -253,7 +253,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "First");
         }
 
@@ -291,7 +291,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Middle");
         }
 
@@ -329,7 +329,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Corporate");
         }
 
@@ -367,7 +367,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "AbbreviatedCaseNumber");
         }
 
@@ -405,7 +405,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "AlbumTitle");
         }
 
@@ -443,7 +443,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "BookTitle");
         }
 
@@ -481,7 +481,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Broadcaster");
         }
 
@@ -519,7 +519,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "BroadcastTitle");
         }
 
@@ -557,7 +557,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "CaseNumber");
         }
 
@@ -595,7 +595,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "ChapterNumber");
         }
 
@@ -633,7 +633,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "City");
         }
 
@@ -671,7 +671,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Comments");
         }
 
@@ -709,7 +709,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "ConferenceName");
         }
 
@@ -747,7 +747,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "CountryRegion");
         }
 
@@ -785,7 +785,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Court");
         }
 
@@ -823,7 +823,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Day");
         }
 
@@ -861,7 +861,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "DayAccessed");
         }
 
@@ -899,7 +899,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Department");
         }
 
@@ -937,7 +937,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Distributor");
         }
 
@@ -975,7 +975,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Edition");
         }
 
@@ -1013,7 +1013,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Guid");
         }
 
@@ -1051,7 +1051,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Institution");
         }
 
@@ -1089,7 +1089,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "InternetSiteTitle");
         }
 
@@ -1127,7 +1127,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Issue");
         }
 
@@ -1165,7 +1165,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "JournalName");
         }
 
@@ -1203,7 +1203,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "LCID");
         }
 
@@ -1241,7 +1241,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Medium");
         }
 
@@ -1279,7 +1279,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Month");
         }
 
@@ -1317,7 +1317,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "MonthAccessed");
         }
 
@@ -1355,7 +1355,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "NumberVolumes");
         }
 
@@ -1393,7 +1393,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Pages");
         }
 
@@ -1431,7 +1431,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "PatentNumber");
         }
 
@@ -1469,7 +1469,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "PeriodicalTitle");
         }
 
@@ -1507,7 +1507,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "ProductionCompany");
         }
 
@@ -1545,7 +1545,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "PublicationTitle");
         }
 
@@ -1583,7 +1583,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Publisher");
         }
 
@@ -1621,7 +1621,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "RecordingNumber");
         }
 
@@ -1659,7 +1659,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "RefOrder");
         }
 
@@ -1697,7 +1697,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Reporter");
         }
 
@@ -1735,7 +1735,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "ShortTitle");
         }
 
@@ -1773,7 +1773,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "StandardNumber");
         }
 
@@ -1811,7 +1811,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "StateProvince");
         }
 
@@ -1849,7 +1849,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Station");
         }
 
@@ -1887,7 +1887,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Tag");
         }
 
@@ -1925,7 +1925,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Theater");
         }
 
@@ -1963,7 +1963,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "ThesisType");
         }
 
@@ -2001,7 +2001,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Title");
         }
 
@@ -2039,7 +2039,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Type");
         }
 
@@ -2077,7 +2077,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "URL");
         }
 
@@ -2115,7 +2115,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Version");
         }
 
@@ -2153,7 +2153,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Volume");
         }
 
@@ -2191,7 +2191,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "Year");
         }
 
@@ -2229,7 +2229,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (255L) });
+            builder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (255L) });
             builder.SetSchema(9, "YearAccessed");
         }
 
@@ -3776,7 +3776,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Bibliography.DataSourceValues>>(new EnumValidatorAttribute());
+            builder.AddValidator<EnumValue<DocumentFormat.OpenXml.Bibliography.DataSourceValues>>(new EnumValidator());
             builder.SetSchema(9, "SourceType");
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_characteristics.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_characteristics.g.cs
@@ -135,15 +135,15 @@ namespace DocumentFormat.OpenXml.AdditionalCharacteristics
             builder.AddElement<Characteristic>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "relation", a => a.Relation, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "vocabulary", a => a.Vocabulary, aBuilder =>
 {

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_characteristics.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_characteristics.g.cs
@@ -135,19 +135,19 @@ namespace DocumentFormat.OpenXml.AdditionalCharacteristics
             builder.AddElement<Characteristic>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "relation", a => a.Relation, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "vocabulary", a => a.Vocabulary, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_custom-properties.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_custom-properties.g.cs
@@ -265,12 +265,12 @@ namespace DocumentFormat.OpenXml.CustomProperties
             builder.AddElement<CustomDocumentProperty>()
 .AddAttribute(0, "fmtid", a => a.FormatId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { Pattern = ("\\s*\\{[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}\\}\\s*") });
 })
 .AddAttribute(0, "pid", a => a.PropertyId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name)
 .AddAttribute(0, "linkTarget", a => a.LinkTarget);

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_custom-properties.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_custom-properties.g.cs
@@ -265,12 +265,12 @@ namespace DocumentFormat.OpenXml.CustomProperties
             builder.AddElement<CustomDocumentProperty>()
 .AddAttribute(0, "fmtid", a => a.FormatId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("\\s*\\{[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}\\}\\s*") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { Pattern = ("\\s*\\{[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}\\}\\s*") });
 })
 .AddAttribute(0, "pid", a => a.PropertyId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name)
 .AddAttribute(0, "linkTarget", a => a.LinkTarget);

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_customXml.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_customXml.g.cs
@@ -77,8 +77,8 @@ namespace DocumentFormat.OpenXml.CustomXmlDataProperties
             builder.AddElement<DataStoreItem>()
 .AddAttribute(20, "itemID", a => a.ItemId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
 
@@ -171,7 +171,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<SchemaReference>()
 .AddAttribute(20, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_customXml.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_customXml.g.cs
@@ -77,7 +77,7 @@ namespace DocumentFormat.OpenXml.CustomXmlDataProperties
             builder.AddElement<DataStoreItem>()
 .AddAttribute(20, "itemID", a => a.ItemId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
@@ -171,7 +171,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<SchemaReference>()
 .AddAttribute(20, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_docPropsVTypes.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_docPropsVTypes.g.cs
@@ -744,11 +744,11 @@ namespace DocumentFormat.OpenXml.VariantTypes
             builder.AddElement<VTVector>()
 .AddAttribute(0, "baseType", a => a.BaseType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "size", a => a.Size, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -897,15 +897,15 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<VTArray>()
 .AddAttribute(0, "lBound", a => a.LowerBounds, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uBound", a => a.UpperBounds, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "baseType", a => a.BaseType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -966,7 +966,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Base64BinaryValue>(new NumberValidatorAttribute());
+            builder.AddValidator<Base64BinaryValue>(new NumberValidator());
             builder.SetSchema(5, "blob");
         }
 
@@ -1004,7 +1004,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Base64BinaryValue>(new NumberValidatorAttribute());
+            builder.AddValidator<Base64BinaryValue>(new NumberValidator());
             builder.SetSchema(5, "oblob");
         }
 
@@ -1042,7 +1042,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Base64BinaryValue>(new NumberValidatorAttribute());
+            builder.AddValidator<Base64BinaryValue>(new NumberValidator());
             builder.SetSchema(5, "stream");
         }
 
@@ -1080,7 +1080,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Base64BinaryValue>(new NumberValidatorAttribute());
+            builder.AddValidator<Base64BinaryValue>(new NumberValidator());
             builder.SetSchema(5, "ostream");
         }
 
@@ -1118,7 +1118,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Base64BinaryValue>(new NumberValidatorAttribute());
+            builder.AddValidator<Base64BinaryValue>(new NumberValidator());
             builder.SetSchema(5, "storage");
         }
 
@@ -1156,7 +1156,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Base64BinaryValue>(new NumberValidatorAttribute());
+            builder.AddValidator<Base64BinaryValue>(new NumberValidator());
             builder.SetSchema(5, "ostorage");
         }
 
@@ -1242,7 +1242,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<SByteValue>(new NumberValidatorAttribute());
+            builder.AddValidator<SByteValue>(new NumberValidator());
             builder.SetSchema(5, "i1");
         }
 
@@ -1280,7 +1280,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int16Value>(new NumberValidatorAttribute());
+            builder.AddValidator<Int16Value>(new NumberValidator());
             builder.SetSchema(5, "i2");
         }
 
@@ -1318,7 +1318,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidatorAttribute());
+            builder.AddValidator<Int32Value>(new NumberValidator());
             builder.SetSchema(5, "i4");
         }
 
@@ -1356,7 +1356,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidatorAttribute());
+            builder.AddValidator<Int32Value>(new NumberValidator());
             builder.SetSchema(5, "int");
         }
 
@@ -1394,7 +1394,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int64Value>(new NumberValidatorAttribute());
+            builder.AddValidator<Int64Value>(new NumberValidator());
             builder.SetSchema(5, "i8");
         }
 
@@ -1432,7 +1432,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<ByteValue>(new NumberValidatorAttribute());
+            builder.AddValidator<ByteValue>(new NumberValidator());
             builder.SetSchema(5, "ui1");
         }
 
@@ -1470,7 +1470,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<UInt16Value>(new NumberValidatorAttribute());
+            builder.AddValidator<UInt16Value>(new NumberValidator());
             builder.SetSchema(5, "ui2");
         }
 
@@ -1508,7 +1508,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<UInt32Value>(new NumberValidatorAttribute());
+            builder.AddValidator<UInt32Value>(new NumberValidator());
             builder.SetSchema(5, "ui4");
         }
 
@@ -1546,7 +1546,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<UInt32Value>(new NumberValidatorAttribute());
+            builder.AddValidator<UInt32Value>(new NumberValidator());
             builder.SetSchema(5, "uint");
         }
 
@@ -1584,7 +1584,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<UInt64Value>(new NumberValidatorAttribute());
+            builder.AddValidator<UInt64Value>(new NumberValidator());
             builder.SetSchema(5, "ui8");
         }
 
@@ -1622,7 +1622,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<SingleValue>(new NumberValidatorAttribute());
+            builder.AddValidator<SingleValue>(new NumberValidator());
             builder.SetSchema(5, "r4");
         }
 
@@ -1660,7 +1660,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<DoubleValue>(new NumberValidatorAttribute());
+            builder.AddValidator<DoubleValue>(new NumberValidator());
             builder.SetSchema(5, "r8");
         }
 
@@ -1698,7 +1698,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<DecimalValue>(new NumberValidatorAttribute());
+            builder.AddValidator<DecimalValue>(new NumberValidator());
             builder.SetSchema(5, "decimal");
         }
 
@@ -1847,7 +1847,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<DateTimeValue>(new NumberValidatorAttribute());
+            builder.AddValidator<DateTimeValue>(new NumberValidator());
             builder.SetSchema(5, "date");
         }
 
@@ -1885,7 +1885,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<DateTimeValue>(new NumberValidatorAttribute());
+            builder.AddValidator<DateTimeValue>(new NumberValidator());
             builder.SetSchema(5, "filetime");
         }
 
@@ -1923,7 +1923,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<BooleanValue>(new NumberValidatorAttribute());
+            builder.AddValidator<BooleanValue>(new NumberValidator());
             builder.SetSchema(5, "bool");
         }
 
@@ -1961,7 +1961,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { Pattern = ("\\s*[0-9]*\\.[0-9]{4}\\s*") });
+            builder.AddValidator(new StringValidator() { Pattern = ("\\s*[0-9]*\\.[0-9]{4}\\s*") });
             builder.SetSchema(5, "cy");
         }
 
@@ -1999,7 +1999,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { Pattern = ("0x[0-9A-Fa-f]{8}") });
+            builder.AddValidator(new StringValidator() { Pattern = ("0x[0-9A-Fa-f]{8}") });
             builder.SetSchema(5, "error");
         }
 
@@ -2051,8 +2051,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<VTVStreamData>()
 .AddAttribute(0, "version", a => a.Version, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("\\s*\\{[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}\\}\\s*") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { Pattern = ("\\s*\\{[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}\\}\\s*") });
 });
         }
 
@@ -2096,7 +2096,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("\\s*\\{[a-fA-
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator(new StringValidatorAttribute() { Pattern = ("\\s*\\{[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}\\}\\s*") });
+            builder.AddValidator(new StringValidator() { Pattern = ("\\s*\\{[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}\\}\\s*") });
             builder.SetSchema(5, "clsid");
         }
 
@@ -2158,11 +2158,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("\\s*\\{[a-fA-
             builder.AddElement<VTClipboardData>()
  .AddAttribute(0, "format", a => a.Format, aBuilder =>
  {
-     aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-3L) });
+     aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-3L) });
  })
  .AddAttribute(0, "size", a => a.Size, aBuilder =>
  {
-     aBuilder.AddValidator(new RequiredValidatorAttribute());
+     aBuilder.AddValidator(new RequiredValidator());
  });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_docPropsVTypes.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_docPropsVTypes.g.cs
@@ -744,11 +744,11 @@ namespace DocumentFormat.OpenXml.VariantTypes
             builder.AddElement<VTVector>()
 .AddAttribute(0, "baseType", a => a.BaseType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "size", a => a.Size, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -897,15 +897,15 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<VTArray>()
 .AddAttribute(0, "lBound", a => a.LowerBounds, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uBound", a => a.UpperBounds, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "baseType", a => a.BaseType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -966,7 +966,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Base64BinaryValue>(new NumberValidator());
+            builder.AddValidator<Base64BinaryValue>(NumberValidator.Instance);
             builder.SetSchema(5, "blob");
         }
 
@@ -1004,7 +1004,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Base64BinaryValue>(new NumberValidator());
+            builder.AddValidator<Base64BinaryValue>(NumberValidator.Instance);
             builder.SetSchema(5, "oblob");
         }
 
@@ -1042,7 +1042,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Base64BinaryValue>(new NumberValidator());
+            builder.AddValidator<Base64BinaryValue>(NumberValidator.Instance);
             builder.SetSchema(5, "stream");
         }
 
@@ -1080,7 +1080,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Base64BinaryValue>(new NumberValidator());
+            builder.AddValidator<Base64BinaryValue>(NumberValidator.Instance);
             builder.SetSchema(5, "ostream");
         }
 
@@ -1118,7 +1118,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Base64BinaryValue>(new NumberValidator());
+            builder.AddValidator<Base64BinaryValue>(NumberValidator.Instance);
             builder.SetSchema(5, "storage");
         }
 
@@ -1156,7 +1156,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Base64BinaryValue>(new NumberValidator());
+            builder.AddValidator<Base64BinaryValue>(NumberValidator.Instance);
             builder.SetSchema(5, "ostorage");
         }
 
@@ -1242,7 +1242,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<SByteValue>(new NumberValidator());
+            builder.AddValidator<SByteValue>(NumberValidator.Instance);
             builder.SetSchema(5, "i1");
         }
 
@@ -1280,7 +1280,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int16Value>(new NumberValidator());
+            builder.AddValidator<Int16Value>(NumberValidator.Instance);
             builder.SetSchema(5, "i2");
         }
 
@@ -1318,7 +1318,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidator());
+            builder.AddValidator<Int32Value>(NumberValidator.Instance);
             builder.SetSchema(5, "i4");
         }
 
@@ -1356,7 +1356,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidator());
+            builder.AddValidator<Int32Value>(NumberValidator.Instance);
             builder.SetSchema(5, "int");
         }
 
@@ -1394,7 +1394,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int64Value>(new NumberValidator());
+            builder.AddValidator<Int64Value>(NumberValidator.Instance);
             builder.SetSchema(5, "i8");
         }
 
@@ -1432,7 +1432,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<ByteValue>(new NumberValidator());
+            builder.AddValidator<ByteValue>(NumberValidator.Instance);
             builder.SetSchema(5, "ui1");
         }
 
@@ -1470,7 +1470,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<UInt16Value>(new NumberValidator());
+            builder.AddValidator<UInt16Value>(NumberValidator.Instance);
             builder.SetSchema(5, "ui2");
         }
 
@@ -1508,7 +1508,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<UInt32Value>(new NumberValidator());
+            builder.AddValidator<UInt32Value>(NumberValidator.Instance);
             builder.SetSchema(5, "ui4");
         }
 
@@ -1546,7 +1546,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<UInt32Value>(new NumberValidator());
+            builder.AddValidator<UInt32Value>(NumberValidator.Instance);
             builder.SetSchema(5, "uint");
         }
 
@@ -1584,7 +1584,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<UInt64Value>(new NumberValidator());
+            builder.AddValidator<UInt64Value>(NumberValidator.Instance);
             builder.SetSchema(5, "ui8");
         }
 
@@ -1622,7 +1622,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<SingleValue>(new NumberValidator());
+            builder.AddValidator<SingleValue>(NumberValidator.Instance);
             builder.SetSchema(5, "r4");
         }
 
@@ -1660,7 +1660,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<DoubleValue>(new NumberValidator());
+            builder.AddValidator<DoubleValue>(NumberValidator.Instance);
             builder.SetSchema(5, "r8");
         }
 
@@ -1698,7 +1698,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<DecimalValue>(new NumberValidator());
+            builder.AddValidator<DecimalValue>(NumberValidator.Instance);
             builder.SetSchema(5, "decimal");
         }
 
@@ -1847,7 +1847,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<DateTimeValue>(new NumberValidator());
+            builder.AddValidator<DateTimeValue>(NumberValidator.Instance);
             builder.SetSchema(5, "date");
         }
 
@@ -1885,7 +1885,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<DateTimeValue>(new NumberValidator());
+            builder.AddValidator<DateTimeValue>(NumberValidator.Instance);
             builder.SetSchema(5, "filetime");
         }
 
@@ -1923,7 +1923,7 @@ aBuilder.AddValidator(new RequiredValidator());
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<BooleanValue>(new NumberValidator());
+            builder.AddValidator<BooleanValue>(NumberValidator.Instance);
             builder.SetSchema(5, "bool");
         }
 
@@ -2051,7 +2051,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<VTVStreamData>()
 .AddAttribute(0, "version", a => a.Version, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { Pattern = ("\\s*\\{[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}\\}\\s*") });
 });
         }
@@ -2162,7 +2162,7 @@ aBuilder.AddValidator(new StringValidator() { Pattern = ("\\s*\\{[a-fA-F0-9]{8}-
  })
  .AddAttribute(0, "size", a => a.Size, aBuilder =>
  {
-     aBuilder.AddValidator(new RequiredValidator());
+     aBuilder.AddValidator(RequiredValidator.Instance);
  });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_extended-properties.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_extended-properties.g.cs
@@ -824,7 +824,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidator());
+            builder.AddValidator<Int32Value>(NumberValidator.Instance);
             builder.SetSchema(3, "Pages");
         }
 
@@ -862,7 +862,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidator());
+            builder.AddValidator<Int32Value>(NumberValidator.Instance);
             builder.SetSchema(3, "Words");
         }
 
@@ -900,7 +900,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidator());
+            builder.AddValidator<Int32Value>(NumberValidator.Instance);
             builder.SetSchema(3, "Characters");
         }
 
@@ -938,7 +938,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidator());
+            builder.AddValidator<Int32Value>(NumberValidator.Instance);
             builder.SetSchema(3, "Lines");
         }
 
@@ -976,7 +976,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidator());
+            builder.AddValidator<Int32Value>(NumberValidator.Instance);
             builder.SetSchema(3, "Paragraphs");
         }
 
@@ -1014,7 +1014,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidator());
+            builder.AddValidator<Int32Value>(NumberValidator.Instance);
             builder.SetSchema(3, "Slides");
         }
 
@@ -1052,7 +1052,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidator());
+            builder.AddValidator<Int32Value>(NumberValidator.Instance);
             builder.SetSchema(3, "Notes");
         }
 
@@ -1090,7 +1090,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidator());
+            builder.AddValidator<Int32Value>(NumberValidator.Instance);
             builder.SetSchema(3, "TotalTime");
         }
 
@@ -1128,7 +1128,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidator());
+            builder.AddValidator<Int32Value>(NumberValidator.Instance);
             builder.SetSchema(3, "HiddenSlides");
         }
 
@@ -1166,7 +1166,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidator());
+            builder.AddValidator<Int32Value>(NumberValidator.Instance);
             builder.SetSchema(3, "MMClips");
         }
 
@@ -1204,7 +1204,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidator());
+            builder.AddValidator<Int32Value>(NumberValidator.Instance);
             builder.SetSchema(3, "CharactersWithSpaces");
         }
 
@@ -1242,7 +1242,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidator());
+            builder.AddValidator<Int32Value>(NumberValidator.Instance);
             builder.SetSchema(3, "DocSecurity");
         }
 
@@ -1280,7 +1280,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<BooleanValue>(new NumberValidator());
+            builder.AddValidator<BooleanValue>(NumberValidator.Instance);
             builder.SetSchema(3, "ScaleCrop");
         }
 
@@ -1318,7 +1318,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<BooleanValue>(new NumberValidator());
+            builder.AddValidator<BooleanValue>(NumberValidator.Instance);
             builder.SetSchema(3, "LinksUpToDate");
         }
 
@@ -1356,7 +1356,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<BooleanValue>(new NumberValidator());
+            builder.AddValidator<BooleanValue>(NumberValidator.Instance);
             builder.SetSchema(3, "SharedDoc");
         }
 
@@ -1394,7 +1394,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<BooleanValue>(new NumberValidator());
+            builder.AddValidator<BooleanValue>(NumberValidator.Instance);
             builder.SetSchema(3, "HyperlinksChanged");
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_extended-properties.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_extended-properties.g.cs
@@ -824,7 +824,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidatorAttribute());
+            builder.AddValidator<Int32Value>(new NumberValidator());
             builder.SetSchema(3, "Pages");
         }
 
@@ -862,7 +862,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidatorAttribute());
+            builder.AddValidator<Int32Value>(new NumberValidator());
             builder.SetSchema(3, "Words");
         }
 
@@ -900,7 +900,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidatorAttribute());
+            builder.AddValidator<Int32Value>(new NumberValidator());
             builder.SetSchema(3, "Characters");
         }
 
@@ -938,7 +938,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidatorAttribute());
+            builder.AddValidator<Int32Value>(new NumberValidator());
             builder.SetSchema(3, "Lines");
         }
 
@@ -976,7 +976,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidatorAttribute());
+            builder.AddValidator<Int32Value>(new NumberValidator());
             builder.SetSchema(3, "Paragraphs");
         }
 
@@ -1014,7 +1014,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidatorAttribute());
+            builder.AddValidator<Int32Value>(new NumberValidator());
             builder.SetSchema(3, "Slides");
         }
 
@@ -1052,7 +1052,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidatorAttribute());
+            builder.AddValidator<Int32Value>(new NumberValidator());
             builder.SetSchema(3, "Notes");
         }
 
@@ -1090,7 +1090,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidatorAttribute());
+            builder.AddValidator<Int32Value>(new NumberValidator());
             builder.SetSchema(3, "TotalTime");
         }
 
@@ -1128,7 +1128,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidatorAttribute());
+            builder.AddValidator<Int32Value>(new NumberValidator());
             builder.SetSchema(3, "HiddenSlides");
         }
 
@@ -1166,7 +1166,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidatorAttribute());
+            builder.AddValidator<Int32Value>(new NumberValidator());
             builder.SetSchema(3, "MMClips");
         }
 
@@ -1204,7 +1204,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidatorAttribute());
+            builder.AddValidator<Int32Value>(new NumberValidator());
             builder.SetSchema(3, "CharactersWithSpaces");
         }
 
@@ -1242,7 +1242,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<Int32Value>(new NumberValidatorAttribute());
+            builder.AddValidator<Int32Value>(new NumberValidator());
             builder.SetSchema(3, "DocSecurity");
         }
 
@@ -1280,7 +1280,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<BooleanValue>(new NumberValidatorAttribute());
+            builder.AddValidator<BooleanValue>(new NumberValidator());
             builder.SetSchema(3, "ScaleCrop");
         }
 
@@ -1318,7 +1318,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<BooleanValue>(new NumberValidatorAttribute());
+            builder.AddValidator<BooleanValue>(new NumberValidator());
             builder.SetSchema(3, "LinksUpToDate");
         }
 
@@ -1356,7 +1356,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<BooleanValue>(new NumberValidatorAttribute());
+            builder.AddValidator<BooleanValue>(new NumberValidator());
             builder.SetSchema(3, "SharedDoc");
         }
 
@@ -1394,7 +1394,7 @@ namespace DocumentFormat.OpenXml.ExtendedProperties
         internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
             base.ConfigureMetadata(builder);
-            builder.AddValidator<BooleanValue>(new NumberValidatorAttribute());
+            builder.AddValidator<BooleanValue>(new NumberValidator());
             builder.SetSchema(3, "HyperlinksChanged");
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_math.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_math.g.cs
@@ -47,7 +47,7 @@ namespace DocumentFormat.OpenXml.Math
             builder.AddElement<Script>()
 .AddAttribute(21, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -89,7 +89,7 @@ namespace DocumentFormat.OpenXml.Math
             builder.AddElement<Style>()
 .AddAttribute(21, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -4137,7 +4137,7 @@ namespace DocumentFormat.OpenXml.Math
             builder.AddElement<CharType>()
                            .AddAttribute(21, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new StringValidator() { MaxLength = (1L) });
                            });
         }
@@ -6919,7 +6919,7 @@ namespace DocumentFormat.OpenXml.Math
             builder.AddElement<TopBottomType>()
                            .AddAttribute(21, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -7407,7 +7407,7 @@ namespace DocumentFormat.OpenXml.Math
             builder.AddElement<Shape>()
 .AddAttribute(21, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -7604,7 +7604,7 @@ namespace DocumentFormat.OpenXml.Math
             builder.AddElement<BaseJustification>()
 .AddAttribute(21, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -7693,7 +7693,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<SpacingRuleType>()
                            .AddAttribute(21, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (4L) });
                            });
         }
@@ -7780,7 +7780,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<UnsignedShortType>()
                            .AddAttribute(21, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -7974,7 +7974,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<FractionType>()
 .AddAttribute(21, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -8455,7 +8455,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<MatrixColumnCount>()
 .AddAttribute(21, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
  aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (64L) });
 });
         }
@@ -8498,7 +8498,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<MatrixColumnJustification>()
 .AddAttribute(21, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -8897,7 +8897,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<TwipsMeasureType>()
                            .AddAttribute(21, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MaxInclusive = (31680L) });
                            });
         }
@@ -9335,7 +9335,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<LimitLocationType>()
                            .AddAttribute(21, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -10091,7 +10091,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ArgumentSize>()
 .AddAttribute(21, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
  aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-2L), MaxInclusive = (2L) });
 });
         }
@@ -10256,7 +10256,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<OfficeMathJustificationType>()
                            .AddAttribute(21, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -10295,7 +10295,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<MathFont>()
 .AddAttribute(21, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (31L) });
 });
         }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_math.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_math.g.cs
@@ -47,7 +47,7 @@ namespace DocumentFormat.OpenXml.Math
             builder.AddElement<Script>()
 .AddAttribute(21, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -89,7 +89,7 @@ namespace DocumentFormat.OpenXml.Math
             builder.AddElement<Style>()
 .AddAttribute(21, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -3842,11 +3842,11 @@ namespace DocumentFormat.OpenXml.Math
             builder.AddElement<Break>()
 .AddAttribute(21, "alnAt", a => a.AlignAt, aBuilder =>
 {
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (255L) });
+   aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (255L) });
 })
 .AddAttribute(21, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (255L) });
+   aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (255L) });
 });
         }
 
@@ -4137,8 +4137,8 @@ namespace DocumentFormat.OpenXml.Math
             builder.AddElement<CharType>()
                            .AddAttribute(21, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (1L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new StringValidator() { MaxLength = (1L) });
                            });
         }
     }
@@ -6919,7 +6919,7 @@ namespace DocumentFormat.OpenXml.Math
             builder.AddElement<TopBottomType>()
                            .AddAttribute(21, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -7407,7 +7407,7 @@ namespace DocumentFormat.OpenXml.Math
             builder.AddElement<Shape>()
 .AddAttribute(21, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -7604,7 +7604,7 @@ namespace DocumentFormat.OpenXml.Math
             builder.AddElement<BaseJustification>()
 .AddAttribute(21, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -7693,8 +7693,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<SpacingRuleType>()
                            .AddAttribute(21, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (4L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (4L) });
                            });
         }
     }
@@ -7780,7 +7780,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<UnsignedShortType>()
                            .AddAttribute(21, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -7974,7 +7974,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<FractionType>()
 .AddAttribute(21, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -8455,8 +8455,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<MatrixColumnCount>()
 .AddAttribute(21, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
- aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (64L) });
+ aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (64L) });
 });
         }
 
@@ -8498,7 +8498,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<MatrixColumnJustification>()
 .AddAttribute(21, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -8897,8 +8897,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TwipsMeasureType>()
                            .AddAttribute(21, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MaxInclusive = (31680L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MaxInclusive = (31680L) });
                            });
         }
     }
@@ -9335,7 +9335,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<LimitLocationType>()
                            .AddAttribute(21, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -10091,8 +10091,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ArgumentSize>()
 .AddAttribute(21, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
- aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-2L), MaxInclusive = (2L) });
+ aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-2L), MaxInclusive = (2L) });
 });
         }
 
@@ -10256,7 +10256,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<OfficeMathJustificationType>()
                            .AddAttribute(21, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -10295,8 +10295,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<MathFont>()
 .AddAttribute(21, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (31L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (31L) });
 });
         }
 
@@ -10377,8 +10377,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (31L) });
             builder.AddElement<BreakBinarySubtraction>()
 .AddAttribute(21, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
-aBuilder.AddValidator(new RequiredValidatorAttribute() { IsRequired = (false), InitialVersion = (FileFormatVersions.Office2010) });
+aBuilder.AddValidator(new RequiredValidator() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator(new RequiredValidator() { IsRequired = (false), InitialVersion = (FileFormatVersions.Office2010) });
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_presentationml_2006_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_presentationml_2006_main.g.cs
@@ -467,11 +467,11 @@ namespace DocumentFormat.OpenXml.Presentation
             builder.AddElement<IndexRangeType>()
                            .AddAttribute(0, "st", a => a.Start, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            })
                            .AddAttribute(0, "end", a => a.End, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -507,7 +507,7 @@ namespace DocumentFormat.OpenXml.Presentation
             builder.AddElement<CustomShowReference>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -576,7 +576,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Extension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -836,62 +836,62 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ColorMap>()
 .AddAttribute(0, "bg1", a => a.Background1, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "tx1", a => a.Text1, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "bg2", a => a.Background2, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "tx2", a => a.Text2, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent1", a => a.Accent1, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent2", a => a.Accent2, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent3", a => a.Accent3, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent4", a => a.Accent4, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent5", a => a.Accent5, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent6", a => a.Accent6, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "hlink", a => a.Hyperlink, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "folHlink", a => a.FollowedHyperlink, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -1193,7 +1193,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<BackgroundStyleReference>()
 .AddAttribute(0, "idx", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -3585,15 +3585,15 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<SlideSyncProperties>()
 .AddAttribute(0, "serverSldId", a => a.ServerSlideId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "serverSldModifiedTime", a => a.ServerSlideModifiedTime, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "clientInsertedTime", a => a.ClientInsertedTime, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -4076,7 +4076,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
 })
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -4239,7 +4239,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<EmbeddedWavAudioFileType>()
                            .AddAttribute(19, "embed", a => a.Embed, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            })
                            .AddAttribute(0, "name", a => a.Name)
                            .AddAttribute(0, "builtIn", a => a.BuiltIn);
@@ -4364,7 +4364,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<TimeAbsolute>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
  aBuilder.AddUnion(union =>
  {
      union.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
@@ -4413,7 +4413,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<TimePercentage>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
  aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 });
         }
@@ -4598,7 +4598,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<TimeNode>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidator());
+    aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -4637,7 +4637,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RuntimeNodeTrigger>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -7454,7 +7454,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<BooleanVariantValue>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -7493,7 +7493,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<IntegerVariantValue>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -7532,7 +7532,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<FloatVariantValue>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -7571,7 +7571,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<StringVariantValue>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -7947,7 +7947,7 @@ aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeDeclarationValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeDeclarationValues>>(EnumValidator.Instance);
 });
 })
 .AddAttribute(0, "fmla", a => a.Fomula);
@@ -8028,17 +8028,17 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeD
             builder.AddElement<RgbColor>()
 .AddAttribute(0, "r", a => a.Red, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "g", a => a.Green, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "b", a => a.Blue, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
 });
         }
@@ -8098,16 +8098,16 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeD
             builder.AddElement<HslColor>()
 .AddAttribute(0, "h", a => a.Hue, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "s", a => a.Saturation, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "l", a => a.Lightness, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
 });
         }
@@ -9264,14 +9264,14 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<BuildParagraph>()
 .AddAttribute(0, "spid", a => a.ShapeId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { Version = (FileFormatVersions.Office2007) });
 aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2010) });
 aBuilder.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2013) });
 })
 .AddAttribute(0, "grpId", a => a.GroupId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uiExpand", a => a.UiExpand)
 .AddAttribute(0, "build", a => a.Build, aBuilder =>
@@ -9388,14 +9388,14 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeD
             builder.AddElement<BuildDiagram>()
 .AddAttribute(0, "spid", a => a.ShapeId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { Version = (FileFormatVersions.Office2007) });
 aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2010) });
 aBuilder.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2013) });
 })
 .AddAttribute(0, "grpId", a => a.GroupId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uiExpand", a => a.UiExpand)
 .AddAttribute(0, "bld", a => a.Build, aBuilder =>
@@ -9486,14 +9486,14 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<BuildOleChart>()
 .AddAttribute(0, "spid", a => a.ShapeId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { Version = (FileFormatVersions.Office2007) });
 aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2010) });
 aBuilder.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2013) });
 })
 .AddAttribute(0, "grpId", a => a.GroupId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uiExpand", a => a.UiExpand)
 .AddAttribute(0, "bld", a => a.Build, aBuilder =>
@@ -9598,14 +9598,14 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<BuildGraphics>()
 .AddAttribute(0, "spid", a => a.ShapeId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { Version = (FileFormatVersions.Office2007) });
 aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2010) });
 aBuilder.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2013) });
 })
 .AddAttribute(0, "grpId", a => a.GroupId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uiExpand", a => a.UiExpand);
         }
@@ -10212,7 +10212,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<SlideListEntry>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -10260,7 +10260,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<CustomerData>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -10302,7 +10302,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<CustomerDataTags>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -10412,23 +10412,23 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<CommentAuthor>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "initials", a => a.Initials, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "lastIdx", a => a.LastIndex, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "clrIdx", a => a.ColorIndex, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -10550,12 +10550,12 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Comment>()
 .AddAttribute(0, "authorId", a => a.AuthorId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "dt", a => a.DateTime)
 .AddAttribute(0, "idx", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -10924,12 +10924,12 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
             builder.AddElement<SlideId>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (2147483648L), MinInclusive = (256L) });
 })
 .AddAttribute(19, "id", a => a.RelationshipId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -11043,7 +11043,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (2147483648L) });
 })
 .AddAttribute(19, "id", a => a.RelationshipId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -11143,7 +11143,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<NotesMasterId>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -11242,7 +11242,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<HandoutMasterId>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -11477,7 +11477,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<EmbeddedFontDataIdType>()
                            .AddAttribute(19, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -11757,11 +11757,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<CustomShow>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -11909,11 +11909,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)
@@ -14352,7 +14352,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (2147483648L) });
 })
 .AddAttribute(19, "id", a => a.RelationshipId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -14579,11 +14579,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Tag>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -14685,7 +14685,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<NormalViewPortionType>()
                            .AddAttribute(0, "sz", a => a.Size, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
                            })
                            .AddAttribute(0, "autoAdjust", a => a.AutoAdjust);
@@ -14871,12 +14871,12 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Point2DType>()
                            .AddAttribute(0, "x", a => a.X, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
                            })
                            .AddAttribute(0, "y", a => a.Y, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
                            });
         }
@@ -15029,7 +15029,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<OutlineViewSlideListEntry>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "collapse", a => a.Collapse);
         }
@@ -16077,12 +16077,12 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<PositiveSize2DType>()
                            .AddAttribute(0, "cx", a => a.Cx, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
                            })
                            .AddAttribute(0, "cy", a => a.Cy, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
                            });
         }
@@ -16152,7 +16152,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<SlideExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -16232,7 +16232,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<CommonSlideDataExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -16315,7 +16315,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<ShowPropertiesExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -18397,7 +18397,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<ShapeTarget>()
 .AddAttribute(0, "spid", a => a.ShapeId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { Version = (FileFormatVersions.Office2007) });
 aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2010) });
 aBuilder.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2013) });
@@ -18562,7 +18562,7 @@ aBuilder.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (Fil
             builder.AddElement<TimeListSubShapeIdType>()
                            .AddAttribute(0, "spid", a => a.ShapeId, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                            });
         }
@@ -18630,7 +18630,7 @@ aBuilder.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (Fil
             builder.AddElement<CommentAuthorExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -18709,7 +18709,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<CommentExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -18788,7 +18788,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<SlideLayoutExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -18867,7 +18867,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<SlideMasterExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -18946,7 +18946,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<HandoutMasterExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -19025,7 +19025,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<NotesMasterExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -19308,7 +19308,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<ApplicationNonVisualDrawingPropertiesExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -19886,11 +19886,11 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<TimeListType>()
                            .AddAttribute(0, "x", a => a.X, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            })
                            .AddAttribute(0, "y", a => a.Y, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -20344,12 +20344,12 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<SlideSize>()
 .AddAttribute(0, "cx", a => a.Cx, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
  aBuilder.AddValidator(new NumberValidator() { MinInclusive = (914400L), MaxInclusive = (51206400L) });
 })
 .AddAttribute(0, "cy", a => a.Cy, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
  aBuilder.AddValidator(new NumberValidator() { MinInclusive = (914400L), MaxInclusive = (51206400L) });
 })
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
@@ -20664,11 +20664,11 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 .AddAttribute(0, "lang", a => a.Language)
 .AddAttribute(0, "invalStChars", a => a.InvalidStartChars, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "invalEndChars", a => a.InvalidEndChars, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -21056,7 +21056,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
             builder.AddElement<PresentationExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -21172,7 +21172,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -21879,7 +21879,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<PresentationPropertiesExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -22493,7 +22493,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<OleChartElement>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "lvl", a => a.Level);
@@ -22896,8 +22896,8 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                            {
                                aBuilder.AddUnion(union =>
                                {
-                                   union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.TransitionSlideDirectionValues>>(new EnumValidator());
-                                   union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.TransitionCornerDirectionValues>>(new EnumValidator());
+                                   union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.TransitionSlideDirectionValues>>(EnumValidator.Instance);
+                                   union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.TransitionCornerDirectionValues>>(EnumValidator.Instance);
                                });
                            });
         }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_presentationml_2006_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_presentationml_2006_main.g.cs
@@ -467,11 +467,11 @@ namespace DocumentFormat.OpenXml.Presentation
             builder.AddElement<IndexRangeType>()
                            .AddAttribute(0, "st", a => a.Start, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            })
                            .AddAttribute(0, "end", a => a.End, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -507,7 +507,7 @@ namespace DocumentFormat.OpenXml.Presentation
             builder.AddElement<CustomShowReference>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -576,8 +576,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Extension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -836,63 +836,63 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ColorMap>()
 .AddAttribute(0, "bg1", a => a.Background1, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "tx1", a => a.Text1, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "bg2", a => a.Background2, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "tx2", a => a.Text2, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent1", a => a.Accent1, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent2", a => a.Accent2, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent3", a => a.Accent3, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent4", a => a.Accent4, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent5", a => a.Accent5, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accent6", a => a.Accent6, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "hlink", a => a.Hyperlink, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "folHlink", a => a.FollowedHyperlink, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -1193,7 +1193,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<BackgroundStyleReference>()
 .AddAttribute(0, "idx", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -1612,18 +1612,18 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<OleObject>()
 .AddAttribute(0, "spid", a => a.ShapeId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "name", a => a.Name)
 .AddAttribute(0, "showAsIcon", a => a.ShowAsIcon)
 .AddAttribute(19, "id", a => a.Id)
 .AddAttribute(0, "imgW", a => a.ImageWidth, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 })
 .AddAttribute(0, "imgH", a => a.ImageHeight, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 })
 .AddAttribute(0, "progId", a => a.ProgId);
         }
@@ -1858,7 +1858,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
 .AddAttribute(0, "autoCompressPictures", a => a.AutoCompressPictures)
 .AddAttribute(0, "bookmarkIdSeed", a => a.BookmarkIdSeed, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (2147483648L), MinInclusive = (1L) });
+aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (2147483648L), MinInclusive = (1L) });
 })
 .AddAttribute(0, "conformance", a => a.Conformance);
         }
@@ -2627,7 +2627,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (214748364
 .AddAttribute(0, "matchingName", a => a.MatchingName)
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "preserve", a => a.Preserve)
 .AddAttribute(0, "userDrawn", a => a.UserDrawn);
@@ -3585,15 +3585,15 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<SlideSyncProperties>()
 .AddAttribute(0, "serverSldId", a => a.ServerSlideId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "serverSldModifiedTime", a => a.ServerSlideModifiedTime, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "clientInsertedTime", a => a.ClientInsertedTime, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -3831,7 +3831,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ViewProperties>()
 .AddAttribute(0, "lastView", a => a.LastView, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "showComments", a => a.ShowComments);
         }
@@ -4072,11 +4072,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<ContentPart>()
 .AddAttribute(49, "bwMode", a => a.BwMode, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -4239,7 +4239,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<EmbeddedWavAudioFileType>()
                            .AddAttribute(19, "embed", a => a.Embed, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            })
                            .AddAttribute(0, "name", a => a.Name)
                            .AddAttribute(0, "builtIn", a => a.BuiltIn);
@@ -4364,16 +4364,16 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TimeAbsolute>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
+ aBuilder.AddValidator(new RequiredValidator());
  aBuilder.AddUnion(union =>
  {
-     union.AddValidator<UInt32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeDeclarationValues>>(new EnumValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+     union.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeDeclarationValues>>(new EnumValidator() { Version = (FileFormatVersions.Office2007) });
  });
  aBuilder.AddUnion(union =>
  {
-     union.AddValidator(new StringValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeDeclarationValues>>(new EnumValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
+     union.AddValidator(new StringValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeDeclarationValues>>(new EnumValidator() { InitialVersion = (FileFormatVersions.Office2010) });
  });
 });
         }
@@ -4413,8 +4413,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TimePercentage>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
- aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+ aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 });
         }
 
@@ -4598,7 +4598,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TimeNode>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidatorAttribute());
+    aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -4637,8 +4637,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RuntimeNodeTrigger>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -4851,19 +4851,19 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TimeListConditionalType>()
 .AddAttribute(0, "evt", a => a.Event, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "delay", a => a.Delay, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<UInt32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeDeclarationValues>>(new EnumValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+union.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeDeclarationValues>>(new EnumValidator() { Version = (FileFormatVersions.Office2007) });
 });
 aBuilder.AddUnion(union =>
 {
-union.AddValidator(new StringValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeDeclarationValues>>(new EnumValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
+union.AddValidator(new StringValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeDeclarationValues>>(new EnumValidator() { InitialVersion = (FileFormatVersions.Office2010) });
 });
 });
         }
@@ -5070,11 +5070,11 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeD
 .AddAttribute(0, "concurrent", a => a.Concurrent)
 .AddAttribute(0, "prevAc", a => a.PreviousAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "nextAc", a => a.NextAction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -5325,16 +5325,16 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "to", a => a.To)
 .AddAttribute(0, "calcmode", a => a.CalculationMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "valueType", a => a.ValueType, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(49, "bounceEnd", a => a.BounceEnd, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 });
         }
 
@@ -5454,11 +5454,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<AnimateColor>()
 .AddAttribute(0, "clrSpc", a => a.ColorSpace, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "dir", a => a.Direction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -5612,7 +5612,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<AnimateEffect>()
 .AddAttribute(0, "transition", a => a.Transition, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "filter", a => a.Filter)
 .AddAttribute(0, "prLst", a => a.PropertyList);
@@ -5779,19 +5779,19 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<AnimateMotion>()
 .AddAttribute(0, "origin", a => a.Origin, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "path", a => a.Path)
 .AddAttribute(0, "pathEditMode", a => a.PathEditMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "rAng", a => a.RelativeAngle)
 .AddAttribute(0, "ptsTypes", a => a.PointTypes)
 .AddAttribute(49, "bounceEnd", a => a.BounceEnd, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 });
         }
 
@@ -5979,8 +5979,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
 .AddAttribute(0, "to", a => a.To)
 .AddAttribute(49, "bounceEnd", a => a.BounceEnd, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 });
         }
 
@@ -6098,8 +6098,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
 .AddAttribute(0, "zoomContents", a => a.ZoomContents)
 .AddAttribute(49, "bounceEnd", a => a.BounceEnd, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 });
         }
 
@@ -6241,7 +6241,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<Command>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "cmd", a => a.CommandName);
         }
@@ -6842,7 +6842,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "presetID", a => a.PresetId)
 .AddAttribute(0, "presetClass", a => a.PresetClass, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "presetSubtype", a => a.PresetSubtype)
 .AddAttribute(0, "dur", a => a.Duration)
@@ -6851,44 +6851,44 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "spd", a => a.Speed)
 .AddAttribute(0, "accel", a => a.Acceleration, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "decel", a => a.Deceleration, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "autoRev", a => a.AutoReverse)
 .AddAttribute(0, "restart", a => a.Restart, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "fill", a => a.Fill, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "syncBehavior", a => a.SyncBehavior, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "tmFilter", a => a.TimeFilter)
 .AddAttribute(0, "evtFilter", a => a.EventFilter)
 .AddAttribute(0, "display", a => a.Display)
 .AddAttribute(0, "masterRel", a => a.MasterRelation, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "bldLvl", a => a.BuildLevel)
 .AddAttribute(0, "grpId", a => a.GroupId)
 .AddAttribute(0, "afterEffect", a => a.AfterEffect)
 .AddAttribute(0, "nodeType", a => a.NodeType, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "nodePh", a => a.NodePlaceholder)
 .AddAttribute(49, "presetBounceEnd", a => a.PresetBounceEnd, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 });
         }
 
@@ -7454,7 +7454,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<BooleanVariantValue>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -7493,7 +7493,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<IntegerVariantValue>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -7532,7 +7532,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<FloatVariantValue>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -7571,7 +7571,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<StringVariantValue>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -7946,8 +7946,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeDeclarationValues>>(new EnumValidatorAttribute());
+union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeDeclarationValues>>(new EnumValidator());
 });
 })
 .AddAttribute(0, "fmla", a => a.Fomula);
@@ -8028,18 +8028,18 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeD
             builder.AddElement<RgbColor>()
 .AddAttribute(0, "r", a => a.Red, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "g", a => a.Green, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "b", a => a.Blue, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
 });
         }
 
@@ -8098,17 +8098,17 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeD
             builder.AddElement<HslColor>()
 .AddAttribute(0, "h", a => a.Hue, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "s", a => a.Saturation, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "l", a => a.Lightness, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
 });
         }
 
@@ -8252,15 +8252,15 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeD
             builder.AddElement<CommonBehavior>()
 .AddAttribute(0, "additive", a => a.Additive, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "accumulate", a => a.Accumulate, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "xfrmType", a => a.TransformType, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "from", a => a.From)
 .AddAttribute(0, "to", a => a.To)
@@ -8268,7 +8268,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "rctx", a => a.RuntimeContext)
 .AddAttribute(0, "override", a => a.Override, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -8755,7 +8755,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<CommonMediaNode>()
 .AddAttribute(0, "vol", a => a.Volume, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
 })
 .AddAttribute(0, "mute", a => a.Mute)
 .AddAttribute(0, "numSld", a => a.SlideCount)
@@ -9264,19 +9264,19 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<BuildParagraph>()
 .AddAttribute(0, "spid", a => a.ShapeId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
-aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2010) });
-aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2013) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2010) });
+aBuilder.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2013) });
 })
 .AddAttribute(0, "grpId", a => a.GroupId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uiExpand", a => a.UiExpand)
 .AddAttribute(0, "build", a => a.Build, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "bldLvl", a => a.BuildLevel)
 .AddAttribute(0, "animBg", a => a.AnimateBackground)
@@ -9286,13 +9286,13 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<UInt32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeDeclarationValues>>(new EnumValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+union.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeDeclarationValues>>(new EnumValidator() { Version = (FileFormatVersions.Office2007) });
 });
 aBuilder.AddUnion(union =>
 {
-union.AddValidator(new StringValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeDeclarationValues>>(new EnumValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
+union.AddValidator(new StringValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeDeclarationValues>>(new EnumValidator() { InitialVersion = (FileFormatVersions.Office2010) });
 });
 });
         }
@@ -9388,19 +9388,19 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeD
             builder.AddElement<BuildDiagram>()
 .AddAttribute(0, "spid", a => a.ShapeId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
-aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2010) });
-aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2013) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2010) });
+aBuilder.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2013) });
 })
 .AddAttribute(0, "grpId", a => a.GroupId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uiExpand", a => a.UiExpand)
 .AddAttribute(0, "bld", a => a.Build, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -9486,19 +9486,19 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<BuildOleChart>()
 .AddAttribute(0, "spid", a => a.ShapeId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
-aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2010) });
-aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2013) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2010) });
+aBuilder.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2013) });
 })
 .AddAttribute(0, "grpId", a => a.GroupId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uiExpand", a => a.UiExpand)
 .AddAttribute(0, "bld", a => a.Build, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "animBg", a => a.AnimateBackground);
         }
@@ -9598,14 +9598,14 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<BuildGraphics>()
 .AddAttribute(0, "spid", a => a.ShapeId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
-aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2010) });
-aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2013) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2010) });
+aBuilder.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2013) });
 })
 .AddAttribute(0, "grpId", a => a.GroupId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uiExpand", a => a.UiExpand);
         }
@@ -10212,7 +10212,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<SlideListEntry>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -10260,7 +10260,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<CustomerData>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -10302,7 +10302,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<CustomerDataTags>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -10412,23 +10412,23 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<CommentAuthor>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "initials", a => a.Initials, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "lastIdx", a => a.LastIndex, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "clrIdx", a => a.ColorIndex, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -10550,12 +10550,12 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Comment>()
 .AddAttribute(0, "authorId", a => a.AuthorId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "dt", a => a.DateTime)
 .AddAttribute(0, "idx", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -10796,18 +10796,18 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Control>()
 .AddAttribute(0, "spid", a => a.ShapeId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "name", a => a.Name)
 .AddAttribute(0, "showAsIcon", a => a.ShowAsIcon)
 .AddAttribute(19, "id", a => a.Id)
 .AddAttribute(0, "imgW", a => a.ImageWidth, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 })
 .AddAttribute(0, "imgH", a => a.ImageHeight, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 });
         }
 
@@ -10924,12 +10924,12 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
             builder.AddElement<SlideId>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MaxExclusive = (2147483648L), MinInclusive = (256L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (2147483648L), MinInclusive = (256L) });
 })
 .AddAttribute(19, "id", a => a.RelationshipId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -11039,11 +11039,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<SlideMasterId>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (2147483648L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (2147483648L) });
 })
 .AddAttribute(19, "id", a => a.RelationshipId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -11143,7 +11143,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<NotesMasterId>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -11242,7 +11242,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<HandoutMasterId>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -11338,7 +11338,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "typeface", a => a.Typeface)
 .AddAttribute(0, "panose", a => a.Panose, aBuilder =>
 {
-  aBuilder.AddValidator(new StringValidatorAttribute() { Length = (10L) });
+  aBuilder.AddValidator(new StringValidator() { Length = (10L) });
 })
 .AddAttribute(0, "pitchFamily", a => a.PitchFamily)
 .AddAttribute(0, "charset", a => a.CharacterSet);
@@ -11477,7 +11477,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<EmbeddedFontDataIdType>()
                            .AddAttribute(19, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -11757,11 +11757,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<CustomShow>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -11909,11 +11909,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<NonVisualDrawingProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "descr", a => a.Description)
 .AddAttribute(0, "hidden", a => a.Hidden)
@@ -12397,7 +12397,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ShapeProperties>()
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -14348,11 +14348,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<SlideLayoutId>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (2147483648L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (2147483648L) });
 })
 .AddAttribute(19, "id", a => a.RelationshipId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -14579,11 +14579,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Tag>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -14685,8 +14685,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<NormalViewPortionType>()
                            .AddAttribute(0, "sz", a => a.Size, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100000L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100000L) });
                            })
                            .AddAttribute(0, "autoAdjust", a => a.AutoAdjust);
         }
@@ -14871,13 +14871,13 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Point2DType>()
                            .AddAttribute(0, "x", a => a.X, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
                            })
                            .AddAttribute(0, "y", a => a.Y, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-27273042329600L), MaxInclusive = (27273042316900L) });
                            });
         }
     }
@@ -15029,7 +15029,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<OutlineViewSlideListEntry>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "collapse", a => a.Collapse);
         }
@@ -15141,7 +15141,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Guide>()
 .AddAttribute(0, "orient", a => a.Orientation, aBuilder =>
 {
- aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "pos", a => a.Position);
         }
@@ -15445,11 +15445,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "snapVertSplitter", a => a.SnapVerticalSplitter)
 .AddAttribute(0, "vertBarState", a => a.VerticalBarState, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "horzBarState", a => a.HorizontalBarState, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "preferSingleView", a => a.PreferSingleView);
         }
@@ -16077,13 +16077,13 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<PositiveSize2DType>()
                            .AddAttribute(0, "cx", a => a.Cx, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
                            })
                            .AddAttribute(0, "cy", a => a.Cy, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (2147483647L) });
                            });
         }
     }
@@ -16152,8 +16152,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<SlideExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -16232,8 +16232,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<CommonSlideDataExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -16315,8 +16315,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<ShowPropertiesExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -16535,7 +16535,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<OleObjectEmbed>()
 .AddAttribute(0, "followColorScheme", a => a.FollowColorScheme, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -16829,18 +16829,18 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Transition>()
 .AddAttribute(0, "spd", a => a.Speed, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(49, "dur", a => a.Duration, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(0, "advClick", a => a.AdvanceOnClick)
 .AddAttribute(0, "advTm", a => a.AdvanceAfterTime, aBuilder =>
 {
-aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
-aBuilder.AddValidator(new StringValidatorAttribute() { Version = (FileFormatVersions.Office2010) });
-aBuilder.AddValidator(new StringValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2013) });
+aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator(new StringValidator() { Version = (FileFormatVersions.Office2010) });
+aBuilder.AddValidator(new StringValidator() { InitialVersion = (FileFormatVersions.Office2013) });
 });
         }
 
@@ -17139,7 +17139,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { InitialVersion = (FileFor
             builder.AddElement<Background>()
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -17818,7 +17818,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<GroupShapeProperties>()
 .AddAttribute(0, "bwMode", a => a.BlackWhiteMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -18397,10 +18397,10 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<ShapeTarget>()
 .AddAttribute(0, "spid", a => a.ShapeId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
-aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2010) });
-aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2013) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2010) });
+aBuilder.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2013) });
 });
         }
 
@@ -18562,8 +18562,8 @@ aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { InitialVersi
             builder.AddElement<TimeListSubShapeIdType>()
                            .AddAttribute(0, "spid", a => a.ShapeId, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                            });
         }
     }
@@ -18630,8 +18630,8 @@ aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { InitialVersi
             builder.AddElement<CommentAuthorExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -18709,8 +18709,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<CommentExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -18788,8 +18788,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<SlideLayoutExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -18867,8 +18867,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<SlideMasterExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -18946,8 +18946,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<HandoutMasterExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -19025,8 +19025,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<NotesMasterExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -19144,15 +19144,15 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<PlaceholderShape>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "orient", a => a.Orientation, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "sz", a => a.Size, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "idx", a => a.Index)
 .AddAttribute(0, "hasCustomPrompt", a => a.HasCustomPrompt);
@@ -19308,8 +19308,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<ApplicationNonVisualDrawingPropertiesExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -19400,7 +19400,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Iterate>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "backwards", a => a.Backwards);
         }
@@ -19886,11 +19886,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<TimeListType>()
                            .AddAttribute(0, "x", a => a.X, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            })
                            .AddAttribute(0, "y", a => a.Y, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -20344,17 +20344,17 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<SlideSize>()
 .AddAttribute(0, "cx", a => a.Cx, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
- aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (914400L), MaxInclusive = (51206400L) });
+ aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (914400L), MaxInclusive = (51206400L) });
 })
 .AddAttribute(0, "cy", a => a.Cy, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
- aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (914400L), MaxInclusive = (51206400L) });
+ aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (914400L), MaxInclusive = (51206400L) });
 })
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
- aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -20580,11 +20580,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "showCaptions", a => a.ShowCaptions)
 .AddAttribute(0, "layout", a => a.Layout, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "frame", a => a.Frame, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -20664,11 +20664,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "lang", a => a.Language)
 .AddAttribute(0, "invalStChars", a => a.InvalidStartChars, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "invalEndChars", a => a.InvalidEndChars, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -20857,38 +20857,38 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ModificationVerifier>()
 .AddAttribute(0, "cryptProviderType", a => a.CryptographicProviderType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
-aBuilder.AddValidator(new RequiredValidatorAttribute() { IsRequired = (false), InitialVersion = (FileFormatVersions.Office2010) });
+aBuilder.AddValidator(new RequiredValidator() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator(new RequiredValidator() { IsRequired = (false), InitialVersion = (FileFormatVersions.Office2010) });
 })
 .AddAttribute(0, "cryptAlgorithmClass", a => a.CryptographicAlgorithmClass, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
-aBuilder.AddValidator(new RequiredValidatorAttribute() { IsRequired = (false), InitialVersion = (FileFormatVersions.Office2010) });
+aBuilder.AddValidator(new RequiredValidator() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator(new RequiredValidator() { IsRequired = (false), InitialVersion = (FileFormatVersions.Office2010) });
 })
 .AddAttribute(0, "cryptAlgorithmType", a => a.CryptographicAlgorithmType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
-aBuilder.AddValidator(new RequiredValidatorAttribute() { IsRequired = (false), InitialVersion = (FileFormatVersions.Office2010) });
+aBuilder.AddValidator(new RequiredValidator() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator(new RequiredValidator() { IsRequired = (false), InitialVersion = (FileFormatVersions.Office2010) });
 })
 .AddAttribute(0, "cryptAlgorithmSid", a => a.CryptographicAlgorithmSid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
-aBuilder.AddValidator(new RequiredValidatorAttribute() { IsRequired = (false), InitialVersion = (FileFormatVersions.Office2010) });
+aBuilder.AddValidator(new RequiredValidator() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator(new RequiredValidator() { IsRequired = (false), InitialVersion = (FileFormatVersions.Office2010) });
 })
 .AddAttribute(0, "spinCount", a => a.SpinCount, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
-aBuilder.AddValidator(new RequiredValidatorAttribute() { IsRequired = (false), InitialVersion = (FileFormatVersions.Office2010) });
+aBuilder.AddValidator(new RequiredValidator() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator(new RequiredValidator() { IsRequired = (false), InitialVersion = (FileFormatVersions.Office2010) });
 })
 .AddAttribute(0, "saltData", a => a.SaltData, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
-aBuilder.AddValidator(new RequiredValidatorAttribute() { IsRequired = (false), InitialVersion = (FileFormatVersions.Office2010) });
+aBuilder.AddValidator(new RequiredValidator() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator(new RequiredValidator() { IsRequired = (false), InitialVersion = (FileFormatVersions.Office2010) });
 })
 .AddAttribute(0, "hashData", a => a.HashData, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
-aBuilder.AddValidator(new RequiredValidatorAttribute() { IsRequired = (false), InitialVersion = (FileFormatVersions.Office2010) });
+aBuilder.AddValidator(new RequiredValidator() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator(new RequiredValidator() { IsRequired = (false), InitialVersion = (FileFormatVersions.Office2010) });
 })
 .AddAttribute(0, "cryptProvider", a => a.CryptographicProvider)
 .AddAttribute(0, "algIdExt", a => a.ExtendedCryptographicAlgorithm)
@@ -20897,19 +20897,19 @@ aBuilder.AddValidator(new RequiredValidatorAttribute() { IsRequired = (false), I
 .AddAttribute(0, "cryptProviderTypeExtSource", a => a.CryptographicProviderTypeExtensibilitySource)
 .AddAttribute(0, "algorithmName", a => a.AlgorithmName, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(0, "hashValue", a => a.HashValue, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(0, "saltValue", a => a.SaltValue, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(0, "spinValue", a => a.SpinValue, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -21056,8 +21056,8 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<PresentationExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -21168,11 +21168,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "showSpeakerNotes", a => a.ShowSpeakerNotes)
 .AddAttribute(0, "pubBrowser", a => a.TargetBrowser, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -21344,12 +21344,12 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "useLongFilenames", a => a.UseLongFilenames)
 .AddAttribute(0, "imgSz", a => a.ImageSize, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "encoding", a => a.Encoding)
 .AddAttribute(0, "clr", a => a.Color, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -21479,11 +21479,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<PrintingProperties>()
 .AddAttribute(0, "prnWhat", a => a.PrintWhat, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "clrMode", a => a.ColorMode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "hiddenSlides", a => a.HiddenSlides)
 .AddAttribute(0, "scaleToFitPaper", a => a.ScaleToFitPaper)
@@ -21879,8 +21879,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<PresentationPropertiesExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -22493,8 +22493,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<OleChartElement>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "lvl", a => a.Level);
         }
@@ -22811,7 +22811,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<OrientationTransitionType>()
                            .AddAttribute(0, "dir", a => a.Direction, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+                               aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                            });
         }
     }
@@ -22896,8 +22896,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
                            {
                                aBuilder.AddUnion(union =>
                                {
-                                   union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.TransitionSlideDirectionValues>>(new EnumValidatorAttribute());
-                                   union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.TransitionCornerDirectionValues>>(new EnumValidatorAttribute());
+                                   union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.TransitionSlideDirectionValues>>(new EnumValidator());
+                                   union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.TransitionCornerDirectionValues>>(new EnumValidator());
                                });
                            });
         }
@@ -23061,7 +23061,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<SideDirectionTransitionType>()
                            .AddAttribute(0, "dir", a => a.Direction, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+                               aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                            });
         }
     }
@@ -23107,11 +23107,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<SplitTransition>()
 .AddAttribute(0, "orient", a => a.Orientation, aBuilder =>
 {
- aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute(0, "dir", a => a.Direction, aBuilder =>
 {
- aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -23150,7 +23150,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<StripsTransition>()
 .AddAttribute(0, "dir", a => a.Direction, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -23225,7 +23225,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<ZoomTransition>()
 .AddAttribute(0, "dir", a => a.Direction, aBuilder =>
 {
-  aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+  aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_spreadsheetml_2006_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_spreadsheetml_2006_main.g.cs
@@ -73,8 +73,8 @@ namespace DocumentFormat.OpenXml.Spreadsheet
             builder.AddElement<Extension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -387,7 +387,7 @@ namespace DocumentFormat.OpenXml.Spreadsheet
             builder.AddElement<MapInfo>()
 .AddAttribute(0, "SelectionNamespaces", a => a.SelectionNamespaces, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -1884,11 +1884,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<PivotTableDefinition>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "cacheId", a => a.CacheId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "dataOnRows", a => a.DataOnRows)
 .AddAttribute(0, "dataPosition", a => a.DataPosition)
@@ -1901,7 +1901,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "applyWidthHeightFormats", a => a.ApplyWidthHeightFormats)
 .AddAttribute(0, "dataCaption", a => a.DataCaption, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "grandTotalCaption", a => a.GrandTotalCaption)
 .AddAttribute(0, "errorCaption", a => a.ErrorCaption)
@@ -2532,7 +2532,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<QueryTable>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "headers", a => a.Headers)
 .AddAttribute(0, "rowNumbers", a => a.RowNumbers)
@@ -2549,7 +2549,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "intermediate", a => a.Intermediate)
 .AddAttribute(0, "connectionId", a => a.ConnectionId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "autoFormatId", a => a.AutoFormatId)
 .AddAttribute(0, "applyNumberFormats", a => a.ApplyNumberFormats)
@@ -2936,12 +2936,12 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Headers>()
 .AddAttribute(0, "guid", a => a.Guid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "lastGuid", a => a.LastGuid, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "shared", a => a.Shared)
 .AddAttribute(0, "diskRevisions", a => a.DiskRevisions)
@@ -5053,17 +5053,17 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<Table>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name)
 .AddAttribute(0, "displayName", a => a.DisplayName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "comment", a => a.Comment)
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "tableType", a => a.TableType)
 .AddAttribute(0, "headerRowCount", a => a.HeaderRowCount)
@@ -5760,7 +5760,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<FilterColumn>()
 .AddAttribute(0, "colId", a => a.ColumnId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "hiddenButton", a => a.HiddenButton)
 .AddAttribute(0, "showButton", a => a.ShowButton);
@@ -6001,7 +6001,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "sortMethod", a => a.SortMethod)
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -6217,7 +6217,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<CalculationCell>()
  .AddAttribute(0, "r", a => a.CellReference, aBuilder =>
  {
-     aBuilder.AddValidator(new RequiredValidatorAttribute());
+     aBuilder.AddValidator(new RequiredValidator());
  })
  .AddAttribute(0, "i", a => a.SheetId)
  .AddAttribute(0, "s", a => a.InChildChain)
@@ -6456,19 +6456,19 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Comment>()
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "authorId", a => a.AuthorId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "guid", a => a.Guid, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "shapeId", a => a.ShapeId, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -7195,7 +7195,7 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<Schema>()
 .AddAttribute(0, "ID", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "SchemaRef", a => a.SchemaReference)
 .AddAttribute(0, "Namespace", a => a.Namespace);
@@ -7363,39 +7363,39 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Map>()
 .AddAttribute(0, "ID", a => a.ID, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "Name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "RootElement", a => a.RootElement, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "SchemaID", a => a.SchemaId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "ShowImportExportValidationErrors", a => a.ShowImportExportErrors, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "AutoFit", a => a.AutoFit, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "Append", a => a.AppendData, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "PreserveSortAFLayout", a => a.PreserveAutoFilterState, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "PreserveFormat", a => a.PreserveFormat, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -7531,7 +7531,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "FileBindingName", a => a.FileBindingName)
 .AddAttribute(0, "DataBindingLoadMode", a => a.DataBindingLoadMode, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -7822,7 +7822,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Connection>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "sourceFile", a => a.SourceFile)
 .AddAttribute(0, "odcFile", a => a.ConnectionFile)
@@ -7834,7 +7834,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "reconnectionMethod", a => a.ReconnectionMethod)
 .AddAttribute(0, "refreshedVersion", a => a.RefreshedVersion, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "minRefreshableVersion", a => a.MinRefreshableVersion)
 .AddAttribute(0, "savePassword", a => a.SavePassword)
@@ -8236,7 +8236,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<CharacterValue>()
  .AddAttribute(0, "v", a => a.Val, aBuilder =>
  {
-     aBuilder.AddValidator(new RequiredValidatorAttribute());
+     aBuilder.AddValidator(new RequiredValidator());
  });
         }
 
@@ -8275,7 +8275,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<FieldItem>()
  .AddAttribute(0, "v", a => a.Val, aBuilder =>
  {
-     aBuilder.AddValidator(new RequiredValidatorAttribute());
+     aBuilder.AddValidator(new RequiredValidator());
  });
         }
 
@@ -8524,7 +8524,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<CacheField>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "caption", a => a.Caption)
 .AddAttribute(0, "propertyName", a => a.PropertyName)
@@ -8839,7 +8839,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<PageItem>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -9139,11 +9139,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "in", a => a.FormatIndex)
 .AddAttribute(0, "bc", a => a.BackgroundColor, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(0, "fc", a => a.ForegroundColor, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(0, "i", a => a.Italic)
 .AddAttribute(0, "un", a => a.Underline)
@@ -9344,7 +9344,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
             builder.AddElement<NumberItem>()
 .AddAttribute(0, "v", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "u", a => a.Unused)
 .AddAttribute(0, "f", a => a.Calculated)
@@ -9353,11 +9353,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "in", a => a.FormatIndex)
 .AddAttribute(0, "bc", a => a.BackgroundColor, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(0, "fc", a => a.ForegroundColor, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(0, "i", a => a.Italic)
 .AddAttribute(0, "un", a => a.Underline)
@@ -9487,7 +9487,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
             builder.AddElement<BooleanItem>()
 .AddAttribute(0, "v", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "u", a => a.Unused)
 .AddAttribute(0, "f", a => a.Calculated)
@@ -9686,7 +9686,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ErrorItem>()
 .AddAttribute(0, "v", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "u", a => a.Unused)
 .AddAttribute(0, "f", a => a.Calculated)
@@ -9695,11 +9695,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "in", a => a.FormatIndex)
 .AddAttribute(0, "bc", a => a.BackgroundColor, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(0, "fc", a => a.ForegroundColor, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(0, "i", a => a.Italic)
 .AddAttribute(0, "un", a => a.Underline)
@@ -9913,7 +9913,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
             builder.AddElement<StringItem>()
 .AddAttribute(0, "v", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "u", a => a.Unused)
 .AddAttribute(0, "f", a => a.Calculated)
@@ -9922,11 +9922,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "in", a => a.FormatIndex)
 .AddAttribute(0, "bc", a => a.BackgroundColor, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(0, "fc", a => a.ForegroundColor, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(0, "i", a => a.Italic)
 .AddAttribute(0, "un", a => a.Underline)
@@ -10055,7 +10055,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
             builder.AddElement<DateTimeItem>()
 .AddAttribute(0, "v", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "u", a => a.Unused)
 .AddAttribute(0, "f", a => a.Calculated)
@@ -10552,18 +10552,18 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Kpi>()
 .AddAttribute(0, "uniqueName", a => a.UniqueName, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "caption", a => a.Caption, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "displayFolder", a => a.DisplayFolder)
 .AddAttribute(0, "measureGroup", a => a.MeasureGroup)
 .AddAttribute(0, "parent", a => a.ParentKpi)
 .AddAttribute(0, "value", a => a.Value, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "goal", a => a.Goal)
 .AddAttribute(0, "status", a => a.Status)
@@ -10621,7 +10621,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<FieldUsage>()
 .AddAttribute(0, "x", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -10730,11 +10730,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<GroupLevel>()
 .AddAttribute(0, "uniqueName", a => a.UniqueName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "caption", a => a.Caption, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "user", a => a.User)
 .AddAttribute(0, "customRollUp", a => a.CustomRollUp);
@@ -10960,15 +10960,15 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Group>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uniqueName", a => a.UniqueName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "caption", a => a.Caption, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uniqueParent", a => a.UniqueParent)
 .AddAttribute(0, "id", a => a.Id);
@@ -11122,7 +11122,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<GroupMember>()
 .AddAttribute(0, "uniqueName", a => a.UniqueName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "group", a => a.Group);
         }
@@ -11551,7 +11551,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "hier", a => a.Hierarchy)
 .AddAttribute(0, "item", a => a.Item, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -11672,11 +11672,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "count", a => a.Count)
 .AddAttribute(0, "maxRank", a => a.MaxRank, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "setDefinition", a => a.SetDefinition, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "sortType", a => a.SortType)
 .AddAttribute(0, "queryFailed", a => a.QueryFailed);
@@ -11763,7 +11763,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Query>()
 .AddAttribute(0, "mdx", a => a.Mdx, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -12263,11 +12263,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<CalculatedMember>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "mdx", a => a.Mdx, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "memberName", a => a.MemberName)
 .AddAttribute(0, "hierarchy", a => a.Hierarchy)
@@ -13233,7 +13233,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "name", a => a.Name)
 .AddAttribute(0, "fld", a => a.Field, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "subtotal", a => a.Subtotal)
 .AddAttribute(0, "showDataAs", a => a.ShowDataAs)
@@ -13405,7 +13405,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Field>()
 .AddAttribute(0, "x", a => a.Index, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
+ aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -13625,7 +13625,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "type", a => a.Type)
 .AddAttribute(0, "priority", a => a.Priority, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -13829,11 +13829,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ChartFormat>()
 .AddAttribute(0, "chart", a => a.Chart, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "format", a => a.Format, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "series", a => a.Series);
         }
@@ -14149,7 +14149,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<HierarchyUsageType>()
                            .AddAttribute(0, "hierarchyUsage", a => a.Value, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -14273,7 +14273,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "level", a => a.Level)
 .AddAttribute(0, "field", a => a.Field, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidatorAttribute());
+    aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -14318,7 +14318,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Member>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -14388,15 +14388,15 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "measure", a => a.Measure)
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uniqueName", a => a.UniqueName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "caption", a => a.Caption, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -14454,11 +14454,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<MeasureGroup>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "caption", a => a.Caption, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -14514,11 +14514,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<MeasureDimensionMap>()
 .AddAttribute(0, "measureGroup", a => a.MeasureGroup, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "dimension", a => a.Dimension, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -14690,17 +14690,17 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<PivotFilter>()
 .AddAttribute(0, "fld", a => a.Field, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "mpFld", a => a.MemberPropertyFieldId)
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "evalOrder", a => a.EvaluationOrder)
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "iMeasureHier", a => a.MeasureHierarchy)
 .AddAttribute(0, "iMeasureFld", a => a.MeasureField)
@@ -15033,7 +15033,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<CacheHierarchy>()
 .AddAttribute(0, "uniqueName", a => a.UniqueName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "caption", a => a.Caption)
 .AddAttribute(0, "measure", a => a.Measure)
@@ -15052,7 +15052,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "measures", a => a.Measures)
 .AddAttribute(0, "count", a => a.Count, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "oneField", a => a.OneField)
 .AddAttribute(0, "memberValueDatatype", a => a.MemberValueDatatype)
@@ -15508,7 +15508,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<PageField>()
 .AddAttribute(0, "fld", a => a.Field, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "item", a => a.Item)
 .AddAttribute(0, "hier", a => a.Hierarchy)
@@ -16053,7 +16053,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<DeletedField>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -16189,7 +16189,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<QueryTableField>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name)
 .AddAttribute(0, "dataBound", a => a.DataBound)
@@ -16772,7 +16772,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<VerticalTextAlignment>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -16811,7 +16811,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<FontSize>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidatorAttribute());
+    aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -17020,7 +17020,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
                            .AddAttribute(0, "indexed", a => a.Indexed)
                            .AddAttribute(0, "rgb", a => a.Rgb, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+                               aBuilder.AddValidator(new StringValidator() { Length = (4L) });
                            })
                            .AddAttribute(0, "theme", a => a.Theme)
                            .AddAttribute(0, "tint", a => a.Tint);
@@ -17058,7 +17058,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RunFont>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
+ aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -17162,7 +17162,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<InternationalPropertyType>()
                            .AddAttribute(0, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -17198,7 +17198,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<FontScheme>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -17473,11 +17473,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<PhoneticRun>()
 .AddAttribute(0, "sb", a => a.BaseTextStartIndex, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "eb", a => a.EndingBaseIndex, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -17562,7 +17562,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<PhoneticProperties>()
 .AddAttribute(0, "fontId", a => a.FontId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "type", a => a.Type)
 .AddAttribute(0, "alignment", a => a.Alignment);
@@ -17707,24 +17707,24 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Header>()
 .AddAttribute(0, "guid", a => a.Guid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "dateTime", a => a.DateTime, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "maxSheetId", a => a.MaxSheetId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "userName", a => a.UserName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "minRId", a => a.MinRevisionId)
 .AddAttribute(0, "maxRId", a => a.MaxRevisionId);
@@ -17926,22 +17926,22 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RevisionRowColumn>()
 .AddAttribute(0, "rId", a => a.RevisionId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "ua", a => a.Ua)
 .AddAttribute(0, "ra", a => a.Ra)
 .AddAttribute(0, "sId", a => a.SheetId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "eol", a => a.EndOfList)
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "action", a => a.Action, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "edge", a => a.Edge);
         }
@@ -18091,21 +18091,21 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RevisionMove>()
 .AddAttribute(0, "rId", a => a.RevisionId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "ua", a => a.Ua)
 .AddAttribute(0, "ra", a => a.Ra)
 .AddAttribute(0, "sheetId", a => a.SheetId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "source", a => a.Source, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "destination", a => a.Destination, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "sourceSheetId", a => a.SourceSheetId);
         }
@@ -18171,12 +18171,12 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RevisionCustomView>()
 .AddAttribute(0, "guid", a => a.Guid, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "action", a => a.Action, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -18296,21 +18296,21 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RevisionSheetName>()
 .AddAttribute(0, "rId", a => a.RevisionId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "ua", a => a.Ua)
 .AddAttribute(0, "ra", a => a.Ra)
 .AddAttribute(0, "sheetId", a => a.SheetId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "oldName", a => a.OldName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "newName", a => a.NewName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -18425,21 +18425,21 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RevisionInsertSheet>()
 .AddAttribute(0, "rId", a => a.RevisionId, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "ua", a => a.Ua)
 .AddAttribute(0, "ra", a => a.Ra)
 .AddAttribute(0, "sheetId", a => a.SheetId, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "sheetPosition", a => a.SheetPosition, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -18654,13 +18654,13 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RevisionCellChange>()
 .AddAttribute(0, "rId", a => a.RevisionId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "ua", a => a.Ua)
 .AddAttribute(0, "ra", a => a.Ra)
 .AddAttribute(0, "sId", a => a.SheetId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "odxf", a => a.OldFormatting)
 .AddAttribute(0, "xfDxf", a => a.RowColumnFormattingAffected)
@@ -18874,13 +18874,13 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RevisionFormat>()
 .AddAttribute(0, "sheetId", a => a.SheetId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "xfDxf", a => a.RowOrColumnAffected)
 .AddAttribute(0, "s", a => a.StyleAffected)
 .AddAttribute(0, "sqref", a => a.SequenceOfReferences, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "start", a => a.Start)
 .AddAttribute(0, "length", a => a.Length);
@@ -19041,7 +19041,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RevisionAutoFormat>()
 .AddAttribute(0, "sheetId", a => a.SheetId, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "autoFormatId", a => a.AutoFormatId)
 .AddAttribute(0, "applyNumberFormats", a => a.ApplyNumberFormats)
@@ -19052,7 +19052,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "applyWidthHeightFormats", a => a.ApplyWidthHeightFormats)
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -19363,7 +19363,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RevisionDefinedName>()
 .AddAttribute(0, "rId", a => a.RevisionId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "ua", a => a.Ua)
 .AddAttribute(0, "ra", a => a.Ra)
@@ -19371,7 +19371,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "customView", a => a.CustomView)
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "function", a => a.Function)
 .AddAttribute(0, "oldFunction", a => a.OldFunction)
@@ -19596,16 +19596,16 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RevisionComment>()
 .AddAttribute(0, "sheetId", a => a.SheetId, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "cell", a => a.Cell, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "guid", a => a.Guid, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
-  aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "action", a => a.Action)
 .AddAttribute(0, "alwaysShow", a => a.AlwaysShow)
@@ -19614,7 +19614,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "hiddenColumn", a => a.HiddenColumn)
 .AddAttribute(0, "author", a => a.Author, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "oldLength", a => a.OldLength)
 .AddAttribute(0, "newLength", a => a.NewLength);
@@ -19681,15 +19681,15 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RevisionQueryTable>()
 .AddAttribute(0, "sheetId", a => a.SheetId, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "fieldId", a => a.FieldId, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -19758,7 +19758,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RevisionConflict>()
 .AddAttribute(0, "rId", a => a.RevisionId, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "ua", a => a.Ua)
 .AddAttribute(0, "ra", a => a.Ra)
@@ -19954,7 +19954,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Reviewed>()
 .AddAttribute(0, "rId", a => a.RevisionId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -20099,11 +20099,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Undo>()
 .AddAttribute(0, "index", a => a.Index, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "exp", a => a.Expression, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "ref3D", a => a.Reference3D)
 .AddAttribute(0, "array", a => a.Array)
@@ -20112,7 +20112,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "cs", a => a.CrossSheetMove)
 .AddAttribute(0, "dr", a => a.DeletedRange, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "dn", a => a.DefinedName)
 .AddAttribute(0, "r", a => a.CellReference)
@@ -20579,7 +20579,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<NewCell>()
 .AddAttribute(0, "r", a => a.CellReference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "s", a => a.StyleIndex)
 .AddAttribute(0, "t", a => a.DataType)
@@ -21066,7 +21066,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<SheetId>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -21363,20 +21363,20 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<UserInfo>()
 .AddAttribute(0, "guid", a => a.Guid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "dateTime", a => a.DateTime, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -21603,7 +21603,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "ph", a => a.ShowPhonetic)
 .AddAttribute(55, "dyDescent", a => a.DyDescent, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -21748,11 +21748,11 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<Column>()
 .AddAttribute(0, "min", a => a.Min, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "max", a => a.Max, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "width", a => a.Width)
 .AddAttribute(0, "style", a => a.Style)
@@ -22292,7 +22292,7 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
 .AddAttribute(0, "click", a => a.Click)
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -22779,27 +22779,27 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<PageMargins>()
 .AddAttribute(0, "left", a => a.Left, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "right", a => a.Right, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "top", a => a.Top, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "bottom", a => a.Bottom, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "header", a => a.Header, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "footer", a => a.Footer, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -23593,12 +23593,12 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ConditionalFormattingRule>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "dxfId", a => a.FormatId)
 .AddAttribute(0, "priority", a => a.Priority, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "stopIfTrue", a => a.StopIfTrue)
 .AddAttribute(0, "aboveAverage", a => a.AboveAverage)
@@ -23709,7 +23709,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Hyperlink>()
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(19, "id", a => a.Id)
 .AddAttribute(0, "location", a => a.Location)
@@ -23812,7 +23812,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ConditionalFormatValueObject>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "val", a => a.Val)
 .AddAttribute(0, "gte", a => a.GreaterThanOrEqual);
@@ -23954,7 +23954,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Scenario>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "locked", a => a.Locked)
 .AddAttribute(0, "hidden", a => a.Hidden)
@@ -24085,7 +24085,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ProtectedRange>()
 .AddAttribute(0, "password", a => a.Password, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
+aBuilder.AddValidator(new StringValidator() { Length = (2L) });
 })
 .AddAttribute(0, "algorithmName", a => a.AlgorithmName)
 .AddAttribute(0, "hashValue", a => a.HashValue)
@@ -24093,11 +24093,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
 .AddAttribute(0, "spinCount", a => a.SpinCount)
 .AddAttribute(0, "sqref", a => a.SequenceOfReferences, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "securityDescriptor", a => a.SecurityDescriptor);
         }
@@ -24145,7 +24145,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<CellWatch>()
 .AddAttribute(0, "r", a => a.CellReference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -24360,11 +24360,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<CustomProperty>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -24479,21 +24479,21 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<WebPublishItem>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "divId", a => a.DivId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "sourceType", a => a.SourceType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "sourceRef", a => a.SourceRef)
 .AddAttribute(0, "sourceObject", a => a.SourceObject)
 .AddAttribute(0, "destinationFile", a => a.DestinationFile, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "title", a => a.Title)
 .AddAttribute(0, "autoRepublish", a => a.AutoRepublish);
@@ -24549,7 +24549,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TablePart>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -24651,7 +24651,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "zoomScale", a => a.ZoomScale)
 .AddAttribute(0, "workbookViewId", a => a.WorkbookViewId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "zoomToFit", a => a.ZoomToFit);
         }
@@ -24783,8 +24783,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<CustomChartsheetView>()
 .AddAttribute(0, "guid", a => a.Guid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "scale", a => a.Scale)
 .AddAttribute(0, "state", a => a.State)
@@ -24920,13 +24920,13 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
             builder.AddElement<InputCells>()
 .AddAttribute(0, "r", a => a.CellReference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "deleted", a => a.Deleted)
 .AddAttribute(0, "undone", a => a.Undone)
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "numFmtId", a => a.NumberFormatId);
         }
@@ -25026,11 +25026,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Control>()
 .AddAttribute(0, "shapeId", a => a.ShapeId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "name", a => a.Name);
         }
@@ -25188,7 +25188,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<IgnoredError>()
 .AddAttribute(0, "sqref", a => a.SequenceOfReferences, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "evalError", a => a.EvalError)
 .AddAttribute(0, "twoDigitTextYear", a => a.TwoDigitTextYear)
@@ -25242,7 +25242,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<MergeCell>()
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -25448,7 +25448,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "prompt", a => a.Prompt)
 .AddAttribute(0, "sqref", a => a.SequenceOfReferences, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -25778,7 +25778,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "zoomScalePageLayoutView", a => a.ZoomScalePageLayoutView)
 .AddAttribute(0, "workbookViewId", a => a.WorkbookViewId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -26089,8 +26089,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<CustomSheetView>()
 .AddAttribute(0, "guid", a => a.Guid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "scale", a => a.Scale)
 .AddAttribute(0, "colorId", a => a.ColorId)
@@ -26400,7 +26400,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
 .AddAttribute(0, "autoLoad", a => a.AutoLoad)
 .AddAttribute(0, "shapeId", a => a.ShapeId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(19, "id", a => a.Id);
         }
@@ -26751,7 +26751,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<FutureMetadata>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "count", a => a.Count);
         }
@@ -27275,11 +27275,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<MetadataType>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "minSupportedVersion", a => a.MinSupportedVersion, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "ghostRow", a => a.GhostRow)
 .AddAttribute(0, "ghostCol", a => a.GhostColumn)
@@ -27423,11 +27423,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<MetadataRecord>()
 .AddAttribute(0, "t", a => a.TypeIndex, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidatorAttribute());
+    aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "v", a => a.Val, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidatorAttribute());
+    aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -27595,11 +27595,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Mdx>()
 .AddAttribute(0, "n", a => a.NameIndex, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "f", a => a.CubeFunction, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -27832,11 +27832,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "fi", a => a.FormatIndex)
 .AddAttribute(0, "bc", a => a.BackgroundColor, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(0, "fc", a => a.ForegroundColor, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(0, "i", a => a.Italic)
 .AddAttribute(0, "u", a => a.Underline)
@@ -27946,7 +27946,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
             builder.AddElement<MdxSet>()
 .AddAttribute(0, "ns", a => a.SetDefinitionIndex, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "c", a => a.MemberIndexCount)
 .AddAttribute(0, "o", a => a.SortingOrder);
@@ -28012,11 +28012,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<MdxMemberProp>()
  .AddAttribute(0, "n", a => a.NameIndex, aBuilder =>
  {
-     aBuilder.AddValidator(new RequiredValidatorAttribute());
+     aBuilder.AddValidator(new RequiredValidator());
  })
  .AddAttribute(0, "np", a => a.PropertyNameIndex, aBuilder =>
  {
-     aBuilder.AddValidator(new RequiredValidatorAttribute());
+     aBuilder.AddValidator(new RequiredValidator());
  });
         }
 
@@ -28084,15 +28084,15 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<MdxKpi>()
  .AddAttribute(0, "n", a => a.NameIndex, aBuilder =>
  {
-     aBuilder.AddValidator(new RequiredValidatorAttribute());
+     aBuilder.AddValidator(new RequiredValidator());
  })
  .AddAttribute(0, "np", a => a.KpiIndex, aBuilder =>
  {
-     aBuilder.AddValidator(new RequiredValidatorAttribute());
+     aBuilder.AddValidator(new RequiredValidator());
  })
  .AddAttribute(0, "p", a => a.KpiProperty, aBuilder =>
  {
-     aBuilder.AddValidator(new RequiredValidatorAttribute());
+     aBuilder.AddValidator(new RequiredValidator());
  });
         }
 
@@ -28150,7 +28150,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<NameIndex>()
  .AddAttribute(0, "x", a => a.Index, aBuilder =>
  {
-     aBuilder.AddValidator(new RequiredValidatorAttribute());
+     aBuilder.AddValidator(new RequiredValidator());
  })
  .AddAttribute(0, "s", a => a.IsASet);
         }
@@ -28250,15 +28250,15 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<SingleXmlCell>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "r", a => a.CellReference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "connectionId", a => a.ConnectionId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -28382,11 +28382,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<XmlCellProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uniqueName", a => a.UniqueName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -28518,15 +28518,15 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<XmlProperties>()
 .AddAttribute(0, "mapId", a => a.MapId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "xpath", a => a.XPath, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "xmlDataType", a => a.XmlDataType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -28865,7 +28865,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<GradientStop>()
 .AddAttribute(0, "position", a => a.Position, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -28940,11 +28940,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<NumberingFormat>()
 .AddAttribute(0, "numFmtId", a => a.NumberFormatId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "formatCode", a => a.FormatCode, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -29991,7 +29991,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TableStyle>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "pivot", a => a.Pivot)
 .AddAttribute(0, "table", a => a.Table)
@@ -30046,7 +30046,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RgbColor>()
 .AddAttribute(0, "rgb", a => a.Rgb, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 });
         }
 
@@ -30167,7 +30167,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
 .AddAttribute(0, "name", a => a.Name)
 .AddAttribute(0, "xfId", a => a.FormatId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "builtinId", a => a.BuiltinId)
 .AddAttribute(0, "iLevel", a => a.OutlineLevel)
@@ -30501,8 +30501,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<FontName>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
-  aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L) });
+  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(new StringValidator() { MinLength = (1L) });
 });
         }
 
@@ -30547,8 +30547,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<FontFamilyNumbering>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (5L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (5L) });
 });
         }
 
@@ -30587,8 +30587,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<FontCharSet>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (255L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (255L) });
 });
         }
 
@@ -30647,7 +30647,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<TableStyleElement>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "size", a => a.Size)
 .AddAttribute(0, "dxfId", a => a.FormatId);
@@ -30901,7 +30901,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ExternalDefinedName>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "refersTo", a => a.RefersTo)
 .AddAttribute(0, "sheetId", a => a.SheetId);
@@ -30989,7 +30989,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ExternalSheetData>()
 .AddAttribute(0, "sheetId", a => a.SheetId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "refreshError", a => a.RefreshError);
         }
@@ -31073,7 +31073,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ExternalRow>()
 .AddAttribute(0, "r", a => a.RowIndex, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -31176,7 +31176,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ExternalCell>()
 .AddAttribute(0, "r", a => a.CellReference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "t", a => a.DataType)
 .AddAttribute(0, "vm", a => a.ValueMetaIndex);
@@ -31715,7 +31715,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ExternalBook>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -31843,11 +31843,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<DdeLink>()
 .AddAttribute(0, "ddeService", a => a.DdeService, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "ddeTopic", a => a.DdeTopic, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -31957,11 +31957,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<OleLink>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "progId", a => a.ProgId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -32252,12 +32252,12 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TableColumn>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "uniqueName", a => a.UniqueName)
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "totalsRowFunction", a => a.TotalsRowFunction)
 .AddAttribute(0, "totalsRowLabel", a => a.TotalsRowLabel)
@@ -32580,16 +32580,16 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<XmlColumnProperties>()
 .AddAttribute(0, "mapId", a => a.MapId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "xpath", a => a.XPath, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "denormalized", a => a.Denormalized)
 .AddAttribute(0, "xmlDataType", a => a.XmlDataType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -32687,7 +32687,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<VolatileType>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -32764,7 +32764,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Main>()
 .AddAttribute(0, "first", a => a.First, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -32919,11 +32919,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TopicReferences>()
 .AddAttribute(0, "r", a => a.CellReference, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidatorAttribute());
+    aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "s", a => a.SheetId, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidatorAttribute());
+    aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -32981,11 +32981,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<PivotCache>()
 .AddAttribute(0, "cacheId", a => a.CacheId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -33081,16 +33081,16 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<WebPublishObject>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "divId", a => a.DivId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "sourceObject", a => a.SourceObject)
 .AddAttribute(0, "destinationFile", a => a.DestinationFile, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "title", a => a.Title)
 .AddAttribute(0, "autoRepublish", a => a.AutoRepublish);
@@ -33144,7 +33144,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ExternalReference>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -33444,12 +33444,12 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<CustomWorkbookView>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "guid", a => a.Guid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "autoUpdate", a => a.AutoUpdate)
 .AddAttribute(0, "mergeInterval", a => a.MergeInterval)
@@ -33470,7 +33470,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
 .AddAttribute(0, "tabRatio", a => a.TabRatio)
 .AddAttribute(0, "activeSheetId", a => a.ActiveSheetId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "showFormulaBar", a => a.ShowFormulaBar)
 .AddAttribute(0, "showStatusbar", a => a.ShowStatusbar)
@@ -33576,16 +33576,16 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Sheet>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
+ aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "sheetId", a => a.SheetId, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
+ aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "state", a => a.State)
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
+ aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -34017,7 +34017,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<DefinedName>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "comment", a => a.Comment)
 .AddAttribute(0, "customMenu", a => a.CustomMenu)
@@ -34078,7 +34078,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<FunctionGroup>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -34154,8 +34154,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TableExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -34604,8 +34604,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<ConditionalFormattingRuleExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -34683,8 +34683,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<PivotHierarchyExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -34762,8 +34762,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<PivotFieldExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -34841,8 +34841,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<CacheSourceExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -35141,7 +35141,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<OleItem>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "icon", a => a.Icon)
 .AddAttribute(0, "advise", a => a.Advise)
@@ -36504,7 +36504,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ChartSheetProtection>()
 .AddAttribute(0, "password", a => a.Password, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
+aBuilder.AddValidator(new StringValidator() { Length = (2L) });
 })
 .AddAttribute(0, "algorithmName", a => a.AlgorithmName)
 .AddAttribute(0, "hashValue", a => a.HashValue)
@@ -36614,7 +36614,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
             builder.AddElement<Drawing>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -36715,7 +36715,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<LegacyDrawingType>()
                            .AddAttribute(19, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -36934,7 +36934,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<DrawingHeaderFooter>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "lho", a => a.Lho)
 .AddAttribute(0, "lhe", a => a.Lhe)
@@ -36994,7 +36994,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Picture>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -37894,7 +37894,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "defaultColWidth", a => a.DefaultColumnWidth)
 .AddAttribute(0, "defaultRowHeight", a => a.DefaultRowHeight, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "customHeight", a => a.CustomHeight)
 .AddAttribute(0, "zeroHeight", a => a.ZeroHeight)
@@ -37904,7 +37904,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "outlineLevelCol", a => a.OutlineLevelColumn)
 .AddAttribute(55, "dyDescent", a => a.DyDescent, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -38152,7 +38152,7 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<SheetProtection>()
 .AddAttribute(0, "password", a => a.Password, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
+aBuilder.AddValidator(new StringValidator() { Length = (2L) });
 })
 .AddAttribute(0, "algorithmName", a => a.AlgorithmName)
 .AddAttribute(0, "hashValue", a => a.HashValue)
@@ -38397,7 +38397,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
             builder.AddElement<SheetDimension>()
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -38633,7 +38633,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "leftLabels", a => a.LeftLabels)
 .AddAttribute(0, "startLabels", a => a.StartLabels, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(0, "topLabels", a => a.TopLabels)
 .AddAttribute(0, "link", a => a.Link);
@@ -39831,7 +39831,7 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
 .AddAttribute(0, "sortBy", a => a.SortBy)
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "customList", a => a.CustomList)
 .AddAttribute(0, "dxfId", a => a.FormatId)
@@ -39874,7 +39874,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Filter>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -39973,7 +39973,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<DateGroupItem>()
 .AddAttribute(0, "year", a => a.Year, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "month", a => a.Month)
 .AddAttribute(0, "day", a => a.Day)
@@ -39982,7 +39982,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "second", a => a.Second)
 .AddAttribute(0, "dateTimeGrouping", a => a.DateTimeGrouping, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -40155,7 +40155,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(0, "percent", a => a.Percent)
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
+ aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "filterVal", a => a.FilterValue);
         }
@@ -40309,17 +40309,17 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<DynamicFilter>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "val", a => a.Val)
 .AddAttribute(0, "maxVal", a => a.MaxVal)
 .AddAttribute(0, "valIso", a => a.ValIso, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(0, "maxValIso", a => a.MaxValIso, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -40368,7 +40368,7 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<ColorFilter>()
 .AddAttribute(0, "dxfId", a => a.FormatId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "cellColor", a => a.CellColor);
         }
@@ -40424,7 +40424,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<IconFilter>()
 .AddAttribute(0, "iconSet", a => a.IconSet, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "iconId", a => a.IconId);
         }
@@ -40499,8 +40499,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<SlicerCacheDefinitionExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -40582,8 +40582,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<PivotFilterExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -40662,8 +40662,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<QueryTableExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -40740,7 +40740,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<DatabaseProperties>()
 .AddAttribute(0, "connection", a => a.Connection, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "command", a => a.Command)
 .AddAttribute(0, "serverCommand", a => a.ServerCommand)
@@ -41575,8 +41575,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<ConnectionExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -41743,7 +41743,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<CacheSource>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "connectionId", a => a.ConnectionId);
         }
@@ -42668,8 +42668,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<PivotCacheDefinitionExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -43148,8 +43148,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<CacheFieldExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -43440,8 +43440,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<CacheHierarchyExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -43584,8 +43584,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<CalculatedMemberExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -43683,19 +43683,19 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<Location>()
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "firstHeaderRow", a => a.FirstHeaderRow, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "firstDataRow", a => a.FirstDataRow, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "firstDataCol", a => a.FirstDataColumn, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "rowPageCount", a => a.RowPageCount)
 .AddAttribute(0, "colPageCount", a => a.ColumnsPerPage);
@@ -44966,8 +44966,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<PivotTableDefinitionExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -45111,8 +45111,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<DataFieldExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -46247,8 +46247,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
             builder.AddElement<WorksheetExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -46421,7 +46421,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "count", a => a.Count)
 .AddAttribute(55, "knownFonts", a => a.KnownFonts, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -47203,8 +47203,8 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<StylesheetExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 
@@ -47298,7 +47298,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
 .AddAttribute(0, "rupBuild", a => a.BuildVersion)
 .AddAttribute(0, "codeName", a => a.CodeName, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
 
@@ -47408,7 +47408,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern
 .AddAttribute(0, "userName", a => a.UserName)
 .AddAttribute(0, "reservationPassword", a => a.ReservationPassword, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
+aBuilder.AddValidator(new StringValidator() { Length = (2L) });
 })
 .AddAttribute(0, "algorithmName", a => a.AlgorithmName)
 .AddAttribute(0, "hashValue", a => a.HashValue)
@@ -47638,7 +47638,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
 .AddAttribute(0, "date1904", a => a.Date1904)
 .AddAttribute(0, "dateCompatibility", a => a.DateCompatibility, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(0, "showObjects", a => a.ShowObjects)
 .AddAttribute(0, "showBorderUnselectedTables", a => a.ShowBorderUnselectedTables)
@@ -47814,11 +47814,11 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<WorkbookProtection>()
 .AddAttribute(0, "workbookPassword", a => a.WorkbookPassword, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
+aBuilder.AddValidator(new StringValidator() { Length = (2L) });
 })
 .AddAttribute(0, "revisionsPassword", a => a.RevisionsPassword, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
+aBuilder.AddValidator(new StringValidator() { Length = (2L) });
 })
 .AddAttribute(0, "lockStructure", a => a.LockStructure)
 .AddAttribute(0, "lockWindows", a => a.LockWindows)
@@ -48364,7 +48364,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
             builder.AddElement<OleSize>()
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -48907,8 +48907,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<WorkbookExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_spreadsheetml_2006_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_spreadsheetml_2006_main.g.cs
@@ -73,7 +73,7 @@ namespace DocumentFormat.OpenXml.Spreadsheet
             builder.AddElement<Extension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -387,7 +387,7 @@ namespace DocumentFormat.OpenXml.Spreadsheet
             builder.AddElement<MapInfo>()
 .AddAttribute(0, "SelectionNamespaces", a => a.SelectionNamespaces, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -1884,11 +1884,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<PivotTableDefinition>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "cacheId", a => a.CacheId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "dataOnRows", a => a.DataOnRows)
 .AddAttribute(0, "dataPosition", a => a.DataPosition)
@@ -1901,7 +1901,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "applyWidthHeightFormats", a => a.ApplyWidthHeightFormats)
 .AddAttribute(0, "dataCaption", a => a.DataCaption, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "grandTotalCaption", a => a.GrandTotalCaption)
 .AddAttribute(0, "errorCaption", a => a.ErrorCaption)
@@ -2532,7 +2532,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<QueryTable>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "headers", a => a.Headers)
 .AddAttribute(0, "rowNumbers", a => a.RowNumbers)
@@ -2549,7 +2549,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "intermediate", a => a.Intermediate)
 .AddAttribute(0, "connectionId", a => a.ConnectionId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "autoFormatId", a => a.AutoFormatId)
 .AddAttribute(0, "applyNumberFormats", a => a.ApplyNumberFormats)
@@ -2936,7 +2936,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Headers>()
 .AddAttribute(0, "guid", a => a.Guid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "lastGuid", a => a.LastGuid, aBuilder =>
@@ -5053,17 +5053,17 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<Table>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name)
 .AddAttribute(0, "displayName", a => a.DisplayName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "comment", a => a.Comment)
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "tableType", a => a.TableType)
 .AddAttribute(0, "headerRowCount", a => a.HeaderRowCount)
@@ -5760,7 +5760,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<FilterColumn>()
 .AddAttribute(0, "colId", a => a.ColumnId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "hiddenButton", a => a.HiddenButton)
 .AddAttribute(0, "showButton", a => a.ShowButton);
@@ -6001,7 +6001,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "sortMethod", a => a.SortMethod)
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -6217,7 +6217,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<CalculationCell>()
  .AddAttribute(0, "r", a => a.CellReference, aBuilder =>
  {
-     aBuilder.AddValidator(new RequiredValidator());
+     aBuilder.AddValidator(RequiredValidator.Instance);
  })
  .AddAttribute(0, "i", a => a.SheetId)
  .AddAttribute(0, "s", a => a.InChildChain)
@@ -6456,11 +6456,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Comment>()
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "authorId", a => a.AuthorId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "guid", a => a.Guid, aBuilder =>
 {
@@ -7195,7 +7195,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
             builder.AddElement<Schema>()
 .AddAttribute(0, "ID", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "SchemaRef", a => a.SchemaReference)
 .AddAttribute(0, "Namespace", a => a.Namespace);
@@ -7363,39 +7363,39 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Map>()
 .AddAttribute(0, "ID", a => a.ID, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "Name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "RootElement", a => a.RootElement, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "SchemaID", a => a.SchemaId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "ShowImportExportValidationErrors", a => a.ShowImportExportErrors, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "AutoFit", a => a.AutoFit, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "Append", a => a.AppendData, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "PreserveSortAFLayout", a => a.PreserveAutoFilterState, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "PreserveFormat", a => a.PreserveFormat, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -7531,7 +7531,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "FileBindingName", a => a.FileBindingName)
 .AddAttribute(0, "DataBindingLoadMode", a => a.DataBindingLoadMode, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -7822,7 +7822,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Connection>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "sourceFile", a => a.SourceFile)
 .AddAttribute(0, "odcFile", a => a.ConnectionFile)
@@ -7834,7 +7834,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "reconnectionMethod", a => a.ReconnectionMethod)
 .AddAttribute(0, "refreshedVersion", a => a.RefreshedVersion, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "minRefreshableVersion", a => a.MinRefreshableVersion)
 .AddAttribute(0, "savePassword", a => a.SavePassword)
@@ -8236,7 +8236,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<CharacterValue>()
  .AddAttribute(0, "v", a => a.Val, aBuilder =>
  {
-     aBuilder.AddValidator(new RequiredValidator());
+     aBuilder.AddValidator(RequiredValidator.Instance);
  });
         }
 
@@ -8275,7 +8275,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<FieldItem>()
  .AddAttribute(0, "v", a => a.Val, aBuilder =>
  {
-     aBuilder.AddValidator(new RequiredValidator());
+     aBuilder.AddValidator(RequiredValidator.Instance);
  });
         }
 
@@ -8524,7 +8524,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<CacheField>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "caption", a => a.Caption)
 .AddAttribute(0, "propertyName", a => a.PropertyName)
@@ -8839,7 +8839,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<PageItem>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -9344,7 +9344,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
             builder.AddElement<NumberItem>()
 .AddAttribute(0, "v", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "u", a => a.Unused)
 .AddAttribute(0, "f", a => a.Calculated)
@@ -9487,7 +9487,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
             builder.AddElement<BooleanItem>()
 .AddAttribute(0, "v", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "u", a => a.Unused)
 .AddAttribute(0, "f", a => a.Calculated)
@@ -9686,7 +9686,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ErrorItem>()
 .AddAttribute(0, "v", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "u", a => a.Unused)
 .AddAttribute(0, "f", a => a.Calculated)
@@ -9913,7 +9913,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
             builder.AddElement<StringItem>()
 .AddAttribute(0, "v", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "u", a => a.Unused)
 .AddAttribute(0, "f", a => a.Calculated)
@@ -10055,7 +10055,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
             builder.AddElement<DateTimeItem>()
 .AddAttribute(0, "v", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "u", a => a.Unused)
 .AddAttribute(0, "f", a => a.Calculated)
@@ -10552,18 +10552,18 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Kpi>()
 .AddAttribute(0, "uniqueName", a => a.UniqueName, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "caption", a => a.Caption, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "displayFolder", a => a.DisplayFolder)
 .AddAttribute(0, "measureGroup", a => a.MeasureGroup)
 .AddAttribute(0, "parent", a => a.ParentKpi)
 .AddAttribute(0, "value", a => a.Value, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "goal", a => a.Goal)
 .AddAttribute(0, "status", a => a.Status)
@@ -10621,7 +10621,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<FieldUsage>()
 .AddAttribute(0, "x", a => a.Index, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -10730,11 +10730,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<GroupLevel>()
 .AddAttribute(0, "uniqueName", a => a.UniqueName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "caption", a => a.Caption, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "user", a => a.User)
 .AddAttribute(0, "customRollUp", a => a.CustomRollUp);
@@ -10960,15 +10960,15 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Group>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uniqueName", a => a.UniqueName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "caption", a => a.Caption, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uniqueParent", a => a.UniqueParent)
 .AddAttribute(0, "id", a => a.Id);
@@ -11122,7 +11122,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<GroupMember>()
 .AddAttribute(0, "uniqueName", a => a.UniqueName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "group", a => a.Group);
         }
@@ -11551,7 +11551,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "hier", a => a.Hierarchy)
 .AddAttribute(0, "item", a => a.Item, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -11672,11 +11672,11 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "count", a => a.Count)
 .AddAttribute(0, "maxRank", a => a.MaxRank, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "setDefinition", a => a.SetDefinition, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "sortType", a => a.SortType)
 .AddAttribute(0, "queryFailed", a => a.QueryFailed);
@@ -11763,7 +11763,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Query>()
 .AddAttribute(0, "mdx", a => a.Mdx, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -12263,11 +12263,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<CalculatedMember>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "mdx", a => a.Mdx, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "memberName", a => a.MemberName)
 .AddAttribute(0, "hierarchy", a => a.Hierarchy)
@@ -13233,7 +13233,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "name", a => a.Name)
 .AddAttribute(0, "fld", a => a.Field, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "subtotal", a => a.Subtotal)
 .AddAttribute(0, "showDataAs", a => a.ShowDataAs)
@@ -13405,7 +13405,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Field>()
 .AddAttribute(0, "x", a => a.Index, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -13625,7 +13625,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "type", a => a.Type)
 .AddAttribute(0, "priority", a => a.Priority, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -13829,11 +13829,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ChartFormat>()
 .AddAttribute(0, "chart", a => a.Chart, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "format", a => a.Format, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "series", a => a.Series);
         }
@@ -14149,7 +14149,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<HierarchyUsageType>()
                            .AddAttribute(0, "hierarchyUsage", a => a.Value, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -14273,7 +14273,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "level", a => a.Level)
 .AddAttribute(0, "field", a => a.Field, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidator());
+    aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -14318,7 +14318,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Member>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -14388,15 +14388,15 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "measure", a => a.Measure)
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uniqueName", a => a.UniqueName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "caption", a => a.Caption, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -14454,11 +14454,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<MeasureGroup>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "caption", a => a.Caption, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -14514,11 +14514,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<MeasureDimensionMap>()
 .AddAttribute(0, "measureGroup", a => a.MeasureGroup, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "dimension", a => a.Dimension, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -14690,17 +14690,17 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<PivotFilter>()
 .AddAttribute(0, "fld", a => a.Field, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "mpFld", a => a.MemberPropertyFieldId)
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "evalOrder", a => a.EvaluationOrder)
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "iMeasureHier", a => a.MeasureHierarchy)
 .AddAttribute(0, "iMeasureFld", a => a.MeasureField)
@@ -15033,7 +15033,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<CacheHierarchy>()
 .AddAttribute(0, "uniqueName", a => a.UniqueName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "caption", a => a.Caption)
 .AddAttribute(0, "measure", a => a.Measure)
@@ -15052,7 +15052,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "measures", a => a.Measures)
 .AddAttribute(0, "count", a => a.Count, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "oneField", a => a.OneField)
 .AddAttribute(0, "memberValueDatatype", a => a.MemberValueDatatype)
@@ -15508,7 +15508,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<PageField>()
 .AddAttribute(0, "fld", a => a.Field, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "item", a => a.Item)
 .AddAttribute(0, "hier", a => a.Hierarchy)
@@ -16053,7 +16053,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<DeletedField>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -16189,7 +16189,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<QueryTableField>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name)
 .AddAttribute(0, "dataBound", a => a.DataBound)
@@ -16772,7 +16772,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<VerticalTextAlignment>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -16811,7 +16811,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<FontSize>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidator());
+    aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -17058,7 +17058,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RunFont>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -17162,7 +17162,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<InternationalPropertyType>()
                            .AddAttribute(0, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -17198,7 +17198,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<FontScheme>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -17473,11 +17473,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<PhoneticRun>()
 .AddAttribute(0, "sb", a => a.BaseTextStartIndex, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "eb", a => a.EndingBaseIndex, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -17562,7 +17562,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<PhoneticProperties>()
 .AddAttribute(0, "fontId", a => a.FontId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "type", a => a.Type)
 .AddAttribute(0, "alignment", a => a.Alignment);
@@ -17707,24 +17707,24 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Header>()
 .AddAttribute(0, "guid", a => a.Guid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "dateTime", a => a.DateTime, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "maxSheetId", a => a.MaxSheetId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "userName", a => a.UserName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "minRId", a => a.MinRevisionId)
 .AddAttribute(0, "maxRId", a => a.MaxRevisionId);
@@ -17926,22 +17926,22 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RevisionRowColumn>()
 .AddAttribute(0, "rId", a => a.RevisionId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "ua", a => a.Ua)
 .AddAttribute(0, "ra", a => a.Ra)
 .AddAttribute(0, "sId", a => a.SheetId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "eol", a => a.EndOfList)
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "action", a => a.Action, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "edge", a => a.Edge);
         }
@@ -18091,21 +18091,21 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RevisionMove>()
 .AddAttribute(0, "rId", a => a.RevisionId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "ua", a => a.Ua)
 .AddAttribute(0, "ra", a => a.Ra)
 .AddAttribute(0, "sheetId", a => a.SheetId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "source", a => a.Source, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "destination", a => a.Destination, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "sourceSheetId", a => a.SourceSheetId);
         }
@@ -18171,12 +18171,12 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RevisionCustomView>()
 .AddAttribute(0, "guid", a => a.Guid, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "action", a => a.Action, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -18296,21 +18296,21 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RevisionSheetName>()
 .AddAttribute(0, "rId", a => a.RevisionId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "ua", a => a.Ua)
 .AddAttribute(0, "ra", a => a.Ra)
 .AddAttribute(0, "sheetId", a => a.SheetId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "oldName", a => a.OldName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "newName", a => a.NewName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -18425,21 +18425,21 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RevisionInsertSheet>()
 .AddAttribute(0, "rId", a => a.RevisionId, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "ua", a => a.Ua)
 .AddAttribute(0, "ra", a => a.Ra)
 .AddAttribute(0, "sheetId", a => a.SheetId, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "sheetPosition", a => a.SheetPosition, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -18654,13 +18654,13 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RevisionCellChange>()
 .AddAttribute(0, "rId", a => a.RevisionId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "ua", a => a.Ua)
 .AddAttribute(0, "ra", a => a.Ra)
 .AddAttribute(0, "sId", a => a.SheetId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "odxf", a => a.OldFormatting)
 .AddAttribute(0, "xfDxf", a => a.RowColumnFormattingAffected)
@@ -18874,13 +18874,13 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RevisionFormat>()
 .AddAttribute(0, "sheetId", a => a.SheetId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "xfDxf", a => a.RowOrColumnAffected)
 .AddAttribute(0, "s", a => a.StyleAffected)
 .AddAttribute(0, "sqref", a => a.SequenceOfReferences, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "start", a => a.Start)
 .AddAttribute(0, "length", a => a.Length);
@@ -19041,7 +19041,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RevisionAutoFormat>()
 .AddAttribute(0, "sheetId", a => a.SheetId, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "autoFormatId", a => a.AutoFormatId)
 .AddAttribute(0, "applyNumberFormats", a => a.ApplyNumberFormats)
@@ -19052,7 +19052,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "applyWidthHeightFormats", a => a.ApplyWidthHeightFormats)
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -19363,7 +19363,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RevisionDefinedName>()
 .AddAttribute(0, "rId", a => a.RevisionId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "ua", a => a.Ua)
 .AddAttribute(0, "ra", a => a.Ra)
@@ -19371,7 +19371,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "customView", a => a.CustomView)
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "function", a => a.Function)
 .AddAttribute(0, "oldFunction", a => a.OldFunction)
@@ -19596,15 +19596,15 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RevisionComment>()
 .AddAttribute(0, "sheetId", a => a.SheetId, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "cell", a => a.Cell, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "guid", a => a.Guid, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
   aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "action", a => a.Action)
@@ -19614,7 +19614,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "hiddenColumn", a => a.HiddenColumn)
 .AddAttribute(0, "author", a => a.Author, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "oldLength", a => a.OldLength)
 .AddAttribute(0, "newLength", a => a.NewLength);
@@ -19681,15 +19681,15 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RevisionQueryTable>()
 .AddAttribute(0, "sheetId", a => a.SheetId, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "fieldId", a => a.FieldId, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -19758,7 +19758,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RevisionConflict>()
 .AddAttribute(0, "rId", a => a.RevisionId, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "ua", a => a.Ua)
 .AddAttribute(0, "ra", a => a.Ra)
@@ -19954,7 +19954,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Reviewed>()
 .AddAttribute(0, "rId", a => a.RevisionId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -20099,11 +20099,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Undo>()
 .AddAttribute(0, "index", a => a.Index, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "exp", a => a.Expression, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "ref3D", a => a.Reference3D)
 .AddAttribute(0, "array", a => a.Array)
@@ -20112,7 +20112,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "cs", a => a.CrossSheetMove)
 .AddAttribute(0, "dr", a => a.DeletedRange, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "dn", a => a.DefinedName)
 .AddAttribute(0, "r", a => a.CellReference)
@@ -20579,7 +20579,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<NewCell>()
 .AddAttribute(0, "r", a => a.CellReference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "s", a => a.StyleIndex)
 .AddAttribute(0, "t", a => a.DataType)
@@ -21066,7 +21066,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<SheetId>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -21363,20 +21363,20 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<UserInfo>()
 .AddAttribute(0, "guid", a => a.Guid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "dateTime", a => a.DateTime, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -21748,11 +21748,11 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
             builder.AddElement<Column>()
 .AddAttribute(0, "min", a => a.Min, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "max", a => a.Max, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "width", a => a.Width)
 .AddAttribute(0, "style", a => a.Style)
@@ -22292,7 +22292,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
 .AddAttribute(0, "click", a => a.Click)
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -22779,27 +22779,27 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<PageMargins>()
 .AddAttribute(0, "left", a => a.Left, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "right", a => a.Right, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "top", a => a.Top, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "bottom", a => a.Bottom, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "header", a => a.Header, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "footer", a => a.Footer, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -23593,12 +23593,12 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ConditionalFormattingRule>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "dxfId", a => a.FormatId)
 .AddAttribute(0, "priority", a => a.Priority, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "stopIfTrue", a => a.StopIfTrue)
 .AddAttribute(0, "aboveAverage", a => a.AboveAverage)
@@ -23709,7 +23709,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Hyperlink>()
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(19, "id", a => a.Id)
 .AddAttribute(0, "location", a => a.Location)
@@ -23812,7 +23812,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ConditionalFormatValueObject>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "val", a => a.Val)
 .AddAttribute(0, "gte", a => a.GreaterThanOrEqual);
@@ -23954,7 +23954,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Scenario>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "locked", a => a.Locked)
 .AddAttribute(0, "hidden", a => a.Hidden)
@@ -24093,11 +24093,11 @@ aBuilder.AddValidator(new StringValidator() { Length = (2L) });
 .AddAttribute(0, "spinCount", a => a.SpinCount)
 .AddAttribute(0, "sqref", a => a.SequenceOfReferences, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "securityDescriptor", a => a.SecurityDescriptor);
         }
@@ -24145,7 +24145,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<CellWatch>()
 .AddAttribute(0, "r", a => a.CellReference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -24360,11 +24360,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<CustomProperty>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -24479,21 +24479,21 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<WebPublishItem>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "divId", a => a.DivId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "sourceType", a => a.SourceType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "sourceRef", a => a.SourceRef)
 .AddAttribute(0, "sourceObject", a => a.SourceObject)
 .AddAttribute(0, "destinationFile", a => a.DestinationFile, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "title", a => a.Title)
 .AddAttribute(0, "autoRepublish", a => a.AutoRepublish);
@@ -24549,7 +24549,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<TablePart>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -24651,7 +24651,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "zoomScale", a => a.ZoomScale)
 .AddAttribute(0, "workbookViewId", a => a.WorkbookViewId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "zoomToFit", a => a.ZoomToFit);
         }
@@ -24783,7 +24783,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<CustomChartsheetView>()
 .AddAttribute(0, "guid", a => a.Guid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "scale", a => a.Scale)
@@ -24920,13 +24920,13 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             builder.AddElement<InputCells>()
 .AddAttribute(0, "r", a => a.CellReference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "deleted", a => a.Deleted)
 .AddAttribute(0, "undone", a => a.Undone)
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "numFmtId", a => a.NumberFormatId);
         }
@@ -25026,11 +25026,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Control>()
 .AddAttribute(0, "shapeId", a => a.ShapeId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "name", a => a.Name);
         }
@@ -25188,7 +25188,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<IgnoredError>()
 .AddAttribute(0, "sqref", a => a.SequenceOfReferences, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "evalError", a => a.EvalError)
 .AddAttribute(0, "twoDigitTextYear", a => a.TwoDigitTextYear)
@@ -25242,7 +25242,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<MergeCell>()
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -25448,7 +25448,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "prompt", a => a.Prompt)
 .AddAttribute(0, "sqref", a => a.SequenceOfReferences, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -25778,7 +25778,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "zoomScalePageLayoutView", a => a.ZoomScalePageLayoutView)
 .AddAttribute(0, "workbookViewId", a => a.WorkbookViewId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -26089,7 +26089,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<CustomSheetView>()
 .AddAttribute(0, "guid", a => a.Guid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "scale", a => a.Scale)
@@ -26400,7 +26400,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
 .AddAttribute(0, "autoLoad", a => a.AutoLoad)
 .AddAttribute(0, "shapeId", a => a.ShapeId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(19, "id", a => a.Id);
         }
@@ -26751,7 +26751,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<FutureMetadata>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "count", a => a.Count);
         }
@@ -27275,11 +27275,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<MetadataType>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "minSupportedVersion", a => a.MinSupportedVersion, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "ghostRow", a => a.GhostRow)
 .AddAttribute(0, "ghostCol", a => a.GhostColumn)
@@ -27423,11 +27423,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<MetadataRecord>()
 .AddAttribute(0, "t", a => a.TypeIndex, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidator());
+    aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "v", a => a.Val, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidator());
+    aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -27595,11 +27595,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Mdx>()
 .AddAttribute(0, "n", a => a.NameIndex, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "f", a => a.CubeFunction, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -27946,7 +27946,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
             builder.AddElement<MdxSet>()
 .AddAttribute(0, "ns", a => a.SetDefinitionIndex, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "c", a => a.MemberIndexCount)
 .AddAttribute(0, "o", a => a.SortingOrder);
@@ -28012,11 +28012,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<MdxMemberProp>()
  .AddAttribute(0, "n", a => a.NameIndex, aBuilder =>
  {
-     aBuilder.AddValidator(new RequiredValidator());
+     aBuilder.AddValidator(RequiredValidator.Instance);
  })
  .AddAttribute(0, "np", a => a.PropertyNameIndex, aBuilder =>
  {
-     aBuilder.AddValidator(new RequiredValidator());
+     aBuilder.AddValidator(RequiredValidator.Instance);
  });
         }
 
@@ -28084,15 +28084,15 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<MdxKpi>()
  .AddAttribute(0, "n", a => a.NameIndex, aBuilder =>
  {
-     aBuilder.AddValidator(new RequiredValidator());
+     aBuilder.AddValidator(RequiredValidator.Instance);
  })
  .AddAttribute(0, "np", a => a.KpiIndex, aBuilder =>
  {
-     aBuilder.AddValidator(new RequiredValidator());
+     aBuilder.AddValidator(RequiredValidator.Instance);
  })
  .AddAttribute(0, "p", a => a.KpiProperty, aBuilder =>
  {
-     aBuilder.AddValidator(new RequiredValidator());
+     aBuilder.AddValidator(RequiredValidator.Instance);
  });
         }
 
@@ -28150,7 +28150,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<NameIndex>()
  .AddAttribute(0, "x", a => a.Index, aBuilder =>
  {
-     aBuilder.AddValidator(new RequiredValidator());
+     aBuilder.AddValidator(RequiredValidator.Instance);
  })
  .AddAttribute(0, "s", a => a.IsASet);
         }
@@ -28250,15 +28250,15 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<SingleXmlCell>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "r", a => a.CellReference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "connectionId", a => a.ConnectionId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -28382,11 +28382,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<XmlCellProperties>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uniqueName", a => a.UniqueName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -28518,15 +28518,15 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<XmlProperties>()
 .AddAttribute(0, "mapId", a => a.MapId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "xpath", a => a.XPath, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "xmlDataType", a => a.XmlDataType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -28865,7 +28865,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<GradientStop>()
 .AddAttribute(0, "position", a => a.Position, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -28940,11 +28940,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<NumberingFormat>()
 .AddAttribute(0, "numFmtId", a => a.NumberFormatId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "formatCode", a => a.FormatCode, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -29991,7 +29991,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<TableStyle>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "pivot", a => a.Pivot)
 .AddAttribute(0, "table", a => a.Table)
@@ -30167,7 +30167,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 .AddAttribute(0, "name", a => a.Name)
 .AddAttribute(0, "xfId", a => a.FormatId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "builtinId", a => a.BuiltinId)
 .AddAttribute(0, "iLevel", a => a.OutlineLevel)
@@ -30501,7 +30501,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<FontName>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
   aBuilder.AddValidator(new StringValidator() { MinLength = (1L) });
 });
         }
@@ -30547,7 +30547,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<FontFamilyNumbering>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (5L) });
 });
         }
@@ -30587,7 +30587,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<FontCharSet>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (255L) });
 });
         }
@@ -30647,7 +30647,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<TableStyleElement>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "size", a => a.Size)
 .AddAttribute(0, "dxfId", a => a.FormatId);
@@ -30901,7 +30901,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ExternalDefinedName>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "refersTo", a => a.RefersTo)
 .AddAttribute(0, "sheetId", a => a.SheetId);
@@ -30989,7 +30989,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ExternalSheetData>()
 .AddAttribute(0, "sheetId", a => a.SheetId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "refreshError", a => a.RefreshError);
         }
@@ -31073,7 +31073,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ExternalRow>()
 .AddAttribute(0, "r", a => a.RowIndex, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -31176,7 +31176,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ExternalCell>()
 .AddAttribute(0, "r", a => a.CellReference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "t", a => a.DataType)
 .AddAttribute(0, "vm", a => a.ValueMetaIndex);
@@ -31715,7 +31715,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ExternalBook>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -31843,11 +31843,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<DdeLink>()
 .AddAttribute(0, "ddeService", a => a.DdeService, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "ddeTopic", a => a.DdeTopic, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -31957,11 +31957,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<OleLink>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "progId", a => a.ProgId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -32252,12 +32252,12 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<TableColumn>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "uniqueName", a => a.UniqueName)
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "totalsRowFunction", a => a.TotalsRowFunction)
 .AddAttribute(0, "totalsRowLabel", a => a.TotalsRowLabel)
@@ -32580,16 +32580,16 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<XmlColumnProperties>()
 .AddAttribute(0, "mapId", a => a.MapId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "xpath", a => a.XPath, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "denormalized", a => a.Denormalized)
 .AddAttribute(0, "xmlDataType", a => a.XmlDataType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -32687,7 +32687,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<VolatileType>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -32764,7 +32764,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Main>()
 .AddAttribute(0, "first", a => a.First, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -32919,11 +32919,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<TopicReferences>()
 .AddAttribute(0, "r", a => a.CellReference, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidator());
+    aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "s", a => a.SheetId, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidator());
+    aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -32981,11 +32981,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<PivotCache>()
 .AddAttribute(0, "cacheId", a => a.CacheId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -33081,16 +33081,16 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<WebPublishObject>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "divId", a => a.DivId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "sourceObject", a => a.SourceObject)
 .AddAttribute(0, "destinationFile", a => a.DestinationFile, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "title", a => a.Title)
 .AddAttribute(0, "autoRepublish", a => a.AutoRepublish);
@@ -33144,7 +33144,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ExternalReference>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -33444,11 +33444,11 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<CustomWorkbookView>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "guid", a => a.Guid, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 })
 .AddAttribute(0, "autoUpdate", a => a.AutoUpdate)
@@ -33470,7 +33470,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
 .AddAttribute(0, "tabRatio", a => a.TabRatio)
 .AddAttribute(0, "activeSheetId", a => a.ActiveSheetId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "showFormulaBar", a => a.ShowFormulaBar)
 .AddAttribute(0, "showStatusbar", a => a.ShowStatusbar)
@@ -33576,16 +33576,16 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Sheet>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "sheetId", a => a.SheetId, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "state", a => a.State)
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -34017,7 +34017,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<DefinedName>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "comment", a => a.Comment)
 .AddAttribute(0, "customMenu", a => a.CustomMenu)
@@ -34078,7 +34078,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<FunctionGroup>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -34154,7 +34154,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<TableExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -34604,7 +34604,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<ConditionalFormattingRuleExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -34683,7 +34683,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<PivotHierarchyExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -34762,7 +34762,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<PivotFieldExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -34841,7 +34841,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<CacheSourceExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -35141,7 +35141,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<OleItem>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "icon", a => a.Icon)
 .AddAttribute(0, "advise", a => a.Advise)
@@ -36614,7 +36614,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (2L) });
             builder.AddElement<Drawing>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -36715,7 +36715,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<LegacyDrawingType>()
                            .AddAttribute(19, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -36934,7 +36934,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<DrawingHeaderFooter>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "lho", a => a.Lho)
 .AddAttribute(0, "lhe", a => a.Lhe)
@@ -36994,7 +36994,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Picture>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -37894,7 +37894,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "defaultColWidth", a => a.DefaultColumnWidth)
 .AddAttribute(0, "defaultRowHeight", a => a.DefaultRowHeight, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "customHeight", a => a.CustomHeight)
 .AddAttribute(0, "zeroHeight", a => a.ZeroHeight)
@@ -38397,7 +38397,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (2L) });
             builder.AddElement<SheetDimension>()
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -39831,7 +39831,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
 .AddAttribute(0, "sortBy", a => a.SortBy)
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "customList", a => a.CustomList)
 .AddAttribute(0, "dxfId", a => a.FormatId)
@@ -39874,7 +39874,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Filter>()
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -39973,7 +39973,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<DateGroupItem>()
 .AddAttribute(0, "year", a => a.Year, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "month", a => a.Month)
 .AddAttribute(0, "day", a => a.Day)
@@ -39982,7 +39982,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "second", a => a.Second)
 .AddAttribute(0, "dateTimeGrouping", a => a.DateTimeGrouping, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -40155,7 +40155,7 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(0, "percent", a => a.Percent)
 .AddAttribute(0, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "filterVal", a => a.FilterValue);
         }
@@ -40309,7 +40309,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<DynamicFilter>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "val", a => a.Val)
 .AddAttribute(0, "maxVal", a => a.MaxVal)
@@ -40368,7 +40368,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
             builder.AddElement<ColorFilter>()
 .AddAttribute(0, "dxfId", a => a.FormatId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "cellColor", a => a.CellColor);
         }
@@ -40424,7 +40424,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<IconFilter>()
 .AddAttribute(0, "iconSet", a => a.IconSet, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "iconId", a => a.IconId);
         }
@@ -40499,7 +40499,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<SlicerCacheDefinitionExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -40582,7 +40582,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<PivotFilterExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -40662,7 +40662,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<QueryTableExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -40740,7 +40740,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<DatabaseProperties>()
 .AddAttribute(0, "connection", a => a.Connection, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "command", a => a.Command)
 .AddAttribute(0, "serverCommand", a => a.ServerCommand)
@@ -41575,7 +41575,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<ConnectionExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -41743,7 +41743,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<CacheSource>()
 .AddAttribute(0, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "connectionId", a => a.ConnectionId);
         }
@@ -42668,7 +42668,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<PivotCacheDefinitionExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -43148,7 +43148,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<CacheFieldExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -43440,7 +43440,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<CacheHierarchyExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -43584,7 +43584,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<CalculatedMemberExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -43683,19 +43683,19 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<Location>()
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "firstHeaderRow", a => a.FirstHeaderRow, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "firstDataRow", a => a.FirstDataRow, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "firstDataCol", a => a.FirstDataColumn, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "rowPageCount", a => a.RowPageCount)
 .AddAttribute(0, "colPageCount", a => a.ColumnsPerPage);
@@ -44966,7 +44966,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<PivotTableDefinitionExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -45111,7 +45111,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<DataFieldExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -46247,7 +46247,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddElement<WorksheetExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -47203,7 +47203,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
             builder.AddElement<StylesheetExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }
@@ -48364,7 +48364,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (2L) });
             builder.AddElement<OleSize>()
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -48907,7 +48907,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<WorkbookExtension>()
 .AddAttribute(0, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
         }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_wordprocessingml_2006_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_wordprocessingml_2006_main.g.cs
@@ -367,17 +367,17 @@ namespace DocumentFormat.OpenXml.Wordprocessing
             builder.AddElement<TrackChangeType>()
                            .AddAttribute(23, "author", a => a.Author, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
                            })
                            .AddAttribute(23, "date", a => a.Date)
                            .AddAttribute(23, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                                aBuilder.AddUnion(union =>
                                {
-                                   union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
-                                   union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-2L) });
+                                   union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
+                                   union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
                                });
                            });
         }
@@ -471,17 +471,17 @@ namespace DocumentFormat.OpenXml.Wordprocessing
 .AddAttribute(23, "vMergeOrig", a => a.VerticalMergeOriginal)
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
- union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
- union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-2L) });
+ union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
+ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
 });
 });
         }
@@ -582,19 +582,19 @@ aBuilder.AddUnion(union =>
             builder.AddElement<BookmarkStart>()
 .AddAttribute(23, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (40L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (40L) });
 })
 .AddAttribute(23, "colFirst", a => a.ColumnFirst)
 .AddAttribute(23, "colLast", a => a.ColumnLast)
 .AddAttribute(23, "displacedByCustomXml", a => a.DisplacedByCustomXml)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-2L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
 });
 });
         }
@@ -808,11 +808,11 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
                            .AddAttribute(23, "displacedByCustomXml", a => a.DisplacedByCustomXml)
                            .AddAttribute(23, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                                aBuilder.AddUnion(union =>
                                {
-                                   union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
-                                   union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-2L) });
+                                   union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
+                                   union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
                                });
                            });
         }
@@ -989,27 +989,27 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
             builder.AddElement<MoveBookmarkType>()
                            .AddAttribute(23, "author", a => a.Author, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            })
                            .AddAttribute(23, "date", a => a.Date, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            })
                            .AddAttribute(23, "name", a => a.Name, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (40L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new StringValidator() { MaxLength = (40L) });
                            })
                            .AddAttribute(23, "colFirst", a => a.ColumnFirst)
                            .AddAttribute(23, "colLast", a => a.ColumnLast)
                            .AddAttribute(23, "displacedByCustomXml", a => a.DisplacedByCustomXml)
                            .AddAttribute(23, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                                aBuilder.AddUnion(union =>
                                {
-                                   union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
-                                   union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-2L) });
+                                   union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
+                                   union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
                                });
                            });
         }
@@ -1193,11 +1193,11 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
             builder.AddElement<MarkupType>()
                            .AddAttribute(23, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                                aBuilder.AddUnion(union =>
                                {
-                                   union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
-                                   union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-2L) });
+                                   union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
+                                   union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
                                });
                            });
         }
@@ -1886,7 +1886,7 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
             builder.AddElement<StringType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -6607,37 +6607,37 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
 .AddAttribute(23, "dropCap", a => a.DropCap)
 .AddAttribute(23, "lines", a => a.Lines, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (10L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (10L) });
 })
 .AddAttribute(23, "w", a => a.Width, aBuilder =>
 {
-aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
 aBuilder.AddUnion(union =>
 {
-   union.AddValidator<UInt32Value>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-   union.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+   union.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+   union.AddValidator(new StringValidator() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
 });
 })
 .AddAttribute(23, "h", a => a.Height, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MaxInclusive = (31680L) });
+aBuilder.AddValidator(new NumberValidator() { MaxInclusive = (31680L) });
 })
 .AddAttribute(23, "vSpace", a => a.VerticalSpace, aBuilder =>
 {
-aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
 aBuilder.AddUnion(union =>
 {
-   union.AddValidator<UInt32Value>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-   union.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+   union.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+   union.AddValidator(new StringValidator() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
 });
 })
 .AddAttribute(23, "hSpace", a => a.HorizontalSpace, aBuilder =>
 {
-aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
 aBuilder.AddUnion(union =>
 {
-   union.AddValidator<UInt32Value>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-   union.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+   union.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+   union.AddValidator(new StringValidator() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
 });
 })
 .AddAttribute(23, "wrap", a => a.Wrap)
@@ -6645,21 +6645,21 @@ aBuilder.AddUnion(union =>
 .AddAttribute(23, "vAnchor", a => a.VerticalPosition)
 .AddAttribute(23, "x", a => a.X, aBuilder =>
 {
-aBuilder.AddValidator<Int32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator<Int32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
 aBuilder.AddUnion(union =>
 {
-   union.AddValidator<IntegerValue>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-   union.AddValidator(new StringValidatorAttribute() { Pattern = ("-?[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+   union.AddValidator<IntegerValue>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+   union.AddValidator(new StringValidator() { Pattern = ("-?[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
 });
 })
 .AddAttribute(23, "xAlign", a => a.XAlign)
 .AddAttribute(23, "y", a => a.Y, aBuilder =>
 {
-aBuilder.AddValidator<Int32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator<Int32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
 aBuilder.AddUnion(union =>
 {
-   union.AddValidator<IntegerValue>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-   union.AddValidator(new StringValidatorAttribute() { Pattern = ("-?[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+   union.AddValidator<IntegerValue>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+   union.AddValidator(new StringValidator() { Pattern = ("-?[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
 });
 })
 .AddAttribute(23, "yAlign", a => a.YAlign)
@@ -7087,41 +7087,41 @@ aBuilder.AddUnion(union =>
             builder.AddElement<Shading>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(23, "color", a => a.Color, aBuilder =>
 {
    aBuilder.AddUnion(union =>
    {
-       union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(new EnumValidatorAttribute());
-       union.AddValidator<HexBinaryValue>(new StringValidatorAttribute() { Length = (3L) });
+       union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(new EnumValidator());
+       union.AddValidator<HexBinaryValue>(new StringValidator() { Length = (3L) });
    });
 })
 .AddAttribute(23, "themeColor", a => a.ThemeColor)
 .AddAttribute(23, "themeTint", a => a.ThemeTint, aBuilder =>
 {
-   aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
+   aBuilder.AddValidator(new StringValidator() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
 })
 .AddAttribute(23, "themeShade", a => a.ThemeShade, aBuilder =>
 {
-   aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
+   aBuilder.AddValidator(new StringValidator() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
 })
 .AddAttribute(23, "fill", a => a.Fill, aBuilder =>
 {
    aBuilder.AddUnion(union =>
    {
-       union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(new EnumValidatorAttribute());
-       union.AddValidator<HexBinaryValue>(new StringValidatorAttribute() { Length = (3L) });
+       union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(new EnumValidator());
+       union.AddValidator<HexBinaryValue>(new StringValidator() { Length = (3L) });
    });
 })
 .AddAttribute(23, "themeFill", a => a.ThemeFill)
 .AddAttribute(23, "themeFillTint", a => a.ThemeFillTint, aBuilder =>
 {
-   aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
+   aBuilder.AddValidator(new StringValidator() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
 })
 .AddAttribute(23, "themeFillShade", a => a.ThemeFillShade, aBuilder =>
 {
-   aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
+   aBuilder.AddValidator(new StringValidator() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
 });
         }
 
@@ -7316,33 +7316,33 @@ aBuilder.AddUnion(union =>
             builder.AddElement<SpacingBetweenLines>()
 .AddAttribute(23, "before", a => a.Before, aBuilder =>
 {
-aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
 aBuilder.AddUnion(union =>
 {
-   union.AddValidator<UInt32Value>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-   union.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+   union.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+   union.AddValidator(new StringValidator() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
 });
 })
 .AddAttribute(23, "beforeLines", a => a.BeforeLines)
 .AddAttribute(23, "beforeAutospacing", a => a.BeforeAutoSpacing)
 .AddAttribute(23, "after", a => a.After, aBuilder =>
 {
-aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
 aBuilder.AddUnion(union =>
 {
-   union.AddValidator<UInt32Value>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-   union.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+   union.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+   union.AddValidator(new StringValidator() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
 });
 })
 .AddAttribute(23, "afterLines", a => a.AfterLines)
 .AddAttribute(23, "afterAutospacing", a => a.AfterAutoSpacing)
 .AddAttribute(23, "line", a => a.Line, aBuilder =>
 {
-aBuilder.AddValidator<Int32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator<Int32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
 aBuilder.AddUnion(union =>
 {
-   union.AddValidator<IntegerValue>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-   union.AddValidator(new StringValidatorAttribute() { Pattern = ("-?[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+   union.AddValidator<IntegerValue>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+   union.AddValidator(new StringValidator() { Pattern = ("-?[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
 });
 })
 .AddAttribute(23, "lineRule", a => a.LineRule);
@@ -7529,69 +7529,69 @@ aBuilder.AddUnion(union =>
             builder.AddElement<Indentation>()
 .AddAttribute(23, "left", a => a.Left, aBuilder =>
 {
-   aBuilder.AddValidator<Int32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+   aBuilder.AddValidator<Int32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
    aBuilder.AddUnion(union =>
    {
-       union.AddValidator<IntegerValue>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-       union.AddValidator(new StringValidatorAttribute() { Pattern = ("-?[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+       union.AddValidator<IntegerValue>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+       union.AddValidator(new StringValidator() { Pattern = ("-?[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
    });
 })
 .AddAttribute(23, "start", a => a.Start, aBuilder =>
 {
-   aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-   aBuilder.AddValidator<Int32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+   aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+   aBuilder.AddValidator<Int32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
    aBuilder.AddUnion(union =>
    {
-       union.AddValidator<IntegerValue>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-       union.AddValidator(new StringValidatorAttribute() { Pattern = ("-?[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+       union.AddValidator<IntegerValue>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+       union.AddValidator(new StringValidator() { Pattern = ("-?[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
    });
 })
 .AddAttribute(23, "leftChars", a => a.LeftChars)
 .AddAttribute(23, "startChars", a => a.StartCharacters, aBuilder =>
 {
-   aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+   aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "right", a => a.Right, aBuilder =>
 {
-   aBuilder.AddValidator<Int32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+   aBuilder.AddValidator<Int32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
    aBuilder.AddUnion(union =>
    {
-       union.AddValidator<IntegerValue>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-       union.AddValidator(new StringValidatorAttribute() { Pattern = ("-?[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+       union.AddValidator<IntegerValue>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+       union.AddValidator(new StringValidator() { Pattern = ("-?[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
    });
 })
 .AddAttribute(23, "end", a => a.End, aBuilder =>
 {
-   aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-   aBuilder.AddValidator<Int32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+   aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+   aBuilder.AddValidator<Int32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
    aBuilder.AddUnion(union =>
    {
-       union.AddValidator<IntegerValue>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-       union.AddValidator(new StringValidatorAttribute() { Pattern = ("-?[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+       union.AddValidator<IntegerValue>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+       union.AddValidator(new StringValidator() { Pattern = ("-?[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
    });
 })
 .AddAttribute(23, "rightChars", a => a.RightChars)
 .AddAttribute(23, "endChars", a => a.EndCharacters, aBuilder =>
 {
-   aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+   aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "hanging", a => a.Hanging, aBuilder =>
 {
-   aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+   aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
    aBuilder.AddUnion(union =>
    {
-       union.AddValidator<UInt32Value>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-       union.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+       union.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+       union.AddValidator(new StringValidator() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
    });
 })
 .AddAttribute(23, "hangingChars", a => a.HangingChars)
 .AddAttribute(23, "firstLine", a => a.FirstLine, aBuilder =>
 {
-   aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+   aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
    aBuilder.AddUnion(union =>
    {
-       union.AddValidator<UInt32Value>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-       union.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+       union.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+       union.AddValidator(new StringValidator() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
    });
 })
 .AddAttribute(23, "firstLineChars", a => a.FirstLineChars);
@@ -7635,7 +7635,7 @@ aBuilder.AddUnion(union =>
             builder.AddElement<Justification>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidatorAttribute());
+    aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -7677,7 +7677,7 @@ aBuilder.AddUnion(union =>
             builder.AddElement<TextDirection>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -7719,7 +7719,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TextAlignment>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -7761,7 +7761,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TextBoxTightWrap>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -8120,7 +8120,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<DecimalNumberType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -8216,17 +8216,17 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ParagraphPropertiesChange>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-2L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
 });
 });
         }
@@ -8372,11 +8372,11 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
             builder.AddElement<HeaderFooterReferenceType>()
                            .AddAttribute(23, "type", a => a.Type, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            })
                            .AddAttribute(19, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -9273,11 +9273,11 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
             builder.AddElement<SymbolChar>()
 .AddAttribute(23, "font", a => a.Font, aBuilder =>
 {
-   aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (31L) });
+   aBuilder.AddValidator(new StringValidator() { MaxLength = (31L) });
 })
 .AddAttribute(23, "char", a => a.Char, aBuilder =>
 {
-   aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
+   aBuilder.AddValidator(new StringValidator() { Length = (2L) });
 });
         }
 
@@ -9408,8 +9408,8 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
 .AddAttribute(23, "dyaOrig", a => a.DyaOriginal)
 .AddAttribute(52, "anchorId", a => a.AnchorId, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 });
         }
 
@@ -9545,8 +9545,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
             builder.AddElement<Picture>()
 .AddAttribute(52, "anchorId", a => a.AnchorId, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 });
         }
 
@@ -9681,7 +9681,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
             builder.AddElement<FieldChar>()
 .AddAttribute(23, "fldCharType", a => a.FieldCharType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(23, "fldLock", a => a.FieldLock)
 .AddAttribute(23, "dirty", a => a.Dirty);
@@ -9947,8 +9947,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
                            .AddAttribute(23, "customMarkFollows", a => a.CustomMarkFollows)
                            .AddAttribute(23, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-2147483648L), MaxInclusive = (32767L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-2147483648L), MaxInclusive = (32767L) });
                            });
         }
     }
@@ -10104,15 +10104,15 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<PositionalTab>()
 .AddAttribute(23, "alignment", a => a.Alignment, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(23, "relativeTo", a => a.RelativeTo, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(23, "leader", a => a.Leader, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -10441,8 +10441,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<String253Type>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (253L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new StringValidator() { MaxLength = (253L) });
                            });
         }
     }
@@ -10586,19 +10586,19 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(23, "hint", a => a.Hint)
 .AddAttribute(23, "ascii", a => a.Ascii, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (31L) });
+aBuilder.AddValidator(new StringValidator() { MaxLength = (31L) });
 })
 .AddAttribute(23, "hAnsi", a => a.HighAnsi, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (31L) });
+aBuilder.AddValidator(new StringValidator() { MaxLength = (31L) });
 })
 .AddAttribute(23, "eastAsia", a => a.EastAsia, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (31L) });
+aBuilder.AddValidator(new StringValidator() { MaxLength = (31L) });
 })
 .AddAttribute(23, "cs", a => a.ComplexScript, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (31L) });
+aBuilder.AddValidator(new StringValidator() { MaxLength = (31L) });
 })
 .AddAttribute(23, "asciiTheme", a => a.AsciiTheme)
 .AddAttribute(23, "hAnsiTheme", a => a.HighAnsiTheme)
@@ -10683,21 +10683,21 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (31L) });
             builder.AddElement<Color>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
+ aBuilder.AddValidator(new RequiredValidator());
  aBuilder.AddUnion(union =>
  {
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(new EnumValidatorAttribute());
-     union.AddValidator<HexBinaryValue>(new StringValidatorAttribute() { Length = (3L) });
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(new EnumValidator());
+     union.AddValidator<HexBinaryValue>(new StringValidator() { Length = (3L) });
  });
 })
 .AddAttribute(23, "themeColor", a => a.ThemeColor)
 .AddAttribute(23, "themeTint", a => a.ThemeTint, aBuilder =>
 {
- aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
+ aBuilder.AddValidator(new StringValidator() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
 })
 .AddAttribute(23, "themeShade", a => a.ThemeShade, aBuilder =>
 {
- aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
+ aBuilder.AddValidator(new StringValidator() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
 });
         }
 
@@ -10739,8 +10739,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (31L) });
             builder.AddElement<Spacing>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-31680L), MaxInclusive = (31680L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-31680L), MaxInclusive = (31680L) });
 });
         }
 
@@ -10782,7 +10782,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-31680L),
             builder.AddElement<CharacterScale>()
  .AddAttribute(23, "val", a => a.Val, aBuilder =>
  {
-     aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (600L) });
+     aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (600L) });
  });
         }
 
@@ -10824,8 +10824,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-31680L),
             builder.AddElement<Kern>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
-  aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (3277L) });
+  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (3277L) });
 });
         }
 
@@ -10867,12 +10867,12 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-31680L),
             builder.AddElement<Position>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator<Int32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator<Int32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
 aBuilder.AddUnion(union =>
 {
-  union.AddValidator<IntegerValue>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-  union.AddValidator(new StringValidatorAttribute() { Pattern = ("-?[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+  union.AddValidator<IntegerValue>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+  union.AddValidator(new StringValidator() { Pattern = ("-?[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
 });
 });
         }
@@ -11034,12 +11034,12 @@ aBuilder.AddUnion(union =>
             builder.AddElement<HpsMeasureType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { MinInclusive = (2L), MaxInclusive = (3277L), Version = (FileFormatVersions.Office2007) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator<UInt32Value>(new NumberValidator() { MinInclusive = (2L), MaxInclusive = (3277L), Version = (FileFormatVersions.Office2007) });
                                aBuilder.AddUnion(union =>
                                {
-                                   union.AddValidator<UInt32Value>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-                                   union.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+                                   union.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+                                   union.AddValidator(new StringValidator() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
                                });
                            });
         }
@@ -11079,7 +11079,7 @@ aBuilder.AddUnion(union =>
             builder.AddElement<Highlight>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -11176,18 +11176,18 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
  {
      aBuilder.AddUnion(union =>
      {
-         union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(new EnumValidatorAttribute());
-         union.AddValidator<HexBinaryValue>(new StringValidatorAttribute() { Length = (3L) });
+         union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(new EnumValidator());
+         union.AddValidator<HexBinaryValue>(new StringValidator() { Length = (3L) });
      });
  })
  .AddAttribute(23, "themeColor", a => a.ThemeColor)
  .AddAttribute(23, "themeTint", a => a.ThemeTint, aBuilder =>
  {
-     aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
+     aBuilder.AddValidator(new StringValidator() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
  })
  .AddAttribute(23, "themeShade", a => a.ThemeShade, aBuilder =>
  {
-     aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
+     aBuilder.AddValidator(new StringValidator() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
  });
         }
 
@@ -11229,7 +11229,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TextEffect>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -11688,29 +11688,29 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<BorderType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            })
                            .AddAttribute(23, "color", a => a.Color, aBuilder =>
                            {
                                aBuilder.AddUnion(union =>
                                {
-                                   union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(new EnumValidatorAttribute());
-                                   union.AddValidator<HexBinaryValue>(new StringValidatorAttribute() { Length = (3L) });
+                                   union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(new EnumValidator());
+                                   union.AddValidator<HexBinaryValue>(new StringValidator() { Length = (3L) });
                                });
                            })
                            .AddAttribute(23, "themeColor", a => a.ThemeColor)
                            .AddAttribute(23, "themeTint", a => a.ThemeTint, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
+                               aBuilder.AddValidator(new StringValidator() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
                            })
                            .AddAttribute(23, "themeShade", a => a.ThemeShade, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
+                               aBuilder.AddValidator(new StringValidator() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
                            })
                            .AddAttribute(23, "sz", a => a.Size)
                            .AddAttribute(23, "space", a => a.Space, aBuilder =>
                            {
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (31L) });
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (31L) });
                            })
                            .AddAttribute(23, "shadow", a => a.Shadow)
                            .AddAttribute(23, "frame", a => a.Frame);
@@ -11764,8 +11764,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<FitText>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MaxInclusive = (31680L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MaxInclusive = (31680L) });
 })
 .AddAttribute(23, "id", a => a.Id);
         }
@@ -11808,7 +11808,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MaxInclusive = (31680L) }
             builder.AddElement<VerticalTextAlignment>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -11850,7 +11850,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Emphasis>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidatorAttribute());
+    aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -11965,15 +11965,15 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<LanguageType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (84L) });
+                               aBuilder.AddValidator(new StringValidator() { MaxLength = (84L) });
                            })
                            .AddAttribute(23, "eastAsia", a => a.EastAsia, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (84L) });
+                               aBuilder.AddValidator(new StringValidator() { MaxLength = (84L) });
                            })
                            .AddAttribute(23, "bidi", a => a.Bidi, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (84L) });
+                               aBuilder.AddValidator(new StringValidator() { MaxLength = (84L) });
                            });
         }
     }
@@ -12164,17 +12164,17 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RunPropertiesChange>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-2L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
 });
 });
         }
@@ -13246,17 +13246,17 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
             builder.AddElement<InsertedMathControl>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-2L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
 });
 });
         }
@@ -13385,17 +13385,17 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
             builder.AddElement<DeletedMathControl>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-2L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
 });
 });
         }
@@ -13692,17 +13692,17 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
             builder.AddElement<MathControlMoveType>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-2L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
 });
 });
         }
@@ -14212,7 +14212,7 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
             builder.AddElement<SimpleFieldRuby>()
 .AddAttribute(23, "instr", a => a.Instruction, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(23, "fldLock", a => a.FieldLock)
 .AddAttribute(23, "dirty", a => a.Dirty);
@@ -14607,20 +14607,20 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<HyperlinkRuby>()
 .AddAttribute(23, "tgtFrame", a => a.TargetFrame, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "tooltip", a => a.Tooltip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (260L) });
+aBuilder.AddValidator(new StringValidator() { MaxLength = (260L) });
 })
 .AddAttribute(23, "docLocation", a => a.DocLocation, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "history", a => a.History)
 .AddAttribute(23, "anchor", a => a.Anchor, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(19, "id", a => a.Id);
         }
@@ -14916,15 +14916,15 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
             builder.AddElement<Run>()
 .AddAttribute(23, "rsidRPr", a => a.RsidRunProperties, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "rsidDel", a => a.RsidRunDeletion, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "rsidR", a => a.RsidRunAddition, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 });
         }
 
@@ -15189,7 +15189,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
             builder.AddElement<ProofError>()
 .AddAttribute(23, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -15298,15 +15298,15 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(23, "ed", a => a.Ed)
 .AddAttribute(23, "colFirst", a => a.ColumnFirst, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 })
 .AddAttribute(23, "colLast", a => a.ColumnLast, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 })
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(23, "displacedByCustomXml", a => a.DisplacedByCustomXml);
         }
@@ -15368,7 +15368,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<PermEnd>()
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(23, "displacedByCustomXml", a => a.DisplacedByCustomXml);
         }
@@ -16615,17 +16615,17 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<RunTrackChangeType>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-2L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
 });
 });
         }
@@ -16666,7 +16666,7 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
             builder.AddElement<ContentPart>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -17480,37 +17480,37 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Paragraph>()
 .AddAttribute(23, "rsidRPr", a => a.RsidParagraphMarkRevision, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "rsidR", a => a.RsidParagraphAddition, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "rsidDel", a => a.RsidParagraphDeletion, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "rsidP", a => a.RsidParagraphProperties, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "rsidRDefault", a => a.RsidRunAdditionDefault, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(52, "paraId", a => a.ParagraphId, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(52, "textId", a => a.TextId, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(52, "noSpellErr", a => a.NoSpellError, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -18137,29 +18137,29 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<TableRow>()
 .AddAttribute(23, "rsidRPr", a => a.RsidTableRowMarkRevision, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "rsidR", a => a.RsidTableRowAddition, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "rsidDel", a => a.RsidTableRowDeletion, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "rsidTr", a => a.RsidTableRowProperties, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(52, "paraId", a => a.ParagraphId, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(52, "textId", a => a.TextId, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 });
         }
 
@@ -19796,7 +19796,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
             builder.AddElement<SimpleField>()
 .AddAttribute(23, "instr", a => a.Instruction, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(23, "fldLock", a => a.FieldLock)
 .AddAttribute(23, "dirty", a => a.Dirty);
@@ -20224,20 +20224,20 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Hyperlink>()
 .AddAttribute(23, "tgtFrame", a => a.TargetFrame, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "tooltip", a => a.Tooltip, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (260L) });
+aBuilder.AddValidator(new StringValidator() { MaxLength = (260L) });
 })
 .AddAttribute(23, "docLocation", a => a.DocLocation, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "history", a => a.History)
 .AddAttribute(23, "anchor", a => a.Anchor, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(19, "id", a => a.Id);
         }
@@ -21381,7 +21381,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
             builder.AddElement<RelationshipType>()
                            .AddAttribute(19, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -21576,58 +21576,58 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
             builder.AddElement<ConditionalFormatStyle>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
-aBuilder.AddValidator(new RequiredValidatorAttribute() { IsRequired = (false), Version = (FileFormatVersions.Office2010) });
-aBuilder.AddValidator(new RequiredValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2013) });
-aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("[01]*"), Length = (12L) });
+aBuilder.AddValidator(new RequiredValidator() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator(new RequiredValidator() { IsRequired = (false), Version = (FileFormatVersions.Office2010) });
+aBuilder.AddValidator(new RequiredValidator() { InitialVersion = (FileFormatVersions.Office2013) });
+aBuilder.AddValidator(new StringValidator() { Pattern = ("[01]*"), Length = (12L) });
 })
 .AddAttribute(23, "firstRow", a => a.FirstRow, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "lastRow", a => a.LastRow, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "firstColumn", a => a.FirstColumn, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "lastColumn", a => a.LastColumn, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "oddVBand", a => a.OddVerticalBand, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "evenVBand", a => a.EvenVerticalBand, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "oddHBand", a => a.OddHorizontalBand, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "evenHBand", a => a.EvenHorizontalBand, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "firstRowFirstColumn", a => a.FirstRowFirstColumn, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "firstRowLastColumn", a => a.FirstRowLastColumn, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "lastRowFirstColumn", a => a.LastRowFirstColumn, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "lastRowLastColumn", a => a.LastRowLastColumn, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -21954,16 +21954,16 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<TableWidthType>()
                            .AddAttribute(23, "w", a => a.Width, aBuilder =>
                            {
-                               aBuilder.AddValidator<Int32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+                               aBuilder.AddValidator<Int32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
                                aBuilder.AddUnion(union =>
                                {
-                                   union.AddValidator(new StringValidatorAttribute() { Pattern = ("-?[0-9]+(\\.[0-9]+)?%"), Version = (FileFormatVersions.Office2010) });
-                                   union.AddValidator<Int32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2010) });
+                                   union.AddValidator(new StringValidator() { Pattern = ("-?[0-9]+(\\.[0-9]+)?%"), Version = (FileFormatVersions.Office2010) });
+                                   union.AddValidator<Int32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2010) });
                                });
                                aBuilder.AddUnion(union =>
                                {
-                                   union.AddValidator(new StringValidatorAttribute() { Pattern = ("-?[0-9]+(\\.[0-9]+)?%"), InitialVersion = (FileFormatVersions.Office2013) });
-                                   union.AddValidator<Int32Value>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2013) });
+                                   union.AddValidator(new StringValidator() { Pattern = ("-?[0-9]+(\\.[0-9]+)?%"), InitialVersion = (FileFormatVersions.Office2013) });
+                                   union.AddValidator<Int32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2013) });
                                });
                            })
                            .AddAttribute(23, "type", a => a.Type);
@@ -22947,7 +22947,7 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<TableCellVerticalAlignment>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -22989,11 +22989,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<DivId>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
+ aBuilder.AddValidator(new RequiredValidator());
  aBuilder.AddUnion(union =>
  {
-     union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (1L) });
-     union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-1L) });
+     union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (1L) });
+     union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-1L) });
  });
 });
         }
@@ -23055,7 +23055,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TableRowHeight>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MaxInclusive = (31680L) });
+aBuilder.AddValidator(new NumberValidator() { MaxInclusive = (31680L) });
 })
 .AddAttribute(23, "hRule", a => a.HeightType);
         }
@@ -23098,7 +23098,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MaxInclusive = (31680L) }
             builder.AddElement<TableJustification>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidatorAttribute());
+    aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -23257,31 +23257,31 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MaxInclusive = (31680L) }
             builder.AddElement<TablePositionProperties>()
 .AddAttribute(23, "leftFromText", a => a.LeftFromText, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 })
 .AddAttribute(23, "rightFromText", a => a.RightFromText, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 })
 .AddAttribute(23, "topFromText", a => a.TopFromText, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 })
 .AddAttribute(23, "bottomFromText", a => a.BottomFromText, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 })
 .AddAttribute(23, "vertAnchor", a => a.VerticalAnchor)
 .AddAttribute(23, "horzAnchor", a => a.HorizontalAnchor)
 .AddAttribute(23, "tblpXSpec", a => a.TablePositionXAlignment)
 .AddAttribute(23, "tblpX", a => a.TablePositionX, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-31680L), MaxInclusive = (31680L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-31680L), MaxInclusive = (31680L) });
 })
 .AddAttribute(23, "tblpYSpec", a => a.TablePositionYAlignment)
 .AddAttribute(23, "tblpY", a => a.TablePositionY, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-31680L), MaxInclusive = (31680L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-31680L), MaxInclusive = (31680L) });
 });
         }
 
@@ -23323,7 +23323,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-31680L),
             builder.AddElement<TableOverlap>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -23412,8 +23412,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<UnsignedDecimalNumberMax3Type>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (3L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (3L) });
                            });
         }
     }
@@ -23886,7 +23886,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<NumberingStart>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -23928,7 +23928,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<NumberingRestart>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -24145,31 +24145,31 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TableLook>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
+aBuilder.AddValidator(new StringValidator() { Length = (2L) });
 })
 .AddAttribute(23, "firstRow", a => a.FirstRow, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "lastRow", a => a.LastRow, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "firstColumn", a => a.FirstColumn, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "lastColumn", a => a.LastColumn, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "noHBand", a => a.NoHorizontalBand, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "noVBand", a => a.NoVerticalBand, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -24469,7 +24469,7 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<SectionType>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -24550,11 +24550,11 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<PageSize>()
 .AddAttribute(23, "w", a => a.Width, aBuilder =>
 {
-  aBuilder.AddValidator(new NumberValidatorAttribute() { MaxInclusive = (31680L) });
+  aBuilder.AddValidator(new NumberValidator() { MaxInclusive = (31680L) });
 })
 .AddAttribute(23, "h", a => a.Height, aBuilder =>
 {
-  aBuilder.AddValidator(new NumberValidatorAttribute() { MaxInclusive = (31680L) });
+  aBuilder.AddValidator(new NumberValidator() { MaxInclusive = (31680L) });
 })
 .AddAttribute(23, "orient", a => a.Orient)
 .AddAttribute(23, "code", a => a.Code);
@@ -24676,31 +24676,31 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<PageMargin>()
 .AddAttribute(23, "top", a => a.Top, aBuilder =>
 {
- aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-31680L), MaxInclusive = (31680L) });
+ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-31680L), MaxInclusive = (31680L) });
 })
 .AddAttribute(23, "right", a => a.Right, aBuilder =>
 {
- aBuilder.AddValidator(new NumberValidatorAttribute() { MaxInclusive = (31680L) });
+ aBuilder.AddValidator(new NumberValidator() { MaxInclusive = (31680L) });
 })
 .AddAttribute(23, "bottom", a => a.Bottom, aBuilder =>
 {
- aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-31680L), MaxInclusive = (31680L) });
+ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-31680L), MaxInclusive = (31680L) });
 })
 .AddAttribute(23, "left", a => a.Left, aBuilder =>
 {
- aBuilder.AddValidator(new NumberValidatorAttribute() { MaxInclusive = (31680L) });
+ aBuilder.AddValidator(new NumberValidator() { MaxInclusive = (31680L) });
 })
 .AddAttribute(23, "header", a => a.Header, aBuilder =>
 {
- aBuilder.AddValidator(new NumberValidatorAttribute() { MaxInclusive = (31680L) });
+ aBuilder.AddValidator(new NumberValidator() { MaxInclusive = (31680L) });
 })
 .AddAttribute(23, "footer", a => a.Footer, aBuilder =>
 {
- aBuilder.AddValidator(new NumberValidatorAttribute() { MaxInclusive = (31680L) });
+ aBuilder.AddValidator(new NumberValidator() { MaxInclusive = (31680L) });
 })
 .AddAttribute(23, "gutter", a => a.Gutter, aBuilder =>
 {
- aBuilder.AddValidator(new NumberValidatorAttribute() { MaxInclusive = (31680L) });
+ aBuilder.AddValidator(new NumberValidator() { MaxInclusive = (31680L) });
 });
         }
 
@@ -25000,19 +25000,19 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<LineNumberType>()
 .AddAttribute(23, "countBy", a => a.CountBy, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (100L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (100L) });
 })
 .AddAttribute(23, "start", a => a.Start, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 })
 .AddAttribute(23, "distance", a => a.Distance, aBuilder =>
 {
-aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
 aBuilder.AddUnion(union =>
 {
- union.AddValidator<UInt32Value>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
- union.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+ union.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+ union.AddValidator(new StringValidator() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
 });
 })
 .AddAttribute(23, "restart", a => a.Restart);
@@ -25096,7 +25096,7 @@ aBuilder.AddUnion(union =>
 .AddAttribute(23, "fmt", a => a.Format)
 .AddAttribute(23, "start", a => a.Start, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 })
 .AddAttribute(23, "chapStyle", a => a.ChapterStyle)
 .AddAttribute(23, "chapSep", a => a.ChapterSeparator);
@@ -25211,16 +25211,16 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
 .AddAttribute(23, "equalWidth", a => a.EqualWidth)
 .AddAttribute(23, "space", a => a.Space, aBuilder =>
 {
-aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<UInt32Value>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-union.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+union.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+union.AddValidator(new StringValidator() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
 });
 })
 .AddAttribute(23, "num", a => a.ColumnCount, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxInclusive = (45L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive = (45L) });
 })
 .AddAttribute(23, "sep", a => a.Separator);
         }
@@ -25270,7 +25270,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L), MaxI
             builder.AddElement<VerticalTextAlignmentOnPage>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -29173,19 +29173,19 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<PreviousSectionProperties>()
 .AddAttribute(23, "rsidRPr", a => a.RsidRPr, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "rsidDel", a => a.RsidDel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "rsidR", a => a.RsidR, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "rsidSect", a => a.RsidSect, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 });
         }
 
@@ -30741,8 +30741,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
             builder.AddElement<NumberingLevelReference>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
-  aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (255L) });
+  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (255L) });
 });
         }
 
@@ -30855,8 +30855,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
             builder.AddElement<NonNegativeDecimalNumberType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
                            });
         }
     }
@@ -30935,17 +30935,17 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
 .AddAttribute(23, "original", a => a.Original)
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-2L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
 });
 });
         }
@@ -31021,13 +31021,13 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
             builder.AddElement<TabStop>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(23, "leader", a => a.Leader)
 .AddAttribute(23, "pos", a => a.Position, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-31680L), MaxInclusive = (31680L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-31680L), MaxInclusive = (31680L) });
 });
         }
 
@@ -31540,19 +31540,19 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
             builder.AddElement<SectionProperties>()
 .AddAttribute(23, "rsidRPr", a => a.RsidRPr, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "rsidDel", a => a.RsidDel, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "rsidR", a => a.RsidR, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "rsidSect", a => a.RsidSect, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 });
         }
 
@@ -31764,7 +31764,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
             builder.AddElement<FormFieldName>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (20L) });
+  aBuilder.AddValidator(new StringValidator() { MaxLength = (20L) });
 });
         }
 
@@ -31853,8 +31853,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
             builder.AddElement<MacroNameType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (33L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new StringValidator() { MaxLength = (33L) });
                            });
         }
     }
@@ -31907,7 +31907,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
 .AddAttribute(23, "type", a => a.Type)
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 });
         }
 
@@ -31963,8 +31963,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
 .AddAttribute(23, "type", a => a.Type)
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (138L), Version = (FileFormatVersions.Office2007) });
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (140L), InitialVersion = (FileFormatVersions.Office2010) });
+aBuilder.AddValidator(new StringValidator() { MaxLength = (138L), Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator(new StringValidator() { MaxLength = (140L), InitialVersion = (FileFormatVersions.Office2010) });
 });
         }
 
@@ -32297,8 +32297,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (140L), Initi
             builder.AddElement<DefaultDropDownListItemIndex>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (24L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (24L) });
 });
         }
 
@@ -32411,8 +32411,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<String255Type>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
                            });
         }
     }
@@ -32451,7 +32451,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<TextBoxFormFieldType>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -32493,8 +32493,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<MaxLength>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L) });
 });
         }
 
@@ -32536,8 +32536,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (1L) });
             builder.AddElement<Format>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (64L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (64L) });
 });
         }
 
@@ -32592,20 +32592,20 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (64L) });
             builder.AddElement<Column>()
 .AddAttribute(23, "w", a => a.Width, aBuilder =>
 {
-   aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+   aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
    aBuilder.AddUnion(union =>
    {
-       union.AddValidator<UInt32Value>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-       union.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+       union.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+       union.AddValidator(new StringValidator() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
    });
 })
 .AddAttribute(23, "space", a => a.Space, aBuilder =>
 {
-   aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+   aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
    aBuilder.AddUnion(union =>
    {
-       union.AddValidator<UInt32Value>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-       union.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+       union.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+       union.AddValidator(new StringValidator() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
    });
 });
         }
@@ -32705,17 +32705,17 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (64L) });
             builder.AddElement<SectionPropertiesChange>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-2L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
 });
 });
         }
@@ -32844,17 +32844,17 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
             builder.AddElement<ParagraphMarkRunPropertiesChange>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-2L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
 });
 });
         }
@@ -33001,7 +33001,7 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
             builder.AddElement<RubyAlign>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -33043,7 +33043,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<PhoneticGuideRaise>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -33085,8 +33085,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<LanguageId>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (84L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new StringValidator() { MaxLength = (84L) });
 });
         }
 
@@ -35600,12 +35600,12 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(23, "uri", a => a.Uri)
 .AddAttribute(23, "name", a => a.Name, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
-  aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), IsNcName = (true), MaxLength = (255L) });
+  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MaxLength = (255L) });
 })
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -35647,11 +35647,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<GridColumn>()
 .AddAttribute(23, "w", a => a.Width, aBuilder =>
 {
-aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
 aBuilder.AddUnion(union =>
 {
-   union.AddValidator<UInt32Value>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-   union.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+   union.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+   union.AddValidator(new StringValidator() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
 });
 });
         }
@@ -35725,11 +35725,11 @@ aBuilder.AddUnion(union =>
             builder.AddElement<TableGridChange>()
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-2L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
 });
 });
         }
@@ -35859,17 +35859,17 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
             builder.AddElement<TableCellPropertiesChange>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-2L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
 });
 });
         }
@@ -36331,17 +36331,17 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
             builder.AddElement<TablePropertiesChange>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-2L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
 });
 });
         }
@@ -36470,17 +36470,17 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
             builder.AddElement<TablePropertyExceptionsChange>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-2L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
 });
 });
         }
@@ -36980,7 +36980,7 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
             builder.AddElement<FootnotePosition>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -37035,11 +37035,11 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
             builder.AddElement<NumberingFormat>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(23, "format", a => a.Format, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -37081,7 +37081,7 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<EndnotePosition>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
+   aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -37184,8 +37184,8 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<FootnoteEndnoteSeparatorReferenceType>()
                            .AddAttribute(23, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-2147483648L), MaxInclusive = (32767L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-2147483648L), MaxInclusive = (32767L) });
                            });
         }
     }
@@ -37271,7 +37271,7 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<UnsignedDecimalNumberType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -37310,7 +37310,7 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<UniqueTag>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -37459,7 +37459,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<MailMergeFieldType>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -37501,7 +37501,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<MailMergeSource>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -37698,7 +37698,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<MainDocumentType>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -37740,7 +37740,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<DataType>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -37782,7 +37782,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Destination>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -37998,13 +37998,13 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<DocumentVariable>()
 .AddAttribute(23, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (1L), MaxLength = (255L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (255L) });
 })
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLength = (65280L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (65280L) });
 });
         }
 
@@ -38141,8 +38141,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
             builder.AddElement<LongHexNumberType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new StringValidator() { Length = (4L) });
                            });
         }
     }
@@ -39550,7 +39550,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
             builder.AddElement<PixelsMeasureType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -39589,7 +39589,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MinLength = (0L), MaxLeng
             builder.AddElement<ScrollbarVisibility>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -39774,12 +39774,12 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TwipsMeasureType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
                                aBuilder.AddUnion(union =>
                                {
-                                   union.AddValidator<UInt32Value>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-                                   union.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+                                   union.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+                                   union.AddValidator(new StringValidator() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
                                });
                            });
         }
@@ -39942,7 +39942,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<FrameLayout>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -40290,7 +40290,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<LevelSuffix>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -40412,20 +40412,20 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(23, "legacy", a => a.Legacy)
 .AddAttribute(23, "legacySpace", a => a.LegacySpace, aBuilder =>
 {
-aBuilder.AddValidator<UInt32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
 aBuilder.AddUnion(union =>
 {
-    union.AddValidator<UInt32Value>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-    union.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+    union.AddValidator<UInt32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+    union.AddValidator(new StringValidator() { Pattern = ("[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
 });
 })
 .AddAttribute(23, "legacyIndent", a => a.LegacyIndent, aBuilder =>
 {
-aBuilder.AddValidator<Int32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator<Int32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
 aBuilder.AddUnion(union =>
 {
-    union.AddValidator<IntegerValue>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-    union.AddValidator(new StringValidatorAttribute() { Pattern = ("-?[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+    union.AddValidator<IntegerValue>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+    union.AddValidator(new StringValidator() { Pattern = ("-?[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
 });
 });
         }
@@ -40468,7 +40468,7 @@ aBuilder.AddUnion(union =>
             builder.AddElement<LevelJustification>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
+ aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -41736,7 +41736,7 @@ aBuilder.AddUnion(union =>
             builder.AddElement<MultiLevelType>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -41857,11 +41857,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Level>()
 .AddAttribute(23, "ilvl", a => a.LevelIndex, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(23, "tplc", a => a.TemplateCode, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "tentative", a => a.Tentative);
         }
@@ -42111,7 +42111,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
             builder.AddElement<LevelOverride>()
 .AddAttribute(23, "ilvl", a => a.LevelIndex, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -42220,7 +42220,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<NumberingPictureBullet>()
 .AddAttribute(23, "numPicBulletId", a => a.NumberingPictureBulletId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -42348,8 +42348,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<AbstractNum>()
 .AddAttribute(23, "abstractNumId", a => a.AbstractNumberId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 });
         }
 
@@ -42521,7 +42521,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
             builder.AddElement<NumberingInstance>()
 .AddAttribute(23, "numId", a => a.NumberID, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -43567,8 +43567,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<StyleName>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
-  aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("[^,]*") });
+  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(new StringValidator() { Pattern = ("[^,]*") });
 });
         }
 
@@ -43610,8 +43610,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<UIPriority>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (99L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (99L) });
 });
         }
 
@@ -44687,7 +44687,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<TableStyleProperties>()
 .AddAttribute(23, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -44870,12 +44870,12 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<LatentStyleExceptionInfo>()
 .AddAttribute(23, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(23, "locked", a => a.Locked)
 .AddAttribute(23, "uiPriority", a => a.UiPriority, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (99L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (99L) });
 })
 .AddAttribute(23, "semiHidden", a => a.SemiHidden)
 .AddAttribute(23, "unhideWhenUsed", a => a.UnhideWhenUsed)
@@ -45108,7 +45108,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
 .AddAttribute(23, "defLockedState", a => a.DefaultLockedState)
 .AddAttribute(23, "defUIPriority", a => a.DefaultUiPriority, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (99L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (99L) });
 })
 .AddAttribute(23, "defSemiHidden", a => a.DefaultSemiHidden)
 .AddAttribute(23, "defUnhideWhenUsed", a => a.DefaultUnhideWhenUsed)
@@ -45274,7 +45274,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
 .AddAttribute(23, "type", a => a.Type)
 .AddAttribute(23, "styleId", a => a.StyleId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (253L) });
+aBuilder.AddValidator(new StringValidator() { MaxLength = (253L) });
 })
 .AddAttribute(23, "default", a => a.Default)
 .AddAttribute(23, "customStyle", a => a.CustomStyle);
@@ -45676,7 +45676,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (253L) });
             builder.AddElement<Font>()
 .AddAttribute(23, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -45973,12 +45973,12 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<SignedTwipsMeasureType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator<Int32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator<Int32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
                                aBuilder.AddUnion(union =>
                                {
-                                   union.AddValidator<IntegerValue>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
-                                   union.AddValidator(new StringValidatorAttribute() { Pattern = ("-?[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
+                                   union.AddValidator<IntegerValue>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2010) });
+                                   union.AddValidator(new StringValidator() { Pattern = ("-?[0-9]+(\\.[0-9]+)?(mm|cm|in|pt|pc|pi)"), InitialVersion = (FileFormatVersions.Office2010) });
                                });
                            });
         }
@@ -46359,11 +46359,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Div>()
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (1L) });
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-1L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (1L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-1L) });
 });
 });
         }
@@ -46609,21 +46609,21 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
             builder.AddElement<Comment>()
 .AddAttribute(23, "initials", a => a.Initials, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (9L) });
+aBuilder.AddValidator(new StringValidator() { MaxLength = (9L) });
 })
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-2L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
 });
 });
         }
@@ -47255,8 +47255,8 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
 .AddAttribute(23, "type", a => a.Type)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-2147483648L), MaxInclusive = (32767L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-2147483648L), MaxInclusive = (32767L) });
 });
         }
     }
@@ -47295,7 +47295,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (-21474836
             builder.AddElement<Behavior>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -47337,7 +47337,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<DocPartType>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -47379,7 +47379,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Gallery>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -47434,13 +47434,13 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<AutoCaption>()
 .AddAttribute(23, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "caption", a => a.Caption, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 });
         }
 
@@ -47566,8 +47566,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
             builder.AddElement<Caption>()
 .AddAttribute(23, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "pos", a => a.Position)
 .AddAttribute(23, "chapNum", a => a.ChapterNumber)
@@ -47749,18 +47749,18 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(new EnumValidatorAttribute());
-union.AddValidator<HexBinaryValue>(new StringValidatorAttribute() { Length = (3L) });
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(new EnumValidator());
+union.AddValidator<HexBinaryValue>(new StringValidator() { Length = (3L) });
 });
 })
 .AddAttribute(23, "themeColor", a => a.ThemeColor)
 .AddAttribute(23, "themeTint", a => a.ThemeTint, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
+aBuilder.AddValidator(new StringValidator() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
 })
 .AddAttribute(23, "themeShade", a => a.ThemeShade, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
+aBuilder.AddValidator(new StringValidator() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
 });
         }
 
@@ -47898,7 +47898,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9a-fA-F]*"
             builder.AddElement<DocPartName>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(23, "decorated", a => a.Decorated);
         }
@@ -48171,7 +48171,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9a-fA-F]*"
             builder.AddElement<DocPartId>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+  aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
         }
 
@@ -49022,15 +49022,15 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9a-fA-F]*"
             builder.AddElement<CompatibilitySetting>()
 .AddAttribute(23, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(23, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -49138,12 +49138,12 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TableWidthDxaNilType>()
                            .AddAttribute(23, "w", a => a.Width, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
                            })
                            .AddAttribute(23, "type", a => a.Type, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }
@@ -49598,17 +49598,17 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<TableRowPropertiesChange>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (255L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MinInclusive = (0L) });
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (-2L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
+union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
 });
 });
         }
@@ -50372,7 +50372,7 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { MaxInclusive = (
 .AddAttribute(23, "name", a => a.Name)
 .AddAttribute(23, "shapeid", a => a.ShapeId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (254L) });
+aBuilder.AddValidator(new StringValidator() { MaxLength = (254L) });
 })
 .AddAttribute(19, "id", a => a.Id);
         }
@@ -50537,7 +50537,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (254L) });
 .AddAttribute(23, "drawAspect", a => a.drawAspect)
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(23, "progId", a => a.ProgId)
 .AddAttribute(23, "shapeId", a => a.ShapeId)
@@ -50660,13 +50660,13 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<ObjectLink>()
 .AddAttribute(23, "updateMode", a => a.UpdateMode, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(23, "lockedField", a => a.LockedField)
 .AddAttribute(23, "drawAspect", a => a.drawAspect)
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(23, "progId", a => a.ProgId)
 .AddAttribute(23, "shapeId", a => a.ShapeId)
@@ -50852,11 +50852,11 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(23, "prefixMappings", a => a.PrefixMappings)
 .AddAttribute(23, "xpath", a => a.XPath, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(23, "storeItemID", a => a.StoreItemId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -51666,36 +51666,36 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(23, "cryptAlgorithmSid", a => a.CryptographicAlgorithmSid)
 .AddAttribute(23, "cryptSpinCount", a => a.CryptographicSpinCount, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MaxInclusive = (5000000L) });
+aBuilder.AddValidator(new NumberValidator() { MaxInclusive = (5000000L) });
 })
 .AddAttribute(23, "cryptProvider", a => a.CryptographicProvider)
 .AddAttribute(23, "algIdExt", a => a.AlgorithmIdExtensibility, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "algIdExtSource", a => a.AlgorithmIdExtensibilitySource)
 .AddAttribute(23, "cryptProviderTypeExt", a => a.CryptographicProviderTypeExtensibility, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "cryptProviderTypeExtSource", a => a.CryptographicProviderTypeExtSource)
 .AddAttribute(23, "hash", a => a.Hash)
 .AddAttribute(23, "salt", a => a.Salt)
 .AddAttribute(23, "algorithmName", a => a.AlgorithmName, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "hashValue", a => a.HashValue, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "saltValue", a => a.SaltValue, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "spinCount", a => a.SpinCount, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -51737,7 +51737,7 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<View>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidatorAttribute());
+  aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -51793,16 +51793,16 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
 .AddAttribute(23, "val", a => a.Val)
 .AddAttribute(23, "percent", a => a.Percent, aBuilder =>
 {
-  aBuilder.AddValidator<Int32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+  aBuilder.AddValidator<Int32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
   aBuilder.AddUnion(union =>
   {
-      union.AddValidator(new StringValidatorAttribute() { Pattern = ("-?[0-9]+(\\.[0-9]+)?%"), Version = (FileFormatVersions.Office2010) });
-      union.AddValidator<Int32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2010) });
+      union.AddValidator(new StringValidator() { Pattern = ("-?[0-9]+(\\.[0-9]+)?%"), Version = (FileFormatVersions.Office2010) });
+      union.AddValidator<Int32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2010) });
   });
   aBuilder.AddUnion(union =>
   {
-      union.AddValidator(new StringValidatorAttribute() { Pattern = ("-?[0-9]+(\\.[0-9]+)?%"), InitialVersion = (FileFormatVersions.Office2013) });
-      union.AddValidator<Int32Value>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2013) });
+      union.AddValidator(new StringValidator() { Pattern = ("-?[0-9]+(\\.[0-9]+)?%"), InitialVersion = (FileFormatVersions.Office2013) });
+      union.AddValidator<Int32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2013) });
   });
 });
         }
@@ -51910,26 +51910,26 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<ActiveWritingStyle>()
 .AddAttribute(23, "lang", a => a.Language, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (84L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (84L) });
 })
 .AddAttribute(23, "vendorID", a => a.VendorID, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(23, "dllVersion", a => a.DllVersion, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 })
 .AddAttribute(23, "nlCheck", a => a.NaturalLanguageGrammarCheck)
 .AddAttribute(23, "checkStyle", a => a.CheckStyle, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(23, "appName", a => a.ApplicationName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -52219,67 +52219,67 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<StylePaneFormatFilter>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (2L) });
+aBuilder.AddValidator(new StringValidator() { Length = (2L) });
 })
 .AddAttribute(23, "allStyles", a => a.AllStyles, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "customStyles", a => a.CustomStyles, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "latentStyles", a => a.LatentStyles, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "stylesInUse", a => a.StylesInUse, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "headingStyles", a => a.HeadingStyles, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "numberingStyles", a => a.NumberingStyles, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "tableStyles", a => a.TableStyles, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "directFormattingOnRuns", a => a.DirectFormattingOnRuns, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "directFormattingOnParagraphs", a => a.DirectFormattingOnParagraphs, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "directFormattingOnNumbering", a => a.DirectFormattingOnNumbering, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "directFormattingOnTables", a => a.DirectFormattingOnTables, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "clearFormatting", a => a.ClearFormatting, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "top3HeadingStyles", a => a.Top3HeadingStyles, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "visibleStyles", a => a.VisibleStyles, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "alternateStyleNames", a => a.AlternateStyleNames, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -52327,9 +52327,9 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<StylePaneSortMethods>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator<HexBinaryValue>(new StringValidatorAttribute() { Length = (2L), Version = (FileFormatVersions.Office2007) });
-aBuilder.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.StylePaneSortMethodsValues>>(new EnumValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2010) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator<HexBinaryValue>(new StringValidator() { Length = (2L), Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.StylePaneSortMethodsValues>>(new EnumValidator() { InitialVersion = (FileFormatVersions.Office2010) });
 });
         }
 
@@ -52371,7 +52371,7 @@ aBuilder.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.StylePaneS
             builder.AddElement<DocumentType>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -53064,36 +53064,36 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 .AddAttribute(23, "cryptAlgorithmSid", a => a.CryptographicAlgorithmSid)
 .AddAttribute(23, "cryptSpinCount", a => a.CryptographicSpinCount, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MaxInclusive = (5000000L) });
+aBuilder.AddValidator(new NumberValidator() { MaxInclusive = (5000000L) });
 })
 .AddAttribute(23, "cryptProvider", a => a.CryptographicProvider)
 .AddAttribute(23, "algIdExt", a => a.AlgorithmIdExtensibility, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "algIdExtSource", a => a.AlgorithmIdExtensibilitySource)
 .AddAttribute(23, "cryptProviderTypeExt", a => a.CryptographicProviderTypeExtensibility, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "cryptProviderTypeExtSource", a => a.CryptographicProviderTypeExtSource)
 .AddAttribute(23, "hash", a => a.Hash)
 .AddAttribute(23, "salt", a => a.Salt)
 .AddAttribute(23, "algorithmName", a => a.AlgorithmName, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "hashValue", a => a.HashValue, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "saltValue", a => a.SaltValue, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 })
 .AddAttribute(23, "spinCount", a => a.SpinCount, aBuilder =>
 {
-aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2010));
+aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
         }
 
@@ -53188,8 +53188,8 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<NonNegativeShortType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
                            });
         }
     }
@@ -53228,7 +53228,7 @@ aBuilder.AddValidator(new OfficeAvailabilityAttribute(FileFormatVersions.Office2
             builder.AddElement<ConsecutiveHyphenLimit>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -53270,8 +53270,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<SummaryLength>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (100L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100L) });
 });
         }
 
@@ -53360,8 +53360,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<UnsignedInt7Type>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
-                               aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (127L) });
+                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (127L) });
                            });
         }
     }
@@ -53400,7 +53400,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<CharacterSpacingControl>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -53455,13 +53455,13 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<NoLineBreaksAfterKinsoku>()
 .AddAttribute(23, "lang", a => a.Language, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (84L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (84L) });
 })
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (50L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (50L) });
 });
         }
 
@@ -53516,13 +53516,13 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (50L) });
             builder.AddElement<NoLineBreaksBeforeKinsoku>()
 .AddAttribute(23, "lang", a => a.Language, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (84L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (84L) });
 })
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (100L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { MaxLength = (100L) });
 });
         }
 
@@ -55618,25 +55618,25 @@ aBuilder.AddValidator(new StringValidatorAttribute() { MaxLength = (100L) });
 .AddAttribute(23, "actualPg", a => a.UseActualPages)
 .AddAttribute(23, "w", a => a.Width, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(23, "h", a => a.Height, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(23, "fontSz", a => a.FontSize, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator<Int32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2007) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator<Int32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
 aBuilder.AddUnion(union =>
 {
-union.AddValidator(new StringValidatorAttribute() { Pattern = ("-?[0-9]+(\\.[0-9]+)?%"), Version = (FileFormatVersions.Office2010) });
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { Version = (FileFormatVersions.Office2010) });
+union.AddValidator(new StringValidator() { Pattern = ("-?[0-9]+(\\.[0-9]+)?%"), Version = (FileFormatVersions.Office2010) });
+union.AddValidator<Int32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2010) });
 });
 aBuilder.AddUnion(union =>
 {
-union.AddValidator(new StringValidatorAttribute() { Pattern = ("-?[0-9]+(\\.[0-9]+)?%"), InitialVersion = (FileFormatVersions.Office2013) });
-union.AddValidator<Int32Value>(new NumberValidatorAttribute() { InitialVersion = (FileFormatVersions.Office2013) });
+union.AddValidator(new StringValidator() { Pattern = ("-?[0-9]+(\\.[0-9]+)?%"), InitialVersion = (FileFormatVersions.Office2013) });
+union.AddValidator<Int32Value>(new NumberValidator() { InitialVersion = (FileFormatVersions.Office2013) });
 });
 });
         }
@@ -55679,7 +55679,7 @@ union.AddValidator<Int32Value>(new NumberValidatorAttribute() { InitialVersion =
             builder.AddElement<TargetScreenSize>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -55813,8 +55813,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Panose1Number>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { Length = (10L) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { Length = (10L) });
 });
         }
 
@@ -55869,7 +55869,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Length = (10L) });
             builder.AddElement<FontCharSet>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
+aBuilder.AddValidator(new StringValidator() { Pattern = ("[0-9a-fA-F]*"), MinLength = (1L), MaxLength = (2L) });
 })
 .AddAttribute(23, "characterSet", a => a.StrictCharacterSet);
         }
@@ -55912,7 +55912,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { Pattern = ("[0-9a-fA-F]*"
             builder.AddElement<FontFamily>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -55954,7 +55954,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Pitch>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
+ aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -56061,33 +56061,33 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<FontSignature>()
 .AddAttribute(23, "usb0", a => a.UnicodeSignature0, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "usb1", a => a.UnicodeSignature1, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "usb2", a => a.UnicodeSignature2, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "usb3", a => a.UnicodeSignature3, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "csb0", a => a.CodePageSignature0, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "csb1", a => a.CodePageSignature1, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidatorAttribute());
-   aBuilder.AddValidator(new StringValidatorAttribute() { Length = (4L) });
+   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 });
         }
 
@@ -56282,12 +56282,12 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<FontRelationshipType>()
                            .AddAttribute(23, "fontKey", a => a.FontKey, aBuilder =>
                            {
-                               aBuilder.AddValidator(new StringValidatorAttribute() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
+                               aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
                            })
                            .AddAttribute(23, "subsetted", a => a.Subsetted)
                            .AddAttribute(19, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidatorAttribute());
+                               aBuilder.AddValidator(new RequiredValidator());
                            });
         }
     }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_wordprocessingml_2006_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_wordprocessingml_2006_main.g.cs
@@ -367,13 +367,13 @@ namespace DocumentFormat.OpenXml.Wordprocessing
             builder.AddElement<TrackChangeType>()
                            .AddAttribute(23, "author", a => a.Author, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
                            })
                            .AddAttribute(23, "date", a => a.Date)
                            .AddAttribute(23, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddUnion(union =>
                                {
                                    union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
@@ -471,13 +471,13 @@ namespace DocumentFormat.OpenXml.Wordprocessing
 .AddAttribute(23, "vMergeOrig", a => a.VerticalMergeOriginal)
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
  union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
@@ -582,7 +582,7 @@ aBuilder.AddUnion(union =>
             builder.AddElement<BookmarkStart>()
 .AddAttribute(23, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (40L) });
 })
 .AddAttribute(23, "colFirst", a => a.ColumnFirst)
@@ -590,7 +590,7 @@ aBuilder.AddValidator(new StringValidator() { MaxLength = (40L) });
 .AddAttribute(23, "displacedByCustomXml", a => a.DisplacedByCustomXml)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
@@ -808,7 +808,7 @@ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
                            .AddAttribute(23, "displacedByCustomXml", a => a.DisplacedByCustomXml)
                            .AddAttribute(23, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddUnion(union =>
                                {
                                    union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
@@ -989,15 +989,15 @@ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
             builder.AddElement<MoveBookmarkType>()
                            .AddAttribute(23, "author", a => a.Author, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            })
                            .AddAttribute(23, "date", a => a.Date, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            })
                            .AddAttribute(23, "name", a => a.Name, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new StringValidator() { MaxLength = (40L) });
                            })
                            .AddAttribute(23, "colFirst", a => a.ColumnFirst)
@@ -1005,7 +1005,7 @@ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
                            .AddAttribute(23, "displacedByCustomXml", a => a.DisplacedByCustomXml)
                            .AddAttribute(23, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddUnion(union =>
                                {
                                    union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
@@ -1193,7 +1193,7 @@ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
             builder.AddElement<MarkupType>()
                            .AddAttribute(23, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddUnion(union =>
                                {
                                    union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
@@ -1886,7 +1886,7 @@ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
             builder.AddElement<StringType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -7087,13 +7087,13 @@ aBuilder.AddUnion(union =>
             builder.AddElement<Shading>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(23, "color", a => a.Color, aBuilder =>
 {
    aBuilder.AddUnion(union =>
    {
-       union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(new EnumValidator());
+       union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(EnumValidator.Instance);
        union.AddValidator<HexBinaryValue>(new StringValidator() { Length = (3L) });
    });
 })
@@ -7110,7 +7110,7 @@ aBuilder.AddUnion(union =>
 {
    aBuilder.AddUnion(union =>
    {
-       union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(new EnumValidator());
+       union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(EnumValidator.Instance);
        union.AddValidator<HexBinaryValue>(new StringValidator() { Length = (3L) });
    });
 })
@@ -7635,7 +7635,7 @@ aBuilder.AddUnion(union =>
             builder.AddElement<Justification>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidator());
+    aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -7677,7 +7677,7 @@ aBuilder.AddUnion(union =>
             builder.AddElement<TextDirection>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -7719,7 +7719,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<TextAlignment>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -7761,7 +7761,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<TextBoxTightWrap>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -8120,7 +8120,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<DecimalNumberType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -8216,13 +8216,13 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ParagraphPropertiesChange>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
@@ -8372,11 +8372,11 @@ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
             builder.AddElement<HeaderFooterReferenceType>()
                            .AddAttribute(23, "type", a => a.Type, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            })
                            .AddAttribute(19, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -9681,7 +9681,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
             builder.AddElement<FieldChar>()
 .AddAttribute(23, "fldCharType", a => a.FieldCharType, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(23, "fldLock", a => a.FieldLock)
 .AddAttribute(23, "dirty", a => a.Dirty);
@@ -9947,7 +9947,7 @@ aBuilder.AddValidator(new RequiredValidator());
                            .AddAttribute(23, "customMarkFollows", a => a.CustomMarkFollows)
                            .AddAttribute(23, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-2147483648L), MaxInclusive = (32767L) });
                            });
         }
@@ -10104,15 +10104,15 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<PositionalTab>()
 .AddAttribute(23, "alignment", a => a.Alignment, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(23, "relativeTo", a => a.RelativeTo, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(23, "leader", a => a.Leader, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -10441,7 +10441,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<String253Type>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new StringValidator() { MaxLength = (253L) });
                            });
         }
@@ -10683,10 +10683,10 @@ aBuilder.AddValidator(new StringValidator() { MaxLength = (31L) });
             builder.AddElement<Color>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
  aBuilder.AddUnion(union =>
  {
-     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(new EnumValidator());
+     union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(EnumValidator.Instance);
      union.AddValidator<HexBinaryValue>(new StringValidator() { Length = (3L) });
  });
 })
@@ -10739,7 +10739,7 @@ aBuilder.AddValidator(new StringValidator() { MaxLength = (31L) });
             builder.AddElement<Spacing>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-31680L), MaxInclusive = (31680L) });
 });
         }
@@ -10824,7 +10824,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-31680L), MaxInclu
             builder.AddElement<Kern>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
   aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (3277L) });
 });
         }
@@ -10867,7 +10867,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-31680L), MaxInclu
             builder.AddElement<Position>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator<Int32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
 aBuilder.AddUnion(union =>
 {
@@ -11034,7 +11034,7 @@ aBuilder.AddUnion(union =>
             builder.AddElement<HpsMeasureType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator<UInt32Value>(new NumberValidator() { MinInclusive = (2L), MaxInclusive = (3277L), Version = (FileFormatVersions.Office2007) });
                                aBuilder.AddUnion(union =>
                                {
@@ -11079,7 +11079,7 @@ aBuilder.AddUnion(union =>
             builder.AddElement<Highlight>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -11176,7 +11176,7 @@ aBuilder.AddValidator(new RequiredValidator());
  {
      aBuilder.AddUnion(union =>
      {
-         union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(new EnumValidator());
+         union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(EnumValidator.Instance);
          union.AddValidator<HexBinaryValue>(new StringValidator() { Length = (3L) });
      });
  })
@@ -11229,7 +11229,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<TextEffect>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -11688,13 +11688,13 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<BorderType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            })
                            .AddAttribute(23, "color", a => a.Color, aBuilder =>
                            {
                                aBuilder.AddUnion(union =>
                                {
-                                   union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(new EnumValidator());
+                                   union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(EnumValidator.Instance);
                                    union.AddValidator<HexBinaryValue>(new StringValidator() { Length = (3L) });
                                });
                            })
@@ -11764,7 +11764,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<FitText>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MaxInclusive = (31680L) });
 })
 .AddAttribute(23, "id", a => a.Id);
@@ -11808,7 +11808,7 @@ aBuilder.AddValidator(new NumberValidator() { MaxInclusive = (31680L) });
             builder.AddElement<VerticalTextAlignment>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -11850,7 +11850,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Emphasis>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidator());
+    aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -12164,13 +12164,13 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RunPropertiesChange>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
@@ -13246,13 +13246,13 @@ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
             builder.AddElement<InsertedMathControl>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
@@ -13385,13 +13385,13 @@ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
             builder.AddElement<DeletedMathControl>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
@@ -13692,13 +13692,13 @@ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
             builder.AddElement<MathControlMoveType>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
@@ -14212,7 +14212,7 @@ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
             builder.AddElement<SimpleFieldRuby>()
 .AddAttribute(23, "instr", a => a.Instruction, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(23, "fldLock", a => a.FieldLock)
 .AddAttribute(23, "dirty", a => a.Dirty);
@@ -15189,7 +15189,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
             builder.AddElement<ProofError>()
 .AddAttribute(23, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -15306,7 +15306,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 })
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(23, "displacedByCustomXml", a => a.DisplacedByCustomXml);
         }
@@ -15368,7 +15368,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<PermEnd>()
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(23, "displacedByCustomXml", a => a.DisplacedByCustomXml);
         }
@@ -16615,13 +16615,13 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<RunTrackChangeType>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
@@ -16666,7 +16666,7 @@ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
             builder.AddElement<ContentPart>()
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -19796,7 +19796,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
             builder.AddElement<SimpleField>()
 .AddAttribute(23, "instr", a => a.Instruction, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(23, "fldLock", a => a.FieldLock)
 .AddAttribute(23, "dirty", a => a.Dirty);
@@ -21381,7 +21381,7 @@ aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
             builder.AddElement<RelationshipType>()
                            .AddAttribute(19, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -22947,7 +22947,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
             builder.AddElement<TableCellVerticalAlignment>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -22989,7 +22989,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<DivId>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
  aBuilder.AddUnion(union =>
  {
      union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (1L) });
@@ -23098,7 +23098,7 @@ aBuilder.AddValidator(new NumberValidator() { MaxInclusive = (31680L) });
             builder.AddElement<TableJustification>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-    aBuilder.AddValidator(new RequiredValidator());
+    aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -23323,7 +23323,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-31680L), MaxInclu
             builder.AddElement<TableOverlap>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -23412,7 +23412,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<UnsignedDecimalNumberMax3Type>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (3L) });
                            });
         }
@@ -23886,7 +23886,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<NumberingStart>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -23928,7 +23928,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<NumberingRestart>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -24469,7 +24469,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
             builder.AddElement<SectionType>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -25270,7 +25270,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L), MaxInclusive 
             builder.AddElement<VerticalTextAlignmentOnPage>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -30741,7 +30741,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
             builder.AddElement<NumberingLevelReference>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
   aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (255L) });
 });
         }
@@ -30855,7 +30855,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
             builder.AddElement<NonNegativeDecimalNumberType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
                            });
         }
@@ -30935,13 +30935,13 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 .AddAttribute(23, "original", a => a.Original)
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
@@ -31021,12 +31021,12 @@ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
             builder.AddElement<TabStop>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(23, "leader", a => a.Leader)
 .AddAttribute(23, "pos", a => a.Position, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-31680L), MaxInclusive = (31680L) });
 });
         }
@@ -31853,7 +31853,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
             builder.AddElement<MacroNameType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new StringValidator() { MaxLength = (33L) });
                            });
         }
@@ -32297,7 +32297,7 @@ aBuilder.AddValidator(new StringValidator() { MaxLength = (140L), InitialVersion
             builder.AddElement<DefaultDropDownListItemIndex>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (24L) });
 });
         }
@@ -32411,7 +32411,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<String255Type>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
                            });
         }
@@ -32451,7 +32451,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<TextBoxFormFieldType>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -32493,7 +32493,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<MaxLength>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L) });
 });
         }
@@ -32536,7 +32536,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (1L) });
             builder.AddElement<Format>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (64L) });
 });
         }
@@ -32705,13 +32705,13 @@ aBuilder.AddValidator(new StringValidator() { MaxLength = (64L) });
             builder.AddElement<SectionPropertiesChange>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
@@ -32844,13 +32844,13 @@ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
             builder.AddElement<ParagraphMarkRunPropertiesChange>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
@@ -33001,7 +33001,7 @@ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
             builder.AddElement<RubyAlign>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -33043,7 +33043,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<PhoneticGuideRaise>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -33085,7 +33085,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<LanguageId>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new StringValidator() { MaxLength = (84L) });
 });
         }
@@ -35600,12 +35600,12 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(23, "uri", a => a.Uri)
 .AddAttribute(23, "name", a => a.Name, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
   aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true), MaxLength = (255L) });
 })
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -35725,7 +35725,7 @@ aBuilder.AddUnion(union =>
             builder.AddElement<TableGridChange>()
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
@@ -35859,13 +35859,13 @@ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
             builder.AddElement<TableCellPropertiesChange>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
@@ -36331,13 +36331,13 @@ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
             builder.AddElement<TablePropertiesChange>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
@@ -36470,13 +36470,13 @@ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
             builder.AddElement<TablePropertyExceptionsChange>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
@@ -36980,7 +36980,7 @@ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
             builder.AddElement<FootnotePosition>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -37035,7 +37035,7 @@ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
             builder.AddElement<NumberingFormat>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(23, "format", a => a.Format, aBuilder =>
 {
@@ -37081,7 +37081,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
             builder.AddElement<EndnotePosition>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -37184,7 +37184,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
             builder.AddElement<FootnoteEndnoteSeparatorReferenceType>()
                            .AddAttribute(23, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-2147483648L), MaxInclusive = (32767L) });
                            });
         }
@@ -37271,7 +37271,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
             builder.AddElement<UnsignedDecimalNumberType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -37310,7 +37310,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
             builder.AddElement<UniqueTag>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -37459,7 +37459,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<MailMergeFieldType>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -37501,7 +37501,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<MailMergeSource>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -37698,7 +37698,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<MainDocumentType>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -37740,7 +37740,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<DataType>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -37782,7 +37782,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Destination>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -37998,12 +37998,12 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<DocumentVariable>()
 .AddAttribute(23, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (255L) });
 })
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (65280L) });
 });
         }
@@ -38141,7 +38141,7 @@ aBuilder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (652
             builder.AddElement<LongHexNumberType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new StringValidator() { Length = (4L) });
                            });
         }
@@ -39550,7 +39550,7 @@ aBuilder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (652
             builder.AddElement<PixelsMeasureType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -39589,7 +39589,7 @@ aBuilder.AddValidator(new StringValidator() { MinLength = (0L), MaxLength = (652
             builder.AddElement<ScrollbarVisibility>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -39774,7 +39774,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<TwipsMeasureType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator<UInt32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
                                aBuilder.AddUnion(union =>
                                {
@@ -39942,7 +39942,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<FrameLayout>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -40290,7 +40290,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<LevelSuffix>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -40468,7 +40468,7 @@ aBuilder.AddUnion(union =>
             builder.AddElement<LevelJustification>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -41736,7 +41736,7 @@ aBuilder.AddUnion(union =>
             builder.AddElement<MultiLevelType>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -41857,7 +41857,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Level>()
 .AddAttribute(23, "ilvl", a => a.LevelIndex, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(23, "tplc", a => a.TemplateCode, aBuilder =>
 {
@@ -42111,7 +42111,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
             builder.AddElement<LevelOverride>()
 .AddAttribute(23, "ilvl", a => a.LevelIndex, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -42220,7 +42220,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<NumberingPictureBullet>()
 .AddAttribute(23, "numPicBulletId", a => a.NumberingPictureBulletId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -42348,7 +42348,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<AbstractNum>()
 .AddAttribute(23, "abstractNumId", a => a.AbstractNumberId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 });
         }
@@ -42521,7 +42521,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
             builder.AddElement<NumberingInstance>()
 .AddAttribute(23, "numId", a => a.NumberID, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -43567,7 +43567,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<StyleName>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
   aBuilder.AddValidator(new StringValidator() { Pattern = ("[^,]*") });
 });
         }
@@ -43610,7 +43610,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<UIPriority>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (99L) });
 });
         }
@@ -44687,7 +44687,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<TableStyleProperties>()
 .AddAttribute(23, "type", a => a.Type, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -44870,7 +44870,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<LatentStyleExceptionInfo>()
 .AddAttribute(23, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(23, "locked", a => a.Locked)
 .AddAttribute(23, "uiPriority", a => a.UiPriority, aBuilder =>
@@ -45676,7 +45676,7 @@ aBuilder.AddValidator(new StringValidator() { MaxLength = (253L) });
             builder.AddElement<Font>()
 .AddAttribute(23, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -45973,7 +45973,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<SignedTwipsMeasureType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator<Int32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
                                aBuilder.AddUnion(union =>
                                {
@@ -46359,7 +46359,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Div>()
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (1L) });
@@ -46613,13 +46613,13 @@ aBuilder.AddValidator(new StringValidator() { MaxLength = (9L) });
 })
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
@@ -47255,7 +47255,7 @@ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
 .AddAttribute(23, "type", a => a.Type)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-2147483648L), MaxInclusive = (32767L) });
 });
         }
@@ -47295,7 +47295,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-2147483648L), Max
             builder.AddElement<Behavior>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -47337,7 +47337,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<DocPartType>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -47379,7 +47379,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Gallery>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -47434,12 +47434,12 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<AutoCaption>()
 .AddAttribute(23, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "caption", a => a.Caption, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 });
         }
@@ -47566,7 +47566,7 @@ aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
             builder.AddElement<Caption>()
 .AddAttribute(23, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "pos", a => a.Position)
@@ -47749,7 +47749,7 @@ aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.AutomaticColorValues>>(EnumValidator.Instance);
 union.AddValidator<HexBinaryValue>(new StringValidator() { Length = (3L) });
 });
 })
@@ -47898,7 +47898,7 @@ aBuilder.AddValidator(new StringValidator() { Pattern = ("[0-9a-fA-F]*"), MinLen
             builder.AddElement<DocPartName>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(23, "decorated", a => a.Decorated);
         }
@@ -49022,15 +49022,15 @@ aBuilder.AddValidator(new StringValidator() { Pattern = ("[0-9a-fA-F]*"), MinLen
             builder.AddElement<CompatibilitySetting>()
 .AddAttribute(23, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(23, "uri", a => a.Uri, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -49138,12 +49138,12 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<TableWidthDxaNilType>()
                            .AddAttribute(23, "w", a => a.Width, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
                            })
                            .AddAttribute(23, "type", a => a.Type, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }
@@ -49598,13 +49598,13 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<TableRowPropertiesChange>()
 .AddAttribute(23, "author", a => a.Author, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
 })
 .AddAttribute(23, "date", a => a.Date)
 .AddAttribute(23, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
 union.AddValidator<Int32Value>(new NumberValidator() { MinInclusive = (0L) });
@@ -50537,7 +50537,7 @@ aBuilder.AddValidator(new StringValidator() { MaxLength = (254L) });
 .AddAttribute(23, "drawAspect", a => a.drawAspect)
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(23, "progId", a => a.ProgId)
 .AddAttribute(23, "shapeId", a => a.ShapeId)
@@ -50660,13 +50660,13 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<ObjectLink>()
 .AddAttribute(23, "updateMode", a => a.UpdateMode, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(23, "lockedField", a => a.LockedField)
 .AddAttribute(23, "drawAspect", a => a.drawAspect)
 .AddAttribute(19, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(23, "progId", a => a.ProgId)
 .AddAttribute(23, "shapeId", a => a.ShapeId)
@@ -50852,11 +50852,11 @@ aBuilder.AddValidator(new RequiredValidator());
 .AddAttribute(23, "prefixMappings", a => a.PrefixMappings)
 .AddAttribute(23, "xpath", a => a.XPath, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(23, "storeItemID", a => a.StoreItemId, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -51737,7 +51737,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
             builder.AddElement<View>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-  aBuilder.AddValidator(new RequiredValidator());
+  aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -51910,26 +51910,26 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
             builder.AddElement<ActiveWritingStyle>()
 .AddAttribute(23, "lang", a => a.Language, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (84L) });
 })
 .AddAttribute(23, "vendorID", a => a.VendorID, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(23, "dllVersion", a => a.DllVersion, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 })
 .AddAttribute(23, "nlCheck", a => a.NaturalLanguageGrammarCheck)
 .AddAttribute(23, "checkStyle", a => a.CheckStyle, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(23, "appName", a => a.ApplicationName, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -52327,7 +52327,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
             builder.AddElement<StylePaneSortMethods>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator<HexBinaryValue>(new StringValidator() { Length = (2L), Version = (FileFormatVersions.Office2007) });
 aBuilder.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.StylePaneSortMethodsValues>>(new EnumValidator() { InitialVersion = (FileFormatVersions.Office2010) });
 });
@@ -52371,7 +52371,7 @@ aBuilder.AddValidator<EnumValue<DocumentFormat.OpenXml.Wordprocessing.StylePaneS
             builder.AddElement<DocumentType>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -53188,7 +53188,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
             builder.AddElement<NonNegativeShortType>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
                            });
         }
@@ -53228,7 +53228,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
             builder.AddElement<ConsecutiveHyphenLimit>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -53270,7 +53270,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<SummaryLength>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (100L) });
 });
         }
@@ -53360,7 +53360,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<UnsignedInt7Type>()
                            .AddAttribute(23, "val", a => a.Val, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                                aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (127L) });
                            });
         }
@@ -53400,7 +53400,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<CharacterSpacingControl>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -53455,12 +53455,12 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<NoLineBreaksAfterKinsoku>()
 .AddAttribute(23, "lang", a => a.Language, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (84L) });
 })
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (50L) });
 });
         }
@@ -53516,12 +53516,12 @@ aBuilder.AddValidator(new StringValidator() { MaxLength = (50L) });
             builder.AddElement<NoLineBreaksBeforeKinsoku>()
 .AddAttribute(23, "lang", a => a.Language, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (84L) });
 })
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { MaxLength = (100L) });
 });
         }
@@ -55618,15 +55618,15 @@ aBuilder.AddValidator(new StringValidator() { MaxLength = (100L) });
 .AddAttribute(23, "actualPg", a => a.UseActualPages)
 .AddAttribute(23, "w", a => a.Width, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(23, "h", a => a.Height, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(23, "fontSz", a => a.FontSize, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator<Int32Value>(new NumberValidator() { Version = (FileFormatVersions.Office2007) });
 aBuilder.AddUnion(union =>
 {
@@ -55679,7 +55679,7 @@ union.AddValidator<Int32Value>(new NumberValidator() { InitialVersion = (FileFor
             builder.AddElement<TargetScreenSize>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -55813,7 +55813,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Panose1Number>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { Length = (10L) });
 });
         }
@@ -55912,7 +55912,7 @@ aBuilder.AddValidator(new StringValidator() { Pattern = ("[0-9a-fA-F]*"), MinLen
             builder.AddElement<FontFamily>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -55954,7 +55954,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Pitch>()
 .AddAttribute(23, "val", a => a.Val, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -56061,32 +56061,32 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<FontSignature>()
 .AddAttribute(23, "usb0", a => a.UnicodeSignature0, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "usb1", a => a.UnicodeSignature1, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "usb2", a => a.UnicodeSignature2, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "usb3", a => a.UnicodeSignature3, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "csb0", a => a.CodePageSignature0, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 })
 .AddAttribute(23, "csb1", a => a.CodePageSignature1, aBuilder =>
 {
-   aBuilder.AddValidator(new RequiredValidator());
+   aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new StringValidator() { Length = (4L) });
 });
         }
@@ -56287,7 +56287,7 @@ aBuilder.AddValidator(new RequiredValidator());
                            .AddAttribute(23, "subsetted", a => a.Subsetted)
                            .AddAttribute(19, "id", a => a.Id, aBuilder =>
                            {
-                               aBuilder.AddValidator(new RequiredValidator());
+                               aBuilder.AddValidator(RequiredValidator.Instance);
                            });
         }
     }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/www_w3_org_2003_04_emma.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/www_w3_org_2003_04_emma.g.cs
@@ -55,7 +55,7 @@ namespace DocumentFormat.OpenXml.EMMA
             builder.AddElement<DerivedFrom>()
 .AddAttribute(0, "resource", a => a.Resource, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 })
 .AddAttribute(0, "composite", a => a.Composite);
@@ -235,12 +235,12 @@ aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
             builder.AddElement<Lattice>()
 .AddAttribute(0, "initial", a => a.Initial, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { IsNonNegative = (true) });
 })
 .AddAttribute(0, "final", a => a.Final, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(44, "time-ref-uri", a => a.TimeReference)
 .AddAttribute(44, "time-ref-anchor-point", a => a.TimeReferenceAnchorPoint);
@@ -690,7 +690,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Interpretation>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true) });
 })
 .AddAttribute(44, "tokens", a => a.Tokens)
@@ -1133,7 +1133,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
 .AddAttribute(0, "disjunction-type", a => a.DisjunctionType)
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true) });
 })
 .AddAttribute(44, "tokens", a => a.Tokens)
@@ -1565,7 +1565,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<Group>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true) });
 })
 .AddAttribute(44, "tokens", a => a.Tokens)
@@ -1990,7 +1990,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<Sequence>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true) });
 })
 .AddAttribute(44, "tokens", a => a.Tokens)
@@ -2225,12 +2225,12 @@ aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
             builder.AddElement<Grammar>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true) });
 })
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 });
         }
@@ -2304,7 +2304,7 @@ aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
             builder.AddElement<Model>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(RequiredValidator.Instance);
  aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true) });
 })
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
@@ -2386,7 +2386,7 @@ aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
             builder.AddElement<EndPointInfo>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true) });
 });
         }
@@ -2587,7 +2587,7 @@ aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), I
             builder.AddElement<EndPoint>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true) });
 })
 .AddAttribute(44, "endpoint-role", a => a.EndpointRole)
@@ -2701,7 +2701,7 @@ aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), I
             builder.AddElement<Node>()
 .AddAttribute(0, "node-number", a => a.NodeNumber, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { IsNonNegative = (true) });
 })
 .AddAttribute(44, "confidence", a => a.Confidence, aBuilder =>
@@ -2927,12 +2927,12 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<Arc>()
 .AddAttribute(0, "from", a => a.From, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { IsNonNegative = (true) });
 })
 .AddAttribute(0, "to", a => a.To, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { IsNonNegative = (true) });
 })
 .AddAttribute(44, "start", a => a.Start)
@@ -3042,7 +3042,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             builder.AddElement<Emma>()
 .AddAttribute(0, "version", a => a.Version, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/www_w3_org_2003_04_emma.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/www_w3_org_2003_04_emma.g.cs
@@ -55,8 +55,8 @@ namespace DocumentFormat.OpenXml.EMMA
             builder.AddElement<DerivedFrom>()
 .AddAttribute(0, "resource", a => a.Resource, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 })
 .AddAttribute(0, "composite", a => a.Composite);
         }
@@ -120,7 +120,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
             builder.AddElement<Info>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-  aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true) });
+  aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true) });
 });
         }
 
@@ -235,12 +235,12 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
             builder.AddElement<Lattice>()
 .AddAttribute(0, "initial", a => a.Initial, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { IsNonNegative = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { IsNonNegative = (true) });
 })
 .AddAttribute(0, "final", a => a.Final, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(44, "time-ref-uri", a => a.TimeReference)
 .AddAttribute(44, "time-ref-anchor-point", a => a.TimeReferenceAnchorPoint);
@@ -690,8 +690,8 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Interpretation>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true) });
 })
 .AddAttribute(44, "tokens", a => a.Tokens)
 .AddAttribute(44, "process", a => a.Process)
@@ -701,7 +701,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = 
 .AddAttribute(44, "media-type", a => a.MediaType)
 .AddAttribute(44, "confidence", a => a.Confidence, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (1L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (1L) });
 })
 .AddAttribute(44, "source", a => a.Source)
 .AddAttribute(44, "start", a => a.Start)
@@ -716,7 +716,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
 .AddAttribute(44, "verbal", a => a.Verbal)
 .AddAttribute(44, "cost", a => a.Cost, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (10000000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (10000000L) });
 })
 .AddAttribute(44, "grammar-ref", a => a.GrammarRef)
 .AddAttribute(44, "endpoint-info-ref", a => a.EndpointInfoRef)
@@ -1133,8 +1133,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
 .AddAttribute(0, "disjunction-type", a => a.DisjunctionType)
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true) });
 })
 .AddAttribute(44, "tokens", a => a.Tokens)
 .AddAttribute(44, "process", a => a.Process)
@@ -1144,7 +1144,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = 
 .AddAttribute(44, "media-type", a => a.MediaType)
 .AddAttribute(44, "confidence", a => a.Confidence, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (1L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (1L) });
 })
 .AddAttribute(44, "source", a => a.Source)
 .AddAttribute(44, "start", a => a.Start)
@@ -1159,7 +1159,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
 .AddAttribute(44, "verbal", a => a.Verbal)
 .AddAttribute(44, "cost", a => a.Cost, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (10000000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (10000000L) });
 })
 .AddAttribute(44, "grammar-ref", a => a.GrammarRef)
 .AddAttribute(44, "endpoint-info-ref", a => a.EndpointInfoRef)
@@ -1565,8 +1565,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<Group>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true) });
 })
 .AddAttribute(44, "tokens", a => a.Tokens)
 .AddAttribute(44, "process", a => a.Process)
@@ -1576,7 +1576,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = 
 .AddAttribute(44, "media-type", a => a.MediaType)
 .AddAttribute(44, "confidence", a => a.Confidence, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (1L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (1L) });
 })
 .AddAttribute(44, "source", a => a.Source)
 .AddAttribute(44, "start", a => a.Start)
@@ -1591,7 +1591,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
 .AddAttribute(44, "verbal", a => a.Verbal)
 .AddAttribute(44, "cost", a => a.Cost, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (10000000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (10000000L) });
 })
 .AddAttribute(44, "grammar-ref", a => a.GrammarRef)
 .AddAttribute(44, "endpoint-info-ref", a => a.EndpointInfoRef)
@@ -1990,8 +1990,8 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<Sequence>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true) });
 })
 .AddAttribute(44, "tokens", a => a.Tokens)
 .AddAttribute(44, "process", a => a.Process)
@@ -2001,7 +2001,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = 
 .AddAttribute(44, "media-type", a => a.MediaType)
 .AddAttribute(44, "confidence", a => a.Confidence, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (1L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (1L) });
 })
 .AddAttribute(44, "source", a => a.Source)
 .AddAttribute(44, "start", a => a.Start)
@@ -2016,7 +2016,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
 .AddAttribute(44, "verbal", a => a.Verbal)
 .AddAttribute(44, "cost", a => a.Cost, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (10000000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (10000000L) });
 })
 .AddAttribute(44, "grammar-ref", a => a.GrammarRef)
 .AddAttribute(44, "endpoint-info-ref", a => a.EndpointInfoRef)
@@ -2098,7 +2098,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<GroupInfo>()
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 });
         }
 
@@ -2225,13 +2225,13 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
             builder.AddElement<Grammar>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true) });
 })
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 });
         }
 
@@ -2304,12 +2304,12 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
             builder.AddElement<Model>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
- aBuilder.AddValidator(new RequiredValidatorAttribute());
- aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true) });
+ aBuilder.AddValidator(new RequiredValidator());
+ aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true) });
 })
 .AddAttribute(0, "ref", a => a.Reference, aBuilder =>
 {
- aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+ aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 });
         }
 
@@ -2386,8 +2386,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
             builder.AddElement<EndPointInfo>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true) });
 });
         }
 
@@ -2587,8 +2587,8 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = 
             builder.AddElement<EndPoint>()
 .AddAttribute(0, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = (true), IsNcName = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new StringValidator() { IsId = (true), IsToken = (true), IsNcName = (true) });
 })
 .AddAttribute(44, "endpoint-role", a => a.EndpointRole)
 .AddAttribute(44, "endpoint-address", a => a.EndPointAddress)
@@ -2701,16 +2701,16 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsId = (true), IsToken = 
             builder.AddElement<Node>()
 .AddAttribute(0, "node-number", a => a.NodeNumber, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { IsNonNegative = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { IsNonNegative = (true) });
 })
 .AddAttribute(44, "confidence", a => a.Confidence, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (1L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (1L) });
 })
 .AddAttribute(44, "cost", a => a.Cost, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (10000000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (10000000L) });
 });
         }
 
@@ -2927,13 +2927,13 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<Arc>()
 .AddAttribute(0, "from", a => a.From, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { IsNonNegative = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { IsNonNegative = (true) });
 })
 .AddAttribute(0, "to", a => a.To, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
-aBuilder.AddValidator(new NumberValidatorAttribute() { IsNonNegative = (true) });
+aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(new NumberValidator() { IsNonNegative = (true) });
 })
 .AddAttribute(44, "start", a => a.Start)
 .AddAttribute(44, "end", a => a.End)
@@ -2941,11 +2941,11 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { IsNonNegative = (true) })
 .AddAttribute(44, "duration", a => a.Duration)
 .AddAttribute(44, "confidence", a => a.Confidence, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (1L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (1L) });
 })
 .AddAttribute(44, "cost", a => a.Cost, aBuilder =>
 {
-aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxInclusive = (10000000L) });
+aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (10000000L) });
 })
 .AddAttribute(44, "lang", a => a.Language)
 .AddAttribute(44, "medium", a => a.Medium)
@@ -3042,7 +3042,7 @@ aBuilder.AddValidator(new NumberValidatorAttribute() { MinInclusive = (0L), MaxI
             builder.AddElement<Emma>()
 .AddAttribute(0, "version", a => a.Version, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/www_w3_org_2003_InkML.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/www_w3_org_2003_InkML.g.cs
@@ -87,7 +87,7 @@ namespace DocumentFormat.OpenXml.InkML
             builder.AddElement<Ink>()
 .AddAttribute(0, "documentID", a => a.DocumentId, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 });
         }
 
@@ -396,7 +396,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
 .AddAttribute(0, "type", a => a.Type)
 .AddAttribute(0, "mappingRef", a => a.MappingRef, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 });
         }
 
@@ -569,11 +569,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
 .AddAttribute(1, "id", a => a.Id)
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardChannelNameValues>>(new EnumValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardChannelNameValues>>(new EnumValidator());
+union.AddValidator(new StringValidator());
 });
 })
 .AddAttribute(0, "type", a => a.Type)
@@ -581,8 +581,8 @@ union.AddValidator(new StringValidatorAttribute());
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<DecimalValue>(new NumberValidatorAttribute());
-union.AddValidator<BooleanValue>(new NumberValidatorAttribute());
+union.AddValidator<DecimalValue>(new NumberValidator());
+union.AddValidator<BooleanValue>(new NumberValidator());
 });
 })
 .AddAttribute(0, "min", a => a.Min)
@@ -590,23 +590,23 @@ union.AddValidator<BooleanValue>(new NumberValidatorAttribute());
 .AddAttribute(0, "orientation", a => a.Orientation)
 .AddAttribute(0, "respectTo", a => a.RespectTo, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 })
 .AddAttribute(0, "units", a => a.Units, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardLengthUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerLengthUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardTimeUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerTimeUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardMassForceUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerMassForceUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardAngleUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerAngleUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardOtherUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerOtherUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardLengthUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerLengthUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardTimeUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerTimeUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardMassForceUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerMassForceUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardAngleUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerAngleUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardOtherUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerOtherUnitsValues>>(new EnumValidator());
+union.AddValidator(new StringValidator());
 });
 });
         }
@@ -751,41 +751,41 @@ union.AddValidator(new StringValidatorAttribute());
             builder.AddElement<ChannelProperty>()
 .AddAttribute(0, "channel", a => a.Channel, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardChannelNameValues>>(new EnumValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardChannelNameValues>>(new EnumValidator());
+union.AddValidator(new StringValidator());
 });
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardChannelPropertyNameValues>>(new EnumValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardChannelPropertyNameValues>>(new EnumValidator());
+union.AddValidator(new StringValidator());
 });
 })
 .AddAttribute(0, "value", a => a.Value, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "units", a => a.Units, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardLengthUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerLengthUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardTimeUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerTimeUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardMassForceUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerMassForceUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardAngleUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerAngleUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardOtherUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerOtherUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardLengthUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerLengthUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardTimeUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerTimeUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardMassForceUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerMassForceUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardAngleUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerAngleUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardOtherUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerOtherUnitsValues>>(new EnumValidator());
+union.AddValidator(new StringValidator());
 });
 });
         }
@@ -922,7 +922,7 @@ union.AddValidator(new StringValidatorAttribute());
 .AddAttribute(0, "uniform", a => a.Uniform)
 .AddAttribute(0, "value", a => a.Value, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -961,7 +961,7 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
             builder.AddElement<Latency>()
 .AddAttribute(0, "value", a => a.Value, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 });
         }
 
@@ -1035,17 +1035,17 @@ aBuilder.AddValidator(new RequiredValidatorAttribute());
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardLengthUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerLengthUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardTimeUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerTimeUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardMassForceUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerMassForceUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardAngleUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerAngleUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardOtherUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerOtherUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardLengthUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerLengthUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardTimeUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerTimeUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardMassForceUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerMassForceUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardAngleUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerAngleUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardOtherUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerOtherUnitsValues>>(new EnumValidator());
+union.AddValidator(new StringValidator());
 });
 });
         }
@@ -1111,27 +1111,27 @@ union.AddValidator(new StringValidatorAttribute());
             builder.AddElement<SourceProperty>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "value", a => a.Value, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "units", a => a.Units, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardLengthUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerLengthUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardTimeUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerTimeUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardMassForceUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerMassForceUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardAngleUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerAngleUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardOtherUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerOtherUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardLengthUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerLengthUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardTimeUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerTimeUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardMassForceUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerMassForceUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardAngleUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerAngleUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardOtherUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerOtherUnitsValues>>(new EnumValidator());
+union.AddValidator(new StringValidator());
 });
 });
         }
@@ -1352,7 +1352,7 @@ union.AddValidator(new StringValidatorAttribute());
 .AddAttribute(0, "encoding", a => a.Encoding)
 .AddAttribute(0, "href", a => a.Href, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 });
         }
 
@@ -1464,40 +1464,40 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
             builder.AddElement<BrushProperty>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardBrushPropertyNameValues>>(new EnumValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardBrushPropertyNameValues>>(new EnumValidator());
+union.AddValidator(new StringValidator());
 });
 })
 .AddAttribute(0, "value", a => a.Value, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<DecimalValue>(new NumberValidatorAttribute());
-union.AddValidator<BooleanValue>(new NumberValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.PenTipShapeValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.RasterOperationValues>>(new EnumValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<DecimalValue>(new NumberValidator());
+union.AddValidator<BooleanValue>(new NumberValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.PenTipShapeValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.RasterOperationValues>>(new EnumValidator());
+union.AddValidator(new StringValidator());
 });
 })
 .AddAttribute(0, "units", a => a.Units, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardLengthUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerLengthUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardTimeUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerTimeUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardMassForceUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerMassForceUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardAngleUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerAngleUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardOtherUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerOtherUnitsValues>>(new EnumValidatorAttribute());
-union.AddValidator(new StringValidatorAttribute());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardLengthUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerLengthUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardTimeUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerTimeUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardMassForceUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerMassForceUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardAngleUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerAngleUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardOtherUnitsValues>>(new EnumValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerOtherUnitsValues>>(new EnumValidator());
+union.AddValidator(new StringValidator());
 });
 });
         }
@@ -1596,7 +1596,7 @@ union.AddValidator(new StringValidatorAttribute());
 .AddAttribute(1, "id", a => a.Id)
 .AddAttribute(0, "traceFormatRef", a => a.TraceFormatRef, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 });
         }
 
@@ -1837,14 +1837,14 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
             builder.AddElement<InkSource>()
 .AddAttribute(1, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "manufacturer", a => a.Manufacturer)
 .AddAttribute(0, "model", a => a.Model)
 .AddAttribute(0, "serialNo", a => a.SerialNo)
 .AddAttribute(0, "specificationRef", a => a.SpecificationRef, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 })
 .AddAttribute(0, "description", a => a.Description);
         }
@@ -1997,7 +1997,7 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
 .AddAttribute(1, "id", a => a.Id)
 .AddAttribute(0, "brushRef", a => a.BrushRef, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 });
         }
 
@@ -2088,12 +2088,12 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
             builder.AddElement<Timestamp>()
 .AddAttribute(1, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidatorAttribute());
+aBuilder.AddValidator(new RequiredValidator());
 })
 .AddAttribute(0, "time", a => a.Time)
 .AddAttribute(0, "timestampRef", a => a.TimestampRef, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 })
 .AddAttribute(0, "timeString", a => a.TimeString)
 .AddAttribute(0, "timeOffset", a => a.TimeOffset);
@@ -2223,15 +2223,15 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
 .AddAttribute(0, "continuation", a => a.Continuation)
 .AddAttribute(0, "priorRef", a => a.PriorRef, aBuilder =>
 {
- aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+ aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 })
 .AddAttribute(0, "contextRef", a => a.ContextRef, aBuilder =>
 {
- aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+ aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 })
 .AddAttribute(0, "brushRef", a => a.BrushRef, aBuilder =>
 {
- aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+ aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 })
 .AddAttribute(0, "duration", a => a.Duration)
 .AddAttribute(0, "timeOffset", a => a.TimeOffset);
@@ -2333,11 +2333,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
 .AddAttribute(1, "id", a => a.Id)
 .AddAttribute(0, "contextRef", a => a.ContextRef, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 })
 .AddAttribute(0, "brushRef", a => a.BrushRef, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 });
         }
 
@@ -2465,11 +2465,11 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
 .AddAttribute(1, "id", a => a.Id)
 .AddAttribute(0, "contextRef", a => a.ContextRef, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 })
 .AddAttribute(0, "traceDataRef", a => a.TraceDataRef, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 })
 .AddAttribute(0, "from", a => a.From)
 .AddAttribute(0, "to", a => a.To);
@@ -2634,31 +2634,31 @@ aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
 .AddAttribute(1, "id", a => a.Id)
 .AddAttribute(0, "contextRef", a => a.ContextRef, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 })
 .AddAttribute(0, "canvasRef", a => a.CanvasRef, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 })
 .AddAttribute(0, "canvasTransformRef", a => a.CanvasTransformRef, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 })
 .AddAttribute(0, "traceFormatRef", a => a.TraceFromatRef, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 })
 .AddAttribute(0, "inkSourceRef", a => a.InkSourceRef, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 })
 .AddAttribute(0, "brushRef", a => a.BrushRef, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 })
 .AddAttribute(0, "timestampRef", a => a.TimestampRef, aBuilder =>
 {
-aBuilder.AddValidator(new StringValidatorAttribute() { IsUri = (true) });
+aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 });
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/www_w3_org_2003_InkML.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/www_w3_org_2003_InkML.g.cs
@@ -569,11 +569,11 @@ aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 .AddAttribute(1, "id", a => a.Id)
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardChannelNameValues>>(new EnumValidator());
-union.AddValidator(new StringValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardChannelNameValues>>(EnumValidator.Instance);
+union.AddValidator(StringValidator.Instance);
 });
 })
 .AddAttribute(0, "type", a => a.Type)
@@ -581,8 +581,8 @@ union.AddValidator(new StringValidator());
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<DecimalValue>(new NumberValidator());
-union.AddValidator<BooleanValue>(new NumberValidator());
+union.AddValidator<DecimalValue>(NumberValidator.Instance);
+union.AddValidator<BooleanValue>(NumberValidator.Instance);
 });
 })
 .AddAttribute(0, "min", a => a.Min)
@@ -596,17 +596,17 @@ aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardLengthUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerLengthUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardTimeUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerTimeUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardMassForceUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerMassForceUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardAngleUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerAngleUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardOtherUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerOtherUnitsValues>>(new EnumValidator());
-union.AddValidator(new StringValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardLengthUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerLengthUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardTimeUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerTimeUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardMassForceUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerMassForceUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardAngleUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerAngleUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardOtherUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerOtherUnitsValues>>(EnumValidator.Instance);
+union.AddValidator(StringValidator.Instance);
 });
 });
         }
@@ -751,41 +751,41 @@ union.AddValidator(new StringValidator());
             builder.AddElement<ChannelProperty>()
 .AddAttribute(0, "channel", a => a.Channel, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardChannelNameValues>>(new EnumValidator());
-union.AddValidator(new StringValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardChannelNameValues>>(EnumValidator.Instance);
+union.AddValidator(StringValidator.Instance);
 });
 })
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardChannelPropertyNameValues>>(new EnumValidator());
-union.AddValidator(new StringValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardChannelPropertyNameValues>>(EnumValidator.Instance);
+union.AddValidator(StringValidator.Instance);
 });
 })
 .AddAttribute(0, "value", a => a.Value, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "units", a => a.Units, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardLengthUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerLengthUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardTimeUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerTimeUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardMassForceUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerMassForceUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardAngleUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerAngleUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardOtherUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerOtherUnitsValues>>(new EnumValidator());
-union.AddValidator(new StringValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardLengthUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerLengthUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardTimeUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerTimeUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardMassForceUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerMassForceUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardAngleUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerAngleUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardOtherUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerOtherUnitsValues>>(EnumValidator.Instance);
+union.AddValidator(StringValidator.Instance);
 });
 });
         }
@@ -922,7 +922,7 @@ union.AddValidator(new StringValidator());
 .AddAttribute(0, "uniform", a => a.Uniform)
 .AddAttribute(0, "value", a => a.Value, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -961,7 +961,7 @@ aBuilder.AddValidator(new RequiredValidator());
             builder.AddElement<Latency>()
 .AddAttribute(0, "value", a => a.Value, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 });
         }
 
@@ -1035,17 +1035,17 @@ aBuilder.AddValidator(new RequiredValidator());
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardLengthUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerLengthUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardTimeUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerTimeUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardMassForceUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerMassForceUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardAngleUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerAngleUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardOtherUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerOtherUnitsValues>>(new EnumValidator());
-union.AddValidator(new StringValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardLengthUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerLengthUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardTimeUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerTimeUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardMassForceUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerMassForceUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardAngleUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerAngleUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardOtherUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerOtherUnitsValues>>(EnumValidator.Instance);
+union.AddValidator(StringValidator.Instance);
 });
 });
         }
@@ -1111,27 +1111,27 @@ union.AddValidator(new StringValidator());
             builder.AddElement<SourceProperty>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "value", a => a.Value, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "units", a => a.Units, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardLengthUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerLengthUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardTimeUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerTimeUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardMassForceUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerMassForceUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardAngleUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerAngleUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardOtherUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerOtherUnitsValues>>(new EnumValidator());
-union.AddValidator(new StringValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardLengthUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerLengthUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardTimeUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerTimeUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardMassForceUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerMassForceUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardAngleUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerAngleUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardOtherUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerOtherUnitsValues>>(EnumValidator.Instance);
+union.AddValidator(StringValidator.Instance);
 });
 });
         }
@@ -1464,40 +1464,40 @@ aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
             builder.AddElement<BrushProperty>()
 .AddAttribute(0, "name", a => a.Name, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardBrushPropertyNameValues>>(new EnumValidator());
-union.AddValidator(new StringValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardBrushPropertyNameValues>>(EnumValidator.Instance);
+union.AddValidator(StringValidator.Instance);
 });
 })
 .AddAttribute(0, "value", a => a.Value, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<DecimalValue>(new NumberValidator());
-union.AddValidator<BooleanValue>(new NumberValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.PenTipShapeValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.RasterOperationValues>>(new EnumValidator());
-union.AddValidator(new StringValidator());
+union.AddValidator<DecimalValue>(NumberValidator.Instance);
+union.AddValidator<BooleanValue>(NumberValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.PenTipShapeValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.RasterOperationValues>>(EnumValidator.Instance);
+union.AddValidator(StringValidator.Instance);
 });
 })
 .AddAttribute(0, "units", a => a.Units, aBuilder =>
 {
 aBuilder.AddUnion(union =>
 {
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardLengthUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerLengthUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardTimeUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerTimeUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardMassForceUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerMassForceUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardAngleUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerAngleUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardOtherUnitsValues>>(new EnumValidator());
-union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerOtherUnitsValues>>(new EnumValidator());
-union.AddValidator(new StringValidator());
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardLengthUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerLengthUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardTimeUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerTimeUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardMassForceUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerMassForceUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardAngleUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerAngleUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardOtherUnitsValues>>(EnumValidator.Instance);
+union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerOtherUnitsValues>>(EnumValidator.Instance);
+union.AddValidator(StringValidator.Instance);
 });
 });
         }
@@ -1837,7 +1837,7 @@ aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
             builder.AddElement<InkSource>()
 .AddAttribute(1, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "manufacturer", a => a.Manufacturer)
 .AddAttribute(0, "model", a => a.Model)
@@ -2088,7 +2088,7 @@ aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
             builder.AddElement<Timestamp>()
 .AddAttribute(1, "id", a => a.Id, aBuilder =>
 {
-aBuilder.AddValidator(new RequiredValidator());
+aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute(0, "time", a => a.Time)
 .AddAttribute(0, "timestampRef", a => a.TimestampRef, aBuilder =>

--- a/src/DocumentFormat.OpenXml/Wordprocessing/CustomXmlElement.cs
+++ b/src/DocumentFormat.OpenXml/Wordprocessing/CustomXmlElement.cs
@@ -90,7 +90,7 @@ namespace DocumentFormat.OpenXml.Wordprocessing
                 .AddAttribute(0, "uri", a => a.Uri)
                 .AddAttribute(23, "element", a => a.Element, a =>
                 {
-                    a.AddValidator(new StringValidatorAttribute { IsNcName = true });
+                    a.AddValidator(new StringValidator { IsNcName = true });
                 });
         }
     }

--- a/test/DocumentFormat.OpenXml.Framework.Tests/PropertyBuilderTests.cs
+++ b/test/DocumentFormat.OpenXml.Framework.Tests/PropertyBuilderTests.cs
@@ -46,7 +46,7 @@ namespace DocumentFormat.OpenXml.Framework.Tests
             builder.AddElement<SomeElement>()
                 .AddAttribute(0, "s", a => a.Str, a =>
                 {
-                    a.AddValidator(new RequiredValidatorAttribute());
+                    a.AddValidator(new RequiredValidator());
                 });
             var data = builder.Build();
 
@@ -54,8 +54,8 @@ namespace DocumentFormat.OpenXml.Framework.Tests
 
             Assert.Collection(
                 elementData.Validators,
-                v => Assert.IsType<RequiredValidatorAttribute>(v),
-                v => Assert.IsType<StringValidatorAttribute>(v));
+                v => Assert.IsType<RequiredValidator>(v),
+                v => Assert.IsType<StringValidator>(v));
         }
 
         private class SomeElement : OpenXmlElement

--- a/test/DocumentFormat.OpenXml.Framework.Tests/ValidatorAttributeTests.cs
+++ b/test/DocumentFormat.OpenXml.Framework.Tests/ValidatorAttributeTests.cs
@@ -21,19 +21,19 @@ namespace DocumentFormat.OpenXml.Framework.Tests
 
             var single = Assert.Single(attribute.Validators);
 
-            Assert.IsType<StringValidatorAttribute>(single);
+            Assert.IsType<StringValidator>(single);
         }
 
         [Fact]
         public void RequiredValidation()
         {
-            var attributes = ElementMetadata.Create<RequiredValidator>();
+            var attributes = ElementMetadata.Create<ContainsRequiredValidator>();
             var attribute = Assert.Single(attributes.Attributes);
 
             Assert.Collection(
                 attribute.Validators,
-                t => Assert.IsType<RequiredValidatorAttribute>(t),
-                t => Assert.IsType<StringValidatorAttribute>(t));
+                t => Assert.IsType<RequiredValidator>(t),
+                t => Assert.IsType<StringValidator>(t));
         }
 
         [Fact]
@@ -50,10 +50,10 @@ namespace DocumentFormat.OpenXml.Framework.Tests
 
                     Assert.Collection(
                         union.Validators,
-                        v => Assert.IsType<StringValidatorAttribute>(v),
-                        v => Assert.IsType<StringValidatorAttribute>(v));
+                        v => Assert.IsType<StringValidator>(v),
+                        v => Assert.IsType<StringValidator>(v));
                 },
-                t => Assert.IsType<StringValidatorAttribute>(t));
+                t => Assert.IsType<StringValidator>(t));
         }
 
         private class NoValidatorsElement : BaseElement
@@ -64,14 +64,14 @@ namespace DocumentFormat.OpenXml.Framework.Tests
                 .AddAttribute(0, "val", a => a.Val);
         }
 
-        private class RequiredValidator : BaseElement
+        private class ContainsRequiredValidator : BaseElement
         {
             public StringValue Val { get; set; }
 
             internal override void ConfigureMetadata(ElementMetadata.Builder builder) => builder.AddElement<NoValidatorsElement>()
                 .AddAttribute(0, "val", a => a.Val, a =>
                 {
-                    a.AddValidator(new RequiredValidatorAttribute());
+                    a.AddValidator(new RequiredValidator());
                 });
         }
 
@@ -84,8 +84,8 @@ namespace DocumentFormat.OpenXml.Framework.Tests
                 {
                     a.AddUnion(aa =>
                     {
-                        aa.AddValidator(new StringValidatorAttribute { IsId = true });
-                        aa.AddValidator(new StringValidatorAttribute { IsNcName = true });
+                        aa.AddValidator(new StringValidator { IsId = true });
+                        aa.AddValidator(new StringValidator { IsNcName = true });
                     });
                 });
         }


### PR DESCRIPTION
Validators are no longer attributes and thus do not need to derive from System.Attribute