### PR TITLE
Reduce property acquisition and repeated call methods 

### DIFF
--- a/src/DocumentFormat.OpenXml/OpenXmlElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlElement.cs
@@ -960,7 +960,7 @@ namespace DocumentFormat.OpenXml
 
             stack.Push(root);
 
-            while (true)
+            while (stack.Count > 0)
             {
                 var topElement = stack.Peek();
                 var firstChildInTopElement = topElement.FirstChild;
@@ -980,13 +980,6 @@ namespace DocumentFormat.OpenXml
                         root = nextSiblingElement;
                         stack.Push(root);
                         yield return root;
-                    }
-                    else
-                    {
-                        if (stack.Count == 0)
-                        {
-                            yield break;
-                        }
                     }
                 }
             }

--- a/src/DocumentFormat.OpenXml/OpenXmlElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlElement.cs
@@ -993,7 +993,7 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-/// <summary>
+        /// <summary>
         /// Enumerates all of the sibling elements that precede the current element and have the same parent as the current element.
         /// </summary>
         /// <returns>An IEnumerable object that contains a list of OpenXmlElement elements.</returns>

--- a/src/DocumentFormat.OpenXml/OpenXmlElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlElement.cs
@@ -994,51 +994,6 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
-        /// Enumerates all of the current element's descendants.
-        /// </summary>
-        /// <returns></returns>
-        public IEnumerable<OpenXmlElement> OldDescendants()
-        {
-            if (FirstChild == null)
-            {
-                yield break;
-            }
-
-            var root = FirstChild;
-
-            yield return root;
-
-            var stack = new Stack<OpenXmlElement>();
-
-            stack.Push(root);
-
-            while (true)
-            {
-                if (stack.Peek() == root && stack.Peek().FirstChild != null)
-                {
-                    root = stack.Peek().FirstChild;
-                    stack.Push(root);
-                    yield return root;
-                }
-                else if (stack.Peek().NextSibling() != null)
-                {
-                    root = stack.Peek().NextSibling();
-                    stack.Pop();
-                    stack.Push(root);
-                    yield return root;
-                }
-                else
-                {
-                    stack.Pop();
-                    if (stack.Count == 0)
-                    {
-                        yield break;
-                    }
-                }
-            }
-        }
-
-        /// <summary>
         /// Enumerates all of the sibling elements that precede the current element and have the same parent as the current element.
         /// </summary>
         /// <returns>An IEnumerable object that contains a list of OpenXmlElement elements.</returns>

--- a/src/DocumentFormat.OpenXml/OpenXmlElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlElement.cs
@@ -974,16 +974,15 @@ namespace DocumentFormat.OpenXml
                 else
                 {
                     var nextSiblingElement = topElement.NextSibling();
+                    stack.Pop();
                     if (nextSiblingElement != null)
                     {
                         root = nextSiblingElement;
-                        stack.Pop();
                         stack.Push(root);
                         yield return root;
                     }
                     else
                     {
-                        stack.Pop();
                         if (stack.Count == 0)
                         {
                             yield break;

--- a/src/DocumentFormat.OpenXml/OpenXmlElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlElement.cs
@@ -994,6 +994,51 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
+        /// Enumerates all of the current element's descendants.
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<OpenXmlElement> OldDescendants()
+        {
+            if (FirstChild == null)
+            {
+                yield break;
+            }
+
+            var root = FirstChild;
+
+            yield return root;
+
+            var stack = new Stack<OpenXmlElement>();
+
+            stack.Push(root);
+
+            while (true)
+            {
+                if (stack.Peek() == root && stack.Peek().FirstChild != null)
+                {
+                    root = stack.Peek().FirstChild;
+                    stack.Push(root);
+                    yield return root;
+                }
+                else if (stack.Peek().NextSibling() != null)
+                {
+                    root = stack.Peek().NextSibling();
+                    stack.Pop();
+                    stack.Push(root);
+                    yield return root;
+                }
+                else
+                {
+                    stack.Pop();
+                    if (stack.Count == 0)
+                    {
+                        yield break;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// Enumerates all of the sibling elements that precede the current element and have the same parent as the current element.
         /// </summary>
         /// <returns>An IEnumerable object that contains a list of OpenXmlElement elements.</returns>

--- a/src/DocumentFormat.OpenXml/OpenXmlElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlElement.cs
@@ -962,31 +962,38 @@ namespace DocumentFormat.OpenXml
 
             while (true)
             {
-                if (stack.Peek() == root && stack.Peek().FirstChild != null)
+                var topElement = stack.Peek();
+                var firstChildInTopElement = topElement.FirstChild;
+
+                if (topElement == root && firstChildInTopElement != null)
                 {
-                    root = stack.Peek().FirstChild;
-                    stack.Push(root);
-                    yield return root;
-                }
-                else if (stack.Peek().NextSibling() != null)
-                {
-                    root = stack.Peek().NextSibling();
-                    stack.Pop();
+                    root = firstChildInTopElement;
                     stack.Push(root);
                     yield return root;
                 }
                 else
                 {
-                    stack.Pop();
-                    if (stack.Count == 0)
+                    var nextSiblingElement = topElement.NextSibling();
+                    if (nextSiblingElement != null)
                     {
-                        yield break;
+                        root = nextSiblingElement;
+                        stack.Pop();
+                        stack.Push(root);
+                        yield return root;
+                    }
+                    else
+                    {
+                        stack.Pop();
+                        if (stack.Count == 0)
+                        {
+                            yield break;
+                        }
                     }
                 }
             }
         }
 
-        /// <summary>
+/// <summary>
         /// Enumerates all of the sibling elements that precede the current element and have the same parent as the current element.
         /// </summary>
         /// <returns>An IEnumerable object that contains a list of OpenXmlElement elements.</returns>

--- a/test/DocumentFormat.OpenXml.Benchmarks/OpenXmlElementDescendantsTests.cs
+++ b/test/DocumentFormat.OpenXml.Benchmarks/OpenXmlElementDescendantsTests.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using DocumentFormat.OpenXml.Drawing;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Tests;
+using DocumentFormat.OpenXml.Validation;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace DocumentFormat.OpenXml.Benchmarks
+{
+    public class OpenXmlElementDescendantsTests
+    {
+        [GlobalSetup]
+        public void Setup()
+        {
+            var textBody = new TextBody();
+            for (int i = 0; i < 1000; i++)
+            {
+                var paragraph = new Paragraph();
+                for (int j = 0; j < 1000; j++)
+                {
+                    paragraph.AppendChild(new Run());
+                }
+
+                textBody.AppendChild(paragraph);
+            }
+
+            _element = textBody;
+        }
+
+        [Benchmark]
+        public List<OpenXmlElement> Descendants()
+        {
+            var list = _element.Descendants().ToList();
+            return list;
+        }
+
+        [Benchmark]
+        public List<OpenXmlElement> OldDescendants()
+        {
+            var list = _element.OldDescendants().ToList();
+            return list;
+        }
+
+        private OpenXmlElement _element;
+    }
+}

--- a/test/DocumentFormat.OpenXml.Benchmarks/OpenXmlElementDescendantsTests.cs
+++ b/test/DocumentFormat.OpenXml.Benchmarks/OpenXmlElementDescendantsTests.cs
@@ -31,8 +31,7 @@ namespace DocumentFormat.OpenXml.Benchmarks
         [Benchmark]
         public List<OpenXmlElement> Descendants()
         {
-            var list = _element.Descendants().ToList();
-            return list;
+            return _element.Descendants().ToList();
         }
 
         private OpenXmlElement _element;

--- a/test/DocumentFormat.OpenXml.Benchmarks/OpenXmlElementDescendantsTests.cs
+++ b/test/DocumentFormat.OpenXml.Benchmarks/OpenXmlElementDescendantsTests.cs
@@ -3,11 +3,7 @@
 
 using BenchmarkDotNet.Attributes;
 using DocumentFormat.OpenXml.Drawing;
-using DocumentFormat.OpenXml.Packaging;
-using DocumentFormat.OpenXml.Tests;
-using DocumentFormat.OpenXml.Validation;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 
 namespace DocumentFormat.OpenXml.Benchmarks
@@ -36,13 +32,6 @@ namespace DocumentFormat.OpenXml.Benchmarks
         public List<OpenXmlElement> Descendants()
         {
             var list = _element.Descendants().ToList();
-            return list;
-        }
-
-        [Benchmark]
-        public List<OpenXmlElement> OldDescendants()
-        {
-            var list = _element.OldDescendants().ToList();
             return list;
         }
 


### PR DESCRIPTION
Reduce property acquisition and repeated call methods to improve performance

|         Method |     Mean |    Error |   StdDev |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|--------------- |---------:|---------:|---------:|---------:|---------:|---------:|----------:|
|    Descendants | 47.73 ms | 0.342 ms | 0.320 ms | 166.6667 | 166.6667 | 166.6667 |     16 MB |
| OldDescendants | 50.80 ms | 0.789 ms | 0.699 ms | 200.0000 | 200.0000 | 200.0000 |     16 MB |

Benchmark code: https://github.com/dotnet-campus/Open-XML-SDK/blob/3f7608a23ba3420d382050c2ca5c7f295a5d381b/test/DocumentFormat.OpenXml.Benchmarks/OpenXmlElementDescendantsTests.cs