### PR TITLE
Reduce massive perf impact from a couple semantic constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Version 2.11.3
 ### Fixed
-- CellValue limits to three most signficant digits on second fractions to correct issue loading DateTime in Office 2016
+- Fixed massive performance bottleneck when IndexReferenceConstraint and ReferenceExistConstraint are involved (#763)
+- Fixed CellValue to only include three most signficant digits on second fractions to correct issue loading dates (#741)
 
 ## Version 2.11.2 - 2020-07-10
 

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/IndexReferenceConstraint.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/IndexReferenceConstraint.cs
@@ -76,17 +76,22 @@ namespace DocumentFormat.OpenXml.Validation.Semantic
                 return new PartHolder<int>(0, null);
             }
 
-            var count = 0;
-
-            foreach (var element in part.RootElement.Descendants())
+            var result = context.State.Get(new { part.Uri, _refElement, _attribute, _refElementParent }, () =>
             {
-                if (_refElementParent is null || element.Parent.GetType() == _refElementParent)
-                {
-                    count++;
-                }
-            }
+                var count = 0;
 
-            return new PartHolder<int>(count, part);
+                foreach (var element in part.RootElement.Descendants())
+                {
+                    if (_refElementParent is null || element.Parent.GetType() == _refElementParent)
+                    {
+                        count++;
+                    }
+                }
+
+                return count;
+            });
+
+            return new PartHolder<int>(result, part);
         }
     }
 }

--- a/src/DocumentFormat.OpenXml/Validation/StateManager.cs
+++ b/src/DocumentFormat.OpenXml/Validation/StateManager.cs
@@ -8,15 +8,13 @@ namespace DocumentFormat.OpenXml.Validation
 {
     internal class StateManager : IValidationContextEvents
     {
-        private Dictionary<Key, object> _state;
+        private Dictionary<object, object> _state;
 
-        public T Get<T>(Type type, int attributeIdx, Type parent, Func<T> factory)
+        public T Get<T>(object key, Func<T> factory)
         {
-            var key = new Key(type, attributeIdx, parent);
-
             if (_state is null)
             {
-                _state = new Dictionary<Key, object>();
+                _state = new Dictionary<object, object>();
             }
             else if (_state.TryGetValue(key, out var value))
             {
@@ -37,6 +35,13 @@ namespace DocumentFormat.OpenXml.Validation
             return result;
         }
 
+        public T Get<T>(Type type, int attributeIdx, Type parent, Func<T> factory)
+        {
+            var key = new Key(type, attributeIdx, parent);
+
+            return Get(key, factory);
+        }
+
         void IValidationContextEvents.OnPartValidationStarted(ValidationContext context)
         {
             _state = null;
@@ -53,7 +58,7 @@ namespace DocumentFormat.OpenXml.Validation
 
             foreach (var state in _state)
             {
-                if (state.Key.Parent == type && state.Value is IValidationContextEvents events)
+                if (state.Key is Key key && key.Parent == type && state.Value is IValidationContextEvents events)
                 {
                     events.OnElementValidationStarted(context);
                 }
@@ -71,7 +76,7 @@ namespace DocumentFormat.OpenXml.Validation
 
             foreach (var state in _state)
             {
-                if (state.Key.Type == type && state.Value is IValidationContextEvents events)
+                if (state.Key is Key key && key.Type == type && state.Value is IValidationContextEvents events)
                 {
                     events.OnElementValidationFinished(context);
                 }


### PR DESCRIPTION
This changes `IndexReferenceConstraint` and `ReferenceExistConstraint` to be much more performant. Two issues were found:

- Using validation infrastructure to just iterate through all the children in a part. Fixing this brought the example issue down from 1.5hr to 15 min
- Recalculating same required information many, many times. Caching this brought the time down from 15 min, to 33 seconds

Fixes #760 