### PR TITLE
Limit milliseconds to three digits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Version 2.11.3
+### Fixed
+- CellValue limits to three most signficant digits on second fractions to correct issue loading DateTime in Office 2016
+
 ## Version 2.11.2 - 2020-07-10
 
 ### Fixed

--- a/src/DocumentFormat.OpenXml/Spreadsheet/CellValue.cs
+++ b/src/DocumentFormat.OpenXml/Spreadsheet/CellValue.cs
@@ -17,7 +17,7 @@ namespace DocumentFormat.OpenXml.Spreadsheet
         /// </summary>
         /// <param name="dateTime">DateTime for cell</param>
         public CellValue(DateTime dateTime)
-            : this(dateTime.ToString("o", CultureInfo.InvariantCulture))
+            : this(dateTime.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff", CultureInfo.InvariantCulture))
         {
         }
 
@@ -27,7 +27,7 @@ namespace DocumentFormat.OpenXml.Spreadsheet
         /// </summary>
         /// <param name="dateTimeOffset">DateTime for cell</param>
         public CellValue(DateTimeOffset dateTimeOffset)
-            : this(dateTimeOffset.ToString("o", CultureInfo.InvariantCulture))
+            : this(dateTimeOffset.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffzzz", CultureInfo.InvariantCulture))
         {
         }
     }

--- a/src/DocumentFormat.OpenXml/Spreadsheet/CellValue.cs
+++ b/src/DocumentFormat.OpenXml/Spreadsheet/CellValue.cs
@@ -17,7 +17,7 @@ namespace DocumentFormat.OpenXml.Spreadsheet
         /// </summary>
         /// <param name="dateTime">DateTime for cell</param>
         public CellValue(DateTime dateTime)
-            : this(dateTime.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff", CultureInfo.InvariantCulture))
+            : this(ToCellFormat(dateTime))
         {
         }
 
@@ -27,8 +27,21 @@ namespace DocumentFormat.OpenXml.Spreadsheet
         /// </summary>
         /// <param name="dateTimeOffset">DateTime for cell</param>
         public CellValue(DateTimeOffset dateTimeOffset)
-            : this(dateTimeOffset.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffzzz", CultureInfo.InvariantCulture))
+            : this(ToCellFormat(dateTimeOffset))
         {
+        }
+
+        private const string DateTimeFormatString = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff";
+        private const string DateTimeOffsetFormatString = DateTimeFormatString + "zzz";
+
+        private static string ToCellFormat(DateTime dateTime)
+        {
+            return dateTime.ToString(DateTimeFormatString, CultureInfo.InvariantCulture);
+        }
+
+        private static string ToCellFormat(DateTimeOffset dateTime)
+        {
+            return dateTime.ToString(DateTimeOffsetFormatString, CultureInfo.InvariantCulture);
         }
     }
 }

--- a/test/DocumentFormat.OpenXml.Tests/SpreadsheetCellTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/SpreadsheetCellTests.cs
@@ -15,7 +15,7 @@ namespace DocumentFormat.OpenXml.Tests
             var dt = new DateTime(2017, 11, 28, 12, 25, 2);
             var value = new CellValue(dt);
 
-            Assert.Equal("2017-11-28T12:25:02.0000000", value.Text);
+            Assert.Equal("2017-11-28T12:25:02.000", value.Text);
         }
 
         [Fact]
@@ -24,7 +24,25 @@ namespace DocumentFormat.OpenXml.Tests
             var dt = new DateTimeOffset(2017, 11, 28, 12, 25, 2, TimeSpan.Zero);
             var value = new CellValue(dt);
 
-            Assert.Equal("2017-11-28T12:25:02.0000000+00:00", value.Text);
+            Assert.Equal("2017-11-28T12:25:02.000+00:00", value.Text);
+        }
+
+        [Fact]
+        public void CellDateTimeWithMillisecondsTest()
+        {
+            var dt = new DateTime(2017, 11, 28, 12, 25, 2).AddMilliseconds(123);
+            var value = new CellValue(dt);
+
+            Assert.Equal("2017-11-28T12:25:02.123", value.Text);
+        }
+
+        [Fact]
+        public void CellDateTimeOffsetWithMillisecondsTest()
+        {
+            var dt = new DateTimeOffset(2017, 11, 28, 12, 25, 2, TimeSpan.Zero).AddMilliseconds(123);
+            var value = new CellValue(dt);
+
+            Assert.Equal("2017-11-28T12:25:02.123+00:00", value.Text);
         }
     }
 }


### PR DESCRIPTION
Fixes #724 and adds test to ensure that's all that changes
No standard format limits to three digits for milliseconds, but the format is the same as `"o"` used before in all other regards