### PR TITLE
Small performance improvements for AddNamespaceDeclaration

### DIFF
--- a/src/DocumentFormat.OpenXml/OpenXmlElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlElement.cs
@@ -752,6 +752,40 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
+        /// Fx
+        /// </summary>
+        /// <param name="prefix"></param>
+        /// <param name="uri"></param>
+        public void OldAddNamespaceDeclaration(string prefix, string uri)
+        {
+            if (string.IsNullOrEmpty(prefix))
+            {
+                throw new ArgumentNullException(nameof(prefix));
+            }
+
+            if (string.IsNullOrEmpty(uri))
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            MakeSureParsed();
+            if (NamespaceDeclField == null)
+            {
+                NamespaceDeclField = new List<KeyValuePair<string, string>>();
+            }
+
+            foreach (var item in NamespaceDeclField)
+            {
+                if (item.Key == prefix)
+                {
+                    throw new InvalidOperationException(SR.Format(ExceptionMessages.DuplicatedPrefix, prefix));
+                }
+            }
+
+            NamespaceDeclField.Add(new KeyValuePair<string, string>(prefix, uri));
+        }
+
+        /// <summary>
         /// Removes the namespace declaration for the specified prefix. Removes nothing if there is no prefix.
         /// </summary>
         /// <param name="prefix"></param>

--- a/src/DocumentFormat.OpenXml/OpenXmlElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlElement.cs
@@ -752,40 +752,6 @@ namespace DocumentFormat.OpenXml
         }
 
         /// <summary>
-        /// Fx
-        /// </summary>
-        /// <param name="prefix"></param>
-        /// <param name="uri"></param>
-        public void OldAddNamespaceDeclaration(string prefix, string uri)
-        {
-            if (string.IsNullOrEmpty(prefix))
-            {
-                throw new ArgumentNullException(nameof(prefix));
-            }
-
-            if (string.IsNullOrEmpty(uri))
-            {
-                throw new ArgumentNullException(nameof(uri));
-            }
-
-            MakeSureParsed();
-            if (NamespaceDeclField == null)
-            {
-                NamespaceDeclField = new List<KeyValuePair<string, string>>();
-            }
-
-            foreach (var item in NamespaceDeclField)
-            {
-                if (item.Key == prefix)
-                {
-                    throw new InvalidOperationException(SR.Format(ExceptionMessages.DuplicatedPrefix, prefix));
-                }
-            }
-
-            NamespaceDeclField.Add(new KeyValuePair<string, string>(prefix, uri));
-        }
-
-        /// <summary>
         /// Removes the namespace declaration for the specified prefix. Removes nothing if there is no prefix.
         /// </summary>
         /// <param name="prefix"></param>

--- a/src/DocumentFormat.OpenXml/OpenXmlElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlElement.cs
@@ -737,12 +737,14 @@ namespace DocumentFormat.OpenXml
             {
                 NamespaceDeclField = new List<KeyValuePair<string, string>>();
             }
-
-            foreach (var item in NamespaceDeclField)
+            else
             {
-                if (item.Key == prefix)
+                foreach (var item in NamespaceDeclField)
                 {
-                    throw new InvalidOperationException(SR.Format(ExceptionMessages.DuplicatedPrefix, prefix));
+                    if (item.Key == prefix)
+                    {
+                        throw new InvalidOperationException(SR.Format(ExceptionMessages.DuplicatedPrefix, prefix));
+                    }
                 }
             }
 

--- a/test/DocumentFormat.OpenXml.Benchmarks/OpenXmlElementAddNamespaceDeclarationTests.cs
+++ b/test/DocumentFormat.OpenXml.Benchmarks/OpenXmlElementAddNamespaceDeclarationTests.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using DocumentFormat.OpenXml.Drawing.ChartDrawing;
+
+namespace DocumentFormat.OpenXml.Benchmarks
+{
+    public class OpenXmlElementAddNamespaceDeclarationTests
+    {
+        [IterationSetup]
+        public void Setup()
+        {
+            _element = new TextBody();
+        }
+
+        [Benchmark]
+        public void AddNamespaceDeclaration()
+        {
+            _element.AddNamespaceDeclaration("test","test");
+        }
+
+        [Benchmark]
+        public void OldAddNamespaceDeclaration()
+        {
+            _element.OldAddNamespaceDeclaration("test", "test");
+        }
+
+        private OpenXmlElement _element;
+    }
+}

--- a/test/DocumentFormat.OpenXml.Benchmarks/OpenXmlElementAddNamespaceDeclarationTests.cs
+++ b/test/DocumentFormat.OpenXml.Benchmarks/OpenXmlElementAddNamespaceDeclarationTests.cs
@@ -20,12 +20,6 @@ namespace DocumentFormat.OpenXml.Benchmarks
             _element.AddNamespaceDeclaration("test","test");
         }
 
-        [Benchmark]
-        public void OldAddNamespaceDeclaration()
-        {
-            _element.OldAddNamespaceDeclaration("test", "test");
-        }
-
         private OpenXmlElement _element;
     }
 }

--- a/test/DocumentFormat.OpenXml.Benchmarks/OpenXmlElementAddNamespaceDeclarationTests.cs
+++ b/test/DocumentFormat.OpenXml.Benchmarks/OpenXmlElementAddNamespaceDeclarationTests.cs
@@ -17,7 +17,7 @@ namespace DocumentFormat.OpenXml.Benchmarks
         [Benchmark]
         public void AddNamespaceDeclaration()
         {
-            _element.AddNamespaceDeclaration("test","test");
+            _element.AddNamespaceDeclaration("test", "test");
         }
 
         private OpenXmlElement _element;


### PR DESCRIPTION
|                     Method |     Mean |     Error |   StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------- |---------:|----------:|---------:|------:|------:|------:|----------:|
|    AddNamespaceDeclaration | 3.665 us | 0.5911 us | 1.658 us |     - |     - |     - |         - |
| OldAddNamespaceDeclaration | 4.303 us | 0.8884 us | 2.462 us |     - |     - |     - |         - |


Because the method execution time is too short, it is difficult to observe the intensity of optimization.


Benchmark code: https://github.com/dotnet-campus/Open-XML-SDK/blob/5d5c307a55066fccb3913d28bf945b51e0a6fcde/test/DocumentFormat.OpenXml.Benchmarks/OpenXmlElementAddNamespaceDeclarationTests.cs