### PR TITLE
Rename TryAddChild to AddChild with option for exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Version 2.12.0
 
 ### Added
+- Added `OpenXmlCompositeElement.AddChild(OpenXmlElement)` to add children in the correct order per schema (#774)
 - Added `SmartTagClean` and `SmartTagId` in place of `SmtClean` and `SmtId` (#747)
 - Added `OpenXmlValidator.Validate(..., CancellationToken)` overrides to allow easier cancellation of long running validation on .NET 4.0+ (#773)
 - Added overloads for `CellValue` to take `decimal`, `double`, and `int`, as well as convenience methods to parse them (#782)

--- a/src/DocumentFormat.OpenXml/OpenXmlCompositeElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlCompositeElement.cs
@@ -208,16 +208,28 @@ namespace DocumentFormat.OpenXml
         /// Adds the specified element to the element if it is a known child. This adds the element in the correct location according to the schema.
         /// </summary>
         /// <param name="newChild">The OpenXmlElement element to append.</param>
+        /// <param name="throwOnError">A flag to indicate if the method should throw if the child could not be added.</param>
         /// <returns>Success if the element was added, otherwise <c>false</c>.</returns>
-        public bool TryAddChild<T>(T newChild)
-            where T : OpenXmlElement
+        public bool AddChild(OpenXmlElement newChild, bool throwOnError = true)
         {
             if (newChild is null)
             {
+                if (throwOnError)
+                {
+                    throw new ArgumentNullException(nameof(newChild));
+                }
+
                 return false;
             }
 
-            return SetElement(newChild);
+            var wasAdded = SetElement(newChild);
+
+            if (throwOnError && !wasAdded)
+            {
+                throw new InvalidOperationException(ExceptionMessages.ElementIsNotChild);
+            }
+
+            return wasAdded;
         }
 
         /// <summary>


### PR DESCRIPTION
This also removes the generic constraint as that is unnecessary and fails to work in the instances where you have just a `OpenXmlElement`.