### PR TITLE
Expose `OpenXmlCompositeElement.TryAddChild`

### DIFF
--- a/src/DocumentFormat.OpenXml/AppendOption.cs
+++ b/src/DocumentFormat.OpenXml/AppendOption.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DocumentFormat.OpenXml
+{
+    /// <summary>
+    /// Options to define how an element should be appeneded.
+    /// </summary>
+    public enum AppendOption
+    {
+        /// <summary>
+        /// Append the item in list order without regard to schema.
+        /// </summary>
+        List = 0,
+
+        /// <summary>
+        /// Append the item in accordance with what the schema defines.
+        /// </summary>
+        Ordered = 1,
+    }
+}

--- a/src/DocumentFormat.OpenXml/Framework/Schema/CompiledParticle.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Schema/CompiledParticle.cs
@@ -22,14 +22,10 @@ namespace DocumentFormat.OpenXml.Framework
 
         public ParticleConstraint Particle { get; }
 
-        public ParticlePath Find<TElement>()
-            where TElement : OpenXmlElement
-            => GetPath(typeof(TElement));
-
         public ParticlePath Find(object obj)
-            => GetPath(obj?.GetType());
+            => Find(obj?.GetType());
 
-        private ParticlePath GetPath(Type type)
+        public ParticlePath Find(Type type)
         {
             if (type is null)
             {
@@ -49,8 +45,8 @@ namespace DocumentFormat.OpenXml.Framework
 
         public int Compare(OpenXmlElement x, OpenXmlElement y)
         {
-            var xPath = GetPath(x?.GetType());
-            var yPath = GetPath(y?.GetType());
+            var xPath = Find(x?.GetType());
+            var yPath = Find(y?.GetType());
 
             if (xPath is null && yPath is null)
             {

--- a/src/DocumentFormat.OpenXml/Framework/Schema/ParticleExtensions.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Schema/ParticleExtensions.cs
@@ -11,9 +11,9 @@ namespace DocumentFormat.OpenXml.Framework
     /// </summary>
     internal static class ParticleExtensions
     {
-        public static ParticleCollection<TElement> GetCollection<TElement>(this CompiledParticle compiled, OpenXmlCompositeElement element)
+        public static ParticleCollection GetCollection<TElement>(this CompiledParticle compiled, OpenXmlCompositeElement element)
             where TElement : OpenXmlElement
-            => new ParticleCollection<TElement>(compiled, element);
+            => new ParticleCollection(typeof(TElement), compiled, element);
 
         public static TElement Get<TElement>(this CompiledParticle compiled, OpenXmlCompositeElement element)
             where TElement : OpenXmlElement
@@ -43,15 +43,19 @@ namespace DocumentFormat.OpenXml.Framework
             return null;
         }
 
-        public static bool Set<TElement>(this CompiledParticle compiled, OpenXmlCompositeElement parent, TElement value)
-            where TElement : OpenXmlElement
+        public static bool Set(this CompiledParticle compiled, OpenXmlCompositeElement parent, OpenXmlElement value)
         {
             if (compiled is null)
             {
                 return false;
             }
 
-            var collection = GetCollection<TElement>(compiled, parent);
+            if (value is null)
+            {
+                return false;
+            }
+
+            var collection = new ParticleCollection(value.GetType(), compiled, parent);
 
             collection.Clear();
             return collection.Add(value);

--- a/src/DocumentFormat.OpenXml/OpenXmlCompositeElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlCompositeElement.cs
@@ -205,6 +205,22 @@ namespace DocumentFormat.OpenXml
         #region change children
 
         /// <summary>
+        /// Adds the specified element to the element if it is a known child. This adds the element in the correct location according to the schema.
+        /// </summary>
+        /// <param name="newChild">The OpenXmlElement element to append.</param>
+        /// <returns>Success if the element was added, otherwise <c>false</c>.</returns>
+        public bool TryAddChild<T>(T newChild)
+            where T : OpenXmlElement
+        {
+            if (newChild is null)
+            {
+                return false;
+            }
+
+            return SetElement(newChild);
+        }
+
+        /// <summary>
         /// Appends the specified element to the end of the current element's list of child nodes.
         /// </summary>
         /// <param name="newChild">The OpenXmlElement element to append.</param>
@@ -761,8 +777,8 @@ namespace DocumentFormat.OpenXml
         private protected TElement GetElement<TElement>()
             where TElement : OpenXmlElement => Metadata.Particle.Get<TElement>(this);
 
-        private protected void SetElement<TElement>(TElement value)
-            where TElement : OpenXmlElement => Metadata.Particle.Set(this, value);
+        private protected bool SetElement(OpenXmlElement value)
+            => Metadata.Particle.Set(this, value);
 
         private void AddANode(OpenXmlElement node)
         {

--- a/test/DocumentFormat.OpenXml.Framework.Tests/Particles/CompiledParticleTests.cs
+++ b/test/DocumentFormat.OpenXml.Framework.Tests/Particles/CompiledParticleTests.cs
@@ -17,7 +17,7 @@ namespace DocumentFormat.OpenXml.Framework.Tests
                 .Compile();
             var data = new TestOpenXmlCompositeElement();
 
-            Assert.False(particle.Set<T2>(data, new T2()));
+            Assert.False(particle.Set(data, new T2()));
             Assert.Null(particle.Get<T2>(data));
         }
 
@@ -91,7 +91,7 @@ namespace DocumentFormat.OpenXml.Framework.Tests
             var data = new TestOpenXmlCompositeElement();
             var instance = new T1();
 
-            Assert.True(particle.Set<T1>(data, instance));
+            Assert.True(particle.Set(data, instance));
             Assert.Equal(instance, particle.Get<T1>(data));
         }
 


### PR DESCRIPTION
This change adds an API to simplify adding child elements in the correct order according to the schema definition.

Part of #492