### PR TITLE
Avoid multi-thread creates ElementMetadata object

### DIFF
--- a/src/DocumentFormat.OpenXml/Framework/Metadata/ElementMetadata.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Metadata/ElementMetadata.cs
@@ -56,17 +56,8 @@ namespace DocumentFormat.OpenXml.Framework.Metadata
         {
             var type = element.GetType();
 
-            // Use TryGetValue first for the common case of already existing types to limit number of allocations
-            if (_lookup.TryGetValue(type, out var result))
-            {
-                return result;
-            }
-
-            var metadata = CreateInternal(element);
-
-            _lookup.TryAdd(type, metadata);
-
-            return metadata;
+            // Use GetOrAdd first for the common case of already existing types to limit number of allocations
+            return _lookup.GetOrAdd(type, _ => CreateInternal(element));
         }
 
         public static ElementMetadata Create<TElement>()


### PR DESCRIPTION
The origin code is not thread-safe and this is the test code

```csharp
    public class ElementMetadataTests
    {
        [Fact]
        public void Create()
        {
            using ManualResetEvent resetEvent = new ManualResetEvent(false);

            List<Thread> threadList = new List<Thread>();
            var maxCount = 100;
            var elementMetadataList = new ElementMetadata[maxCount];
            for (var i = 0; i < maxCount; i++)
            {
                var n = i;
                threadList.Add(new Thread(() =>
                {
                    resetEvent.WaitOne();
                    var alternateContent = new AlternateContent();
                    var metadata = ElementMetadata.Create(alternateContent);
                    elementMetadataList[n] = metadata;
                })
                {
                    IsBackground = true,
                });
            }

            foreach (var thread in threadList)
            {
                thread.Start();
            }

            resetEvent.Set();
            foreach (var thread in threadList)
            {
                thread.Join();
            }

            ElementMetadata elementMetadata = elementMetadataList[0];
            foreach (var temp in elementMetadataList)
            {
                if (!ReferenceEquals(elementMetadata, temp))
                {
                    // If it enter this branch, means the ElementMetadata object is created more than once
                    break;
                }
            }
        }
    }
```