### PR TITLE
Stream children in a validation traversal

### DIFF
--- a/src/DocumentFormat.OpenXml/OpenXmlElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlElement.cs
@@ -4,7 +4,6 @@
 using DocumentFormat.OpenXml.Framework;
 using DocumentFormat.OpenXml.Framework.Metadata;
 using DocumentFormat.OpenXml.Packaging;
-using DocumentFormat.OpenXml.Validation.Schema;
 using DocumentFormat.OpenXml.Validation.Semantic;
 using System;
 using System.Collections.Generic;
@@ -793,8 +792,7 @@ namespace DocumentFormat.OpenXml
         /// <returns>The OpenXmlElement element that immediately precedes the current OpenXmlElement element.</returns>
         public OpenXmlElement PreviousSibling()
         {
-            var parent = Parent as OpenXmlCompositeElement;
-            if (parent == null)
+            if (!(Parent is OpenXmlCompositeElement parent))
             {
                 return null;
             }
@@ -827,9 +825,9 @@ namespace DocumentFormat.OpenXml
 
             while (element != null)
             {
-                if (element is T)
+                if (element is T t)
                 {
-                    return (T)element;
+                    return t;
                 }
 
                 element = element.PreviousSibling();
@@ -866,9 +864,9 @@ namespace DocumentFormat.OpenXml
 
             while (element != null)
             {
-                if (element is T)
+                if (element is T t)
                 {
-                    return (T)element;
+                    return t;
                 }
 
                 element = element.NextSibling();
@@ -904,9 +902,9 @@ namespace DocumentFormat.OpenXml
 
             while (ancestor != null)
             {
-                if (ancestor is T)
+                if (ancestor is T t)
                 {
-                    yield return (T)ancestor;
+                    yield return t;
                 }
 
                 ancestor = ancestor.Parent;
@@ -936,12 +934,9 @@ namespace DocumentFormat.OpenXml
         public IEnumerable<T> Descendants<T>()
             where T : OpenXmlElement
         {
-            T elementT = null;
-
             foreach (var element in Descendants())
             {
-                elementT = element as T;
-                if (elementT != null)
+                if (element is T elementT)
                 {
                     yield return elementT;
                 }

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/IndexReferenceConstraint.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/IndexReferenceConstraint.cs
@@ -80,9 +80,9 @@ namespace DocumentFormat.OpenXml.Validation.Semantic
             {
                 var count = 0;
 
-                foreach (var element in part.RootElement.Descendants())
+                foreach (var element in part.RootElement.Descendants(context.FileFormat, TraversalOptions.SelectAlternateContent))
                 {
-                    if (_refElementParent is null || element.Parent.GetType() == _refElementParent)
+                    if (_refElementParent is null || element.Parent?.GetType() == _refElementParent)
                     {
                         count++;
                     }

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/ReferenceExistConstraint.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/ReferenceExistConstraint.cs
@@ -80,7 +80,7 @@ namespace DocumentFormat.OpenXml.Validation.Semantic
             {
                 var referencedAttributes = new HashSet<string>(StringComparer.Ordinal);
 
-                foreach (var element in part.RootElement.Descendants())
+                foreach (var element in part.RootElement.Descendants(context.FileFormat, TraversalOptions.SelectAlternateContent))
                 {
                     if (element.GetType() == _element)
                     {

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/UniqueAttributeValueConstraint.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/UniqueAttributeValueConstraint.cs
@@ -55,29 +55,20 @@ namespace DocumentFormat.OpenXml.Validation.Semantic
             {
                 added = true;
 
-                var found = false;
-                var innerContext = new ValidationContext(context);
-
-                using (innerContext.Stack.Push(part.OpenXmlPackage, part, part.RootElement))
+                foreach (var e in root.Descendants(context.FileFormat, TraversalOptions.SelectAlternateContent))
                 {
-                    // We want to use ValidationTraverser as it will correctly handle AlternateContent blocks
-                    ValidationTraverser.ValidatingTraverse(innerContext, c =>
+                    if (e != element & e.GetType() == elementType)
                     {
-                        var e = c.Stack.Current.Element;
+                        var eValue = e.ParsedState.Attributes[_attribute];
 
-                        if (e != element & e.GetType() == elementType)
+                        if (eValue.HasValue && _comparer.Equals(attributeText, eValue.Value.InnerText))
                         {
-                            var eValue = e.ParsedState.Attributes[_attribute];
-
-                            if (eValue.HasValue && _comparer.Equals(attributeText, eValue.Value.InnerText))
-                            {
-                                found = true;
-                            }
+                            return true;
                         }
-                    });
+                    }
                 }
 
-                return found;
+                return false;
             });
 
             if (!isDuplicate || !added)

--- a/src/DocumentFormat.OpenXml/Validation/StateManager.cs
+++ b/src/DocumentFormat.OpenXml/Validation/StateManager.cs
@@ -36,3 +36,4 @@ namespace DocumentFormat.OpenXml.Validation
         }
     }
 }
+

--- a/src/DocumentFormat.OpenXml/Validation/StateManager.cs
+++ b/src/DocumentFormat.OpenXml/Validation/StateManager.cs
@@ -36,4 +36,3 @@ namespace DocumentFormat.OpenXml.Validation
         }
     }
 }
-

--- a/src/DocumentFormat.OpenXml/Validation/TraversalOptions.cs
+++ b/src/DocumentFormat.OpenXml/Validation/TraversalOptions.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DocumentFormat.OpenXml.Validation
+{
+    [Flags]
+    internal enum TraversalOptions
+    {
+        None = 0,
+        SelectAlternateContent = 1,
+    }
+}

--- a/src/DocumentFormat.OpenXml/Validation/ValidationTraverser.cs
+++ b/src/DocumentFormat.OpenXml/Validation/ValidationTraverser.cs
@@ -17,7 +17,7 @@ namespace DocumentFormat.OpenXml.Validation
                 return Cached.Array<OpenXmlElement>();
             }
 
-            if (options.HasFlag(TraversalOptions.SelectAlternateContent))
+            if ((options & TraversalOptions.SelectAlternateContent) == TraversalOptions.SelectAlternateContent)
             {
                 return ValidatingTraverse(element, new MCContext(false), version);
             }

--- a/test/DocumentFormat.OpenXml.Tests/ofapiTest/BugRegressionTest.cs
+++ b/test/DocumentFormat.OpenXml.Tests/ofapiTest/BugRegressionTest.cs
@@ -93,10 +93,19 @@ namespace DocumentFormat.OpenXml.Tests
 
             // an empty "AlternateContent"
             var errors = validator.Validate(p); // should no hang, no OOM
-            Assert.Equal(2, errors.Count());
-            Assert.Equal("Sch_IncompleteContentExpectingComplex", errors.First().Id);
-            Assert.Same(p.FirstChild, errors.First().Node);  // acb should have a choice
-            Assert.Same(p.FirstChild.NextSibling().FirstChild.NextSibling(), errors.ElementAt(1).RelatedNode);
+
+            Assert.Collection(
+                errors,
+                error =>
+                {
+                    Assert.Equal("Sch_UnexpectedElementContentExpectingComplex", error.Id);
+                    Assert.Same(p.FirstChild.NextSibling().FirstChild.NextSibling(), error.RelatedNode);
+                },
+                error =>
+                {
+                    Assert.Equal("Sch_IncompleteContentExpectingComplex", error.Id);
+                    Assert.Same(p.FirstChild, error.Node);  // acb should have a choice
+                });
 
             // append an empty "Choice"
             p.AddNamespaceDeclaration("w14", "http://w14");

--- a/test/DocumentFormat.OpenXml.Tests/ofapiTest/SchemaValidatorTest.cs
+++ b/test/DocumentFormat.OpenXml.Tests/ofapiTest/SchemaValidatorTest.cs
@@ -27,15 +27,20 @@ namespace DocumentFormat.OpenXml.Tests
             var openxmlElement = new Run(runOuterXml);
             var result = target.Validate(openxmlElement);
 
-            Assert.Equal(2, result.Count);
-
-            Assert.Same(openxmlElement.GetFirstChild<RunProperties>().WebHidden, result[0].Node);
-            Assert.Equal("Sch_InvalidChildinLeafElement", result[0].Id);
-            Assert.Equal("The element 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:webHidden' is a leaf element and cannot contain children.", result[0].Description);
-
-            Assert.Same(openxmlElement.LastChild, result[1].Node);
-            Assert.Equal("Sch_InvalidChildinLeafElement", result[1].Id);
-            Assert.Equal("The element 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:t' is a leaf element and cannot contain children.", result[1].Description);
+            Assert.Collection(
+                result,
+                error =>
+                {
+                    Assert.Same(openxmlElement.LastChild, error.Node);
+                    Assert.Equal("Sch_InvalidChildinLeafElement", error.Id);
+                    Assert.Equal("The element 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:t' is a leaf element and cannot contain children.", error.Description);
+                },
+                error =>
+                {
+                    Assert.Same(openxmlElement.GetFirstChild<RunProperties>().WebHidden, error.Node);
+                    Assert.Equal("Sch_InvalidChildinLeafElement", error.Id);
+                    Assert.Equal("The element 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:webHidden' is a leaf element and cannot contain children.", error.Description);
+                });
         }
     }
 }


### PR DESCRIPTION
Update ValidationTraverser to not be recursive. This allows us to stream the elements it finds, including the elements from the correct AlternateContent blocks.