### PR TITLE
Use WindowsBase instead of package on .NET Framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `SmartTagClean` and `SmartTagId` in place of `SmtClean` and `SmtId` (#747)
 - Added `OpenXmlValidator.Validate(..., CancellationToken)` overrides to allow easier cancellation of long running validation on .NET 4.0+ (#773)
 
+### Removed
+- Removed explicit reference to `System.IO.Packaging` on .NET 4.6 builds (#774)
+
 ## Version 2.11.3 - 2020-07-17
 ### Fixed
 - Fixed massive performance bottleneck when IndexReferenceConstraint and ReferenceExistConstraint are involved (#763)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
          - DevCore31:      .NET Core 3.1
          - All: Will build for all platforms
          -->
-    <ProjectLoadStyle Condition=" '$(ProjectLoadStyle)' == '' ">DevCore31</ProjectLoadStyle>
+    <ProjectLoadStyle Condition=" '$(ProjectLoadStyle)' == '' ">DevFramework46</ProjectLoadStyle>
     <__InvalidProjectLoadStyle>false</__InvalidProjectLoadStyle>
   </PropertyGroup>
 
@@ -60,6 +60,9 @@
         <BenchmarkTargetFramework>net461</BenchmarkTargetFramework>
         <SamplesFrameworks>net46</SamplesFrameworks>
       </PropertyGroup>
+      <ItemGroup>
+        <Reference Include="WindowsBase" />
+      </ItemGroup>
     </When>
     <When Condition=" '$(ProjectLoadStyle)' == 'DevCore11' ">
       <PropertyGroup>
@@ -104,6 +107,10 @@
         <!-- Must disable this due to https://github.com/NuGet/Home/issues/7414 so .NET Core 1.x will build -->
         <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
       </PropertyGroup>
+
+      <ItemGroup Condition=" '$(TargetFramework)' == 'net35' OR '$(TargetFramework)' == 'net40' OR '$(TargetFramework)'=='net452' OR '$(TargetFramework)' == 'net46'  ">
+        <Reference Include="WindowsBase" />
+      </ItemGroup>
     </When>
     <Otherwise>
       <PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@ Table of Contents
 -----------------
 
 - [Releases](#releases)
-  - [Supported platforms](#supported-platforms)
-  - [WindowsBase or System.IO.Packaging](#windowsbase-or-systemiopackaging)
-  - [How to install the NuGet package](#how-to-install-the-nuget-package)
+- [How to install the NuGet package](#how-to-install-the-nuget-package)
 - [If You Have Problems](#if-you-have-problems)
 - [Known Issues](#known-issues)
 - [Documentation](#documentation)
@@ -40,35 +38,7 @@ The NuGet package for the latest builds of the Open XML SDK is available as a cu
 
 For latests changes, please see the [changelog](CHANGELOG.md)
 
-Supported platforms
------------------
-
-This library supports many platforms. There are builds for .NET 3.5, .NET 4.0, .NET 4.6, and .NET Standard 1.3. The following platforms are currently supported:
-
-|    Platform     | Minimum Version |
-|-----------------|-----------------|
-| .NET Framework  | 3.5             |
-| .NET Core       | 1.0             |
-| UWP             | 10.0            |
-| Mono            | 3.5             |
-| Xamarin.iOS     | 10.0            |
-| Xamarin.Mac     | 3.0             |
-| Xamarin.Android | 7.0             |
-
-WindowsBase or System.IO.Packaging
-----------------------------------
-
-There is a known issue in `WindowsBase` that causes crashes when handling large data sources. This is fixed in later versions of the library, based on the platform availability of the `System.IO.Packaging` package. When possible, we use this package instead of `WindowsBase`. This not only fixes the crash seen by some users, but is available cross platform. However, it is only available on .NET Standard 1.3+ and .NET Framework 4.6+. For this reason, the NuGet package has multiple targets to bring in, when possible. The targets are determined by NuGet at installation and build time and are listed in the table below.
-
-| Platform          | System.IO.Packing Source | Tested by                    |
-| ----------------- | ------------------------ | ---------------------------- |
-| .NET 3.5          | WindowsBase              | N/A                          |
-| .NET 4.0          | WindowsBase              | .NET 4.5.2                   |
-| .NET 4.6          | NuGet                    | .NET 4.6                     |
-| .NET Standard 1.3 | NuGet                    | .NET Core 1.1                |
-| .NET Standard 2.0 | NuGet                    | .NET Core 2.1, .NET Core 3.1 |
-
-Keep in mind, though, that the `System.IO.Packaging` on .NET 4.6+ is simply a facade over WindowsBase, and thus everything running on .NET 4.6 will use WindowsBase instead of the newer implementation.
+This library supports many platforms. There are builds for .NET 3.5, .NET 4.0, .NET 4.6, .NET Standard 1.3, .NET Standard 2.0. The following platforms are currently supported:
 
 How to install the NuGet package
 ---------------------------------

--- a/samples/SunburstChartExample/SunburstChartExample.csproj
+++ b/samples/SunburstChartExample/SunburstChartExample.csproj
@@ -9,5 +9,4 @@
     <ProjectReference Include="..\..\src\DocumentFormat.OpenXml\DocumentFormat.OpenXml.csproj" />
   </ItemGroup>
 
-
 </Project>

--- a/src/DocumentFormat.OpenXml/DocumentFormat.OpenXml.csproj
+++ b/src/DocumentFormat.OpenXml/DocumentFormat.OpenXml.csproj
@@ -43,7 +43,6 @@
         <Reference Include="System" />
         <Reference Include="System.Xml" />
         <Reference Include="System.Xml.Linq" />
-        <Reference Include="WindowsBase" />
       </ItemGroup>
 
       <ItemGroup>
@@ -69,14 +68,10 @@
         <CompileWithPeVerify>true</CompileWithPeVerify>
       </PropertyGroup>
 
-      <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+      <ItemGroup>
         <Reference Include="System" />
         <Reference Include="System.Xml" />
         <Reference Include="System.Xml.Linq" />
-      </ItemGroup>
-
-      <ItemGroup>
-        <PackageReference Include="System.IO.Packaging" Version="$(SystemIOPackagingVersion)" />
       </ItemGroup>
     </When>
 


### PR DESCRIPTION
Currently we're using System.IO.Packaging NuGet package on .NET 4.6+,
when this isn't really necessary. This ends up just being a bunch of
type forwarders that people don't really need on .NET Framework. We can
just directly reference WindowsBase instead.

This should be a non-breaking change as all the type-forwarders would be
brought in by another dependency if they require them.