### PR TITLE
Skip attribute required semantic check if the required attribute exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Ensure .NET Framework builds pass PEVerify (#744)
 - `OpenXmlPartContainer.DeletePart` no longer throws an exception if there isn't a match for the identifier given (#740)
 - Mark obsolete members to not show up with Intellisense (#745)
+- Fixed issue with `AttributeRequiredConditionToValue` semantic constraint where validation could fail on correct input (#746)
 
 ## Version 2.11.0 - 2020-05-21
 ### Added

--- a/src/DocumentFormat.OpenXml/Validation/Schema/SchemaTypeValidator.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Schema/SchemaTypeValidator.cs
@@ -198,6 +198,11 @@ namespace DocumentFormat.OpenXml.Validation.Schema
         {
             var particleConstraint = validationContext.GetParticleConstraint();
 
+            if (particleConstraint is null)
+            {
+                return;
+            }
+
             switch (particleConstraint.ParticleType)
             {
                 case ParticleType.All:

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeRequiredConditionToValue.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeRequiredConditionToValue.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using DocumentFormat.OpenXml.Validation;
-
 namespace DocumentFormat.OpenXml.Validation.Semantic
 {
     /// <summary>
@@ -10,24 +8,24 @@ namespace DocumentFormat.OpenXml.Validation.Semantic
     /// </summary>
     internal class AttributeRequiredConditionToValue : SemanticConstraint
     {
-        private readonly string[] _values;
+        private readonly string _value;
         private readonly byte _requiredAttribute;
         private readonly byte _conditionAttribute;
 
-        public AttributeRequiredConditionToValue(byte requiredAttribute, byte conditionAttribute, params string[] values)
+        public AttributeRequiredConditionToValue(byte requiredAttribute, byte conditionAttribute, string value)
             : base(SemanticValidationLevel.Element)
         {
             _requiredAttribute = requiredAttribute;
             _conditionAttribute = conditionAttribute;
-            _values = values;
+            _value = value;
         }
 
         public override ValidationErrorInfo Validate(ValidationContext context)
         {
             var element = context.Stack.Current.Element;
-            var attribute = element.ParsedState.Attributes[_requiredAttribute];
+            var requiredAttribute = element.ParsedState.Attributes[_requiredAttribute];
 
-            if (!attribute.HasValue)
+            if (requiredAttribute.HasValue)
             {
                 return null;
             }
@@ -39,34 +37,19 @@ namespace DocumentFormat.OpenXml.Validation.Semantic
                 return null;
             }
 
-            foreach (string value in _values)
+            if (AttributeValueEquals(conditionAttribute.Value, _value, false))
             {
-                if (AttributeValueEquals(conditionAttribute.Value, value, false))
+                return new ValidationErrorInfo()
                 {
-                    string valueString = "'" + _values[0] + "'";
-
-                    if (_values.Length > 1)
-                    {
-                        for (int i = 1; i < _values.Length - 1; i++)
-                        {
-                            valueString += ", '" + _values[i] + "'";
-                        }
-
-                        valueString += " or '" + _values[_values.Length - 1] + "'";
-                    }
-
-                    return new ValidationErrorInfo()
-                    {
-                        Id = "Sem_AttributeRequiredConditionToValue",
-                        ErrorType = ValidationErrorType.Semantic,
-                        Node = element,
-                        Description = SR.Format(
-                            ValidationResources.Sem_AttributeRequiredConditionToValue,
-                            GetAttributeQualifiedName(element, _requiredAttribute),
-                            GetAttributeQualifiedName(element, _conditionAttribute),
-                            valueString),
-                    };
-                }
+                    Id = "Sem_AttributeRequiredConditionToValue",
+                    ErrorType = ValidationErrorType.Semantic,
+                    Node = element,
+                    Description = SR.Format(
+                        ValidationResources.Sem_AttributeRequiredConditionToValue,
+                        GetAttributeQualifiedName(element, _requiredAttribute),
+                        GetAttributeQualifiedName(element, _conditionAttribute),
+                        _value),
+                };
             }
 
             return null;

--- a/src/DocumentFormat.OpenXml/Validation/ValidationResources.Designer.cs
+++ b/src/DocumentFormat.OpenXml/Validation/ValidationResources.Designer.cs
@@ -521,7 +521,7 @@ namespace DocumentFormat.OpenXml.Validation {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Attribute &apos;{0}&apos; should be present when the value of attribute &apos;{1}&apos; is {2}..
+        ///   Looks up a localized string similar to Attribute &apos;{0}&apos; should be present when the value of attribute &apos;{1}&apos; is &apos;{2}&apos;..
         /// </summary>
         internal static string Sem_AttributeRequiredConditionToValue {
             get {

--- a/src/DocumentFormat.OpenXml/Validation/ValidationResources.resx
+++ b/src/DocumentFormat.OpenXml/Validation/ValidationResources.resx
@@ -265,7 +265,7 @@
     <value>Attribute '{0}' and '{1}' cannot be present at the same time. Only one of these attributes '{2}' can be present at a given time.</value>
   </data>
   <data name="Sem_AttributeRequiredConditionToValue" xml:space="preserve">
-    <value>Attribute '{0}' should be present when the value of attribute '{1}' is {2}.</value>
+    <value>Attribute '{0}' should be present when the value of attribute '{1}' is '{2}'.</value>
   </data>
   <data name="Sem_AttributeValueConditionToAnother" xml:space="preserve">
     <value>Attribute '{0}' should have value(s) {1} when attribute '{2}' has value(s) {3}. Current value of attribute '{4}' is '{5}'.</value>

--- a/test/DocumentFormat.OpenXml.Tests/Validation/Semantic/AttributeRequiredConditionToValueTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/Validation/Semantic/AttributeRequiredConditionToValueTests.cs
@@ -10,7 +10,6 @@ namespace DocumentFormat.OpenXml.Tests.Validation.Semantic
 {
     public class AttributeRequiredConditionToValueTests
     {
-        private const string Empty = "";
         private const string RequiredValue = "requiredValue";
         private const string ExpectedConditionValue = "hello";
         private const string UnexpectedConditionValue = "helloWorld!";
@@ -29,12 +28,12 @@ namespace DocumentFormat.OpenXml.Tests.Validation.Semantic
             if (required is string)
             {
                 element.Required = required;
-            };
+            }
 
             if (condition is string)
             {
                 element.Condition = condition;
-            };
+            }
 
             var results = validator.Validate(element);
 

--- a/test/DocumentFormat.OpenXml.Tests/Validation/Semantic/AttributeRequiredConditionToValueTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/Validation/Semantic/AttributeRequiredConditionToValueTests.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Framework.Metadata;
+using DocumentFormat.OpenXml.Validation;
+using DocumentFormat.OpenXml.Validation.Semantic;
+using Xunit;
+
+namespace DocumentFormat.OpenXml.Tests.Validation.Semantic
+{
+    public class AttributeRequiredConditionToValueTests
+    {
+        private const string RequiredValue = "requiredValue";
+        private const string ExpectedValue = "hello";
+        private const string UnexpectedValue = "helloWorld!";
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, UnexpectedValue)]
+        [InlineData(RequiredValue, UnexpectedValue)]
+        [InlineData(RequiredValue, null)]
+        [InlineData(RequiredValue, ExpectedValue)]
+        public void NoErrors(StringValue required, StringValue condition)
+        {
+            var validator = new OpenXmlValidator();
+            var element = new TestElement
+            {
+                Required = required,
+                Condition = condition,
+            };
+
+            var results = validator.Validate(element);
+
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public void SemanticErrorValue()
+        {
+            var validator = new OpenXmlValidator();
+            var element = new TestElement
+            {
+                Condition = ExpectedValue,
+            };
+
+            var error = Assert.Single(validator.Validate(element));
+        }
+
+        private class TestElement : OpenXmlCompositeElement
+        {
+            public StringValue Required
+            {
+                get => GetAttribute<StringValue>();
+                set => SetAttribute(value);
+            }
+
+            public StringValue Condition
+            {
+                get => GetAttribute<StringValue>();
+                set => SetAttribute(value);
+            }
+
+            internal override void ConfigureMetadata(ElementMetadata.Builder builder)
+            {
+                builder.AddElement<TestElement>()
+                    .AddAttribute(0, "required", t => t.Required)
+                    .AddAttribute(0, "condition", t => t.Condition);
+            }
+
+            internal override ISemanticConstraint[] SemanticConstraints { get; } = new[]
+            {
+                new AttributeRequiredConditionToValue(0, 1, ExpectedValue),
+            };
+        }
+    }
+}

--- a/test/DocumentFormat.OpenXml.Tests/Validation/Semantic/AttributeRequiredConditionToValueTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/Validation/Semantic/AttributeRequiredConditionToValueTests.cs
@@ -20,7 +20,7 @@ namespace DocumentFormat.OpenXml.Tests.Validation.Semantic
         [InlineData(RequiredValue, UnexpectedValue)]
         [InlineData(RequiredValue, null)]
         [InlineData(RequiredValue, ExpectedValue)]
-        public void NoErrors(StringValue required, StringValue condition)
+        public void NoErrors(string required, string condition)
         {
             var validator = new OpenXmlValidator();
             var element = new TestElement

--- a/test/DocumentFormat.OpenXml.Tests/Validation/Semantic/AttributeRequiredConditionToValueTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/Validation/Semantic/AttributeRequiredConditionToValueTests.cs
@@ -10,23 +10,30 @@ namespace DocumentFormat.OpenXml.Tests.Validation.Semantic
 {
     public class AttributeRequiredConditionToValueTests
     {
+        private const string Empty = "";
         private const string RequiredValue = "requiredValue";
-        private const string ExpectedValue = "hello";
-        private const string UnexpectedValue = "helloWorld!";
+        private const string ExpectedConditionValue = "hello";
+        private const string UnexpectedConditionValue = "helloWorld!";
 
         [Theory]
         [InlineData(null, null)]
-        [InlineData(null, UnexpectedValue)]
-        [InlineData(RequiredValue, UnexpectedValue)]
+        [InlineData(null, UnexpectedConditionValue)]
+        [InlineData(RequiredValue, UnexpectedConditionValue)]
         [InlineData(RequiredValue, null)]
-        [InlineData(RequiredValue, ExpectedValue)]
+        [InlineData(RequiredValue, ExpectedConditionValue)]
         public void NoErrors(string required, string condition)
         {
             var validator = new OpenXmlValidator();
-            var element = new TestElement
+            var element = new TestElement();
+
+            if (required is string)
             {
-                Required = required,
-                Condition = condition,
+                element.Required = required;
+            };
+
+            if (condition is string)
+            {
+                element.Condition = condition;
             };
 
             var results = validator.Validate(element);
@@ -40,10 +47,13 @@ namespace DocumentFormat.OpenXml.Tests.Validation.Semantic
             var validator = new OpenXmlValidator();
             var element = new TestElement
             {
-                Condition = ExpectedValue,
+                Condition = ExpectedConditionValue,
             };
 
             var error = Assert.Single(validator.Validate(element));
+
+            Assert.Equal("Sem_AttributeRequiredConditionToValue", error.Id);
+            Assert.Equal(ValidationErrorType.Semantic, error.ErrorType);
         }
 
         private class TestElement : OpenXmlCompositeElement
@@ -69,7 +79,7 @@ namespace DocumentFormat.OpenXml.Tests.Validation.Semantic
 
             internal override ISemanticConstraint[] SemanticConstraints { get; } = new[]
             {
-                new AttributeRequiredConditionToValue(0, 1, ExpectedValue),
+                new AttributeRequiredConditionToValue(0, 1, ExpectedConditionValue),
             };
         }
     }


### PR DESCRIPTION
The semantic constraint `AttributeRequiredConditionToValue` does not need to be checked if the required value exists. This was causing incorrect semantic validation of the form `Semantic Error : Attribute 'si' should be present when the value of attribute 't' is 'shared'`. Now, if the required value exists, the constraint is exited without looking further as there is no way it could fail.

Fixes #735 