### PR TITLE
Add a relationship rewriter to help sanitize malformed URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Version 2.12.0
 
 ### Added
+- Added `OpenSettings.RelationshipErrorHandlerFactory` to provide a way to handle URIs that break parsing documents with malformed links (#793)
 - Added `OpenXmlCompositeElement.AddChild(OpenXmlElement)` to add children in the correct order per schema (#774)
 - Added `SmartTagClean` and `SmartTagId` in place of `SmtClean` and `SmtId` (#747)
 - Added `OpenXmlValidator.Validate(..., CancellationToken)` overrides to allow easier cancellation of long running validation on .NET 4.0+ (#773)
@@ -18,8 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Version 2.11.3 - 2020-07-17
 ### Fixed
-- Fixed massive performance bottleneck when IndexReferenceConstraint and ReferenceExistConstraint are involved (#763)
-- Fixed CellValue to only include three most signficant digits on second fractions to correct issue loading dates (#741)
+- Fixed massive performance bottleneck when `IndexReferenceConstraint` and `ReferenceExistConstraint` are involved (#763)
+- Fixed `CellValue` to only include three most signficant digits on second fractions to correct issue loading dates (#741)
 - Fixed a couple of validation indexing errors that might cause erroneous validation errors (#767)
 - Updated internal validation system to not use recursion, allowing for better short-circuiting (#766)
 

--- a/src/DocumentFormat.OpenXml/DocumentFormat.OpenXml.csproj
+++ b/src/DocumentFormat.OpenXml/DocumentFormat.OpenXml.csproj
@@ -60,6 +60,7 @@
         <Compile Include="System\IO\StreamCopyExtensions.cs" />
         <Compile Include="System\Threading\CancellationToken.cs" />
         <Compile Include="System\Lazy{T}.cs" />
+        <Compile Include="System\Xml\Linq\XDocumentExtensions.cs" />
       </ItemGroup>
     </When>
 

--- a/src/DocumentFormat.OpenXml/Packaging/OpenSettings.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenSettings.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace DocumentFormat.OpenXml.Packaging
 {
     /// <summary>
@@ -24,6 +26,7 @@ namespace DocumentFormat.OpenXml.Packaging
             MarkupCompatibilityProcessSettings.ProcessMode = other.MarkupCompatibilityProcessSettings.ProcessMode;
             MarkupCompatibilityProcessSettings.TargetFileFormatVersions = other.MarkupCompatibilityProcessSettings.TargetFileFormatVersions;
             MaxCharactersInPart = other.MaxCharactersInPart;
+            RelationshipErrorHandlerFactory = other.RelationshipErrorHandlerFactory;
         }
 
         /// <summary>
@@ -64,5 +67,10 @@ namespace DocumentFormat.OpenXml.Packaging
         /// This property allows you to mitigate denial of service attacks where the attacker submits a package with an extremely large Open XML part. By limiting the size of the part, you can detect the attack and recover reliably.
         /// </remarks>
         public long MaxCharactersInPart { get; set; }
+
+        /// <summary>
+        /// Gets or sets a delegate that is used to create a handler to rewrite relationships that are malformed. On platforms after .NET 4.5, <see cref="Uri"/> parsing will fail on malformed strings.
+        /// </summary>
+        public Func<OpenXmlPackage, RelationshipErrorHandler> RelationshipErrorHandlerFactory { get; set; }
     }
 }

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
@@ -183,6 +183,10 @@ namespace DocumentFormat.OpenXml.Packaging
                 // relationCollection.StrictRelationshipFound is true when this collection contains Transitional relationships converted from Strict.
                 StrictRelationshipFound = relationshipCollection.StrictRelationshipFound;
 
+                var handler = OpenSettings.RelationshipErrorHandlerFactory?.Invoke(this);
+
+                handler?.Handle(Package);
+
                 // AutoSave must be false when opening ISO Strict doc as editable.
                 // (Attention: #2545529. Now we disable this code until we finally decide to go with this. Instead, we take an alternative approach that is added in the SavePartContents() method
                 // which we ignore AutoSave when this.StrictRelationshipFound is true to keep consistency in the document.)
@@ -218,6 +222,8 @@ namespace DocumentFormat.OpenXml.Packaging
                 }
 
                 LoadReferencedPartsAndRelationships(this, null, relationshipCollection, loadedParts);
+
+                handler?.OnPackageLoaded();
             }
             catch (UriFormatException exception)
             {

--- a/src/DocumentFormat.OpenXml/Packaging/RelationshipErrorHandler.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/RelationshipErrorHandler.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.IO.Packaging;
+using System.Xml.Linq;
+
+namespace DocumentFormat.OpenXml.Packaging
+{
+    /// <summary>
+    /// A class that holds information about invalid relationships in <see cref="PackagePart"/> instances.
+    /// </summary>
+    public abstract class RelationshipErrorHandler
+    {
+        private const string RelationshipsTagName = "Relationships";
+        private const string RelationshipTagName = "Relationship";
+        private const string RelationshipNamespaceUri = "http://schemas.openxmlformats.org/package/2006/relationships";
+        private const string TargetAttributeName = "Target";
+        private const string IdAttributeName = "Id";
+
+        /// <summary>
+        /// Create a <see cref="RelationshipErrorHandler"/> that simply rewrites the invalid target Uri.
+        /// </summary>
+        /// <param name="rewriter">The delegate used to rewrite the Uri.</param>
+        /// <returns>A factory function for use in <see cref="OpenSettings.RelationshipErrorHandlerFactory"/>.</returns>
+        public static Func<OpenXmlPackage, RelationshipErrorHandler> CreateRewriterFactory(Rewriter rewriter)
+        {
+            var handler = new DelegateRelationshipErrorHandler(rewriter);
+
+            return _ => handler;
+        }
+
+        /// <summary>
+        /// Delegate to be used for simple rewriting of malformed Uris.
+        /// </summary>
+        /// <param name="partUri">Uri of the part with the invalid relationship.</param>
+        /// <param name="id">Id of relationship</param>
+        /// <param name="uri">Invalid <see cref="Uri"/></param>
+        /// <returns>Rewritten string if available, otherwise <c>null</c>.</returns>
+        public delegate string Rewriter(Uri partUri, string id, string uri);
+
+        /// <summary>
+        /// Rewrites an invalid URI with a valid one in order to correctly open a package.
+        /// </summary>
+        /// <param name="partUri">Uri of the part with the invalid relationship.</param>
+        /// <param name="id">Id of relationship</param>
+        /// <param name="uri">Invalid <see cref="Uri"/></param>
+        /// <returns>Rewritten string if available, otherwise <c>null</c>.</returns>
+        public abstract string Rewrite(Uri partUri, string id, string uri);
+
+        /// <summary>
+        /// Callback for after a package has been completely loaded and all rewritting has occurred.
+        /// </summary>
+        public virtual void OnPackageLoaded()
+        {
+        }
+
+        internal void Handle(Package package)
+        {
+            if (package is null)
+            {
+                throw new ArgumentNullException(nameof(package));
+            }
+
+            if ((package.FileOpenAccess & FileAccess.ReadWrite) != FileAccess.ReadWrite)
+            {
+                throw new OpenXmlPackageException(ExceptionMessages.PackageAccessModeIsReadonly);
+            }
+
+            foreach (var part in package.GetParts())
+            {
+                if (part.Uri.OriginalString.EndsWith(".rels", StringComparison.OrdinalIgnoreCase))
+                {
+                    var doc = WalkRelationships(part);
+
+                    if (doc != null)
+                    {
+                        using var stream = part.GetStream(FileMode.Open, FileAccess.Write);
+
+                        doc.Save(stream);
+                    }
+                }
+            }
+        }
+
+        private XDocument WalkRelationships(PackagePart part)
+        {
+            using var stream = part.GetStream(FileMode.Open, FileAccess.Read);
+            using var reader = new StreamReader(stream);
+
+            var doc = XDocument.Load(reader);
+            var changed = false;
+
+            if (string.Equals(RelationshipsTagName, doc.Root.Name.LocalName, StringComparison.Ordinal)
+                && string.Equals(RelationshipNamespaceUri, doc.Root.Name.Namespace.NamespaceName, StringComparison.Ordinal))
+            {
+                foreach (var child in doc.Root.Descendants(XName.Get(RelationshipTagName, RelationshipNamespaceUri)))
+                {
+                    var id = child.Attribute(IdAttributeName)?.Value;
+                    var target = child.Attribute(TargetAttributeName)?.Value;
+
+                    if (!Uri.TryCreate(target, UriHelper.RelativeOrAbsolute, out _))
+                    {
+                        var updated = Rewrite(part.Uri, id, target);
+
+                        if (updated != null)
+                        {
+                            if (!Uri.TryCreate(updated, UriHelper.RelativeOrAbsolute, out _))
+                            {
+                                throw new InvalidOperationException(ExceptionMessages.InvalidUriProvided);
+                            }
+
+                            child.SetAttributeValue(TargetAttributeName, updated);
+
+                            changed = true;
+                        }
+                    }
+                }
+            }
+
+            return changed ? doc : null;
+        }
+
+        private class DelegateRelationshipErrorHandler : RelationshipErrorHandler
+        {
+            private readonly Rewriter _rewriter;
+
+            public DelegateRelationshipErrorHandler(Rewriter rewriter)
+            {
+                _rewriter = rewriter;
+            }
+
+            public override string Rewrite(Uri partUri, string id, string uri) => _rewriter(partUri, id, uri);
+        }
+    }
+}

--- a/src/DocumentFormat.OpenXml/Resources/ExceptionMessages.Designer.cs
+++ b/src/DocumentFormat.OpenXml/Resources/ExceptionMessages.Designer.cs
@@ -451,11 +451,20 @@ namespace DocumentFormat.OpenXml {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid Hyperlink: Malformed URI is embedded as a hyperlink in the document..
+        ///   Looks up a localized string similar to A malformed URI was found in the document. Please provide a OpenSettings.RelationshipErrorRewriter to handle these errors while opening a package..
         /// </summary>
         internal static string InvalidUriFormat {
             get {
                 return ResourceManager.GetString("InvalidUriFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Provided URI was invalid after rewriting malformed relationship URI.
+        /// </summary>
+        internal static string InvalidUriProvided {
+            get {
+                return ResourceManager.GetString("InvalidUriProvided", resourceCulture);
             }
         }
         

--- a/src/DocumentFormat.OpenXml/Resources/ExceptionMessages.resx
+++ b/src/DocumentFormat.OpenXml/Resources/ExceptionMessages.resx
@@ -385,7 +385,7 @@
     <value>You should not validate document preprocessed based on FileFormatVersions.{0} against FileFormatVersions.{1} constraints. The preprocessing file format version is set in OpenSettings. Also check the file format version setting in the OpenXmlValidator.</value>
   </data>
   <data name="InvalidUriFormat" xml:space="preserve">
-    <value>Invalid Hyperlink: Malformed URI is embedded as a hyperlink in the document.</value>
+    <value>A malformed URI was found in the document. Please provide a OpenSettings.RelationshipErrorRewriter to handle these errors while opening a package.</value>
   </data>
   <data name="FileNotFound" xml:space="preserve">
     <value>Could not find document</value>
@@ -398,5 +398,8 @@
   </data>
   <data name="AnyParticleTypeNotSupported" xml:space="preserve">
     <value>Schemas with ParticleType.Any is not supported</value>
+  </data>
+  <data name="InvalidUriProvided" xml:space="preserve">
+    <value>Provided URI was invalid after rewriting malformed relationship URI</value>
   </data>
 </root>

--- a/src/DocumentFormat.OpenXml/System/Xml/Linq/XDocumentExtensions.cs
+++ b/src/DocumentFormat.OpenXml/System/Xml/Linq/XDocumentExtensions.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+
+namespace System.Xml.Linq
+{
+    internal static class XDocumentExtensions
+    {
+        public static void Save(this XDocument doc, Stream stream)
+        {
+            using var writer = new StreamWriter(stream);
+
+            doc.Save(writer);
+        }
+    }
+}

--- a/test/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/DocumentOpenTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/DocumentOpenTests.cs
@@ -1,8 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using DocumentFormat.OpenXml.Office2010.ExcelAc;
 using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using DocumentFormat.OpenXml.Validation;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Xunit;
 
@@ -20,6 +24,146 @@ namespace DocumentFormat.OpenXml.Tests
                 var exception = Assert.Throws<OpenXmlPackageException>(() => SpreadsheetDocument.Open(stream, false));
 
                 Assert.IsType<UriFormatException>(exception.InnerException);
+            }
+        }
+
+        [Fact]
+        public void ExceptionIfNotWritable()
+        {
+            using (var stream = GetStream(TestFiles.malformed_uri_xlsx))
+            {
+                var settings = new OpenSettings
+                {
+                    RelationshipErrorHandlerFactory = RelationshipErrorHandler.CreateRewriterFactory((partUri, id, uri) => null),
+                };
+
+                var exception = Assert.Throws<OpenXmlPackageException>(() => SpreadsheetDocument.Open(stream, false));
+
+                Assert.IsType<UriFormatException>(exception.InnerException);
+            }
+        }
+
+        [Fact]
+        public void RewriteMalformedUri()
+        {
+            const string Rewritten = "http://error";
+            const string Id = "rId1";
+
+            var Count = 0;
+
+            using (var stream = GetStream(TestFiles.malformed_uri_xlsx, isEditable: true))
+            {
+                var settings = new OpenSettings
+                {
+                    RelationshipErrorHandlerFactory = RelationshipErrorHandler.CreateRewriterFactory((partUri, id, uri) =>
+                    {
+                        Count++;
+                        Assert.Equal(Id, id);
+                        Assert.Equal("/xl/worksheets/_rels/sheet1.xml.rels", partUri.OriginalString);
+                        Assert.Equal("mailto:one@", uri);
+
+                        return Rewritten;
+                    }),
+                };
+
+                using (var doc = SpreadsheetDocument.Open(stream, true, settings))
+                {
+                    Assert.Equal(1, Count);
+
+                    var worksheetPart = Assert.Single(doc.WorkbookPart.WorksheetParts);
+                    var hyperlinkRelationship = Assert.Single(worksheetPart.HyperlinkRelationships);
+                    var worksheet = Assert.IsType<Worksheet>(worksheetPart.RootElement);
+                    var hyperlink = Assert.Single(worksheet.Descendants<Hyperlink>());
+
+                    Assert.Equal(Id, hyperlinkRelationship.Id);
+                    Assert.Equal(Rewritten, hyperlinkRelationship.Uri.OriginalString);
+
+                    Assert.Equal(Id, hyperlink.Id);
+                }
+            }
+        }
+
+        [Fact]
+        public void RemoveHyperlinks()
+        {
+            using (var stream = GetStream(TestFiles.malformed_uri_xlsx, isEditable: true))
+            {
+                var settings = new OpenSettings
+                {
+                    RelationshipErrorHandlerFactory = p => new RemoveMalformedHyperlinksRelationshipErrorHandler(p),
+                };
+
+                using (var doc = SpreadsheetDocument.Open(stream, true, settings))
+                {
+                    var worksheetPart = Assert.Single(doc.WorkbookPart.WorksheetParts);
+                    Assert.Empty(worksheetPart.HyperlinkRelationships);
+
+                    var worksheet = Assert.IsType<Worksheet>(worksheetPart.RootElement);
+                    Assert.Empty(worksheet.Descendants<Hyperlink>());
+
+                    var validator = new OpenXmlValidator();
+                    Assert.Empty(validator.Validate(doc));
+                }
+            }
+        }
+
+        private class RemoveMalformedHyperlinksRelationshipErrorHandler : RelationshipErrorHandler
+        {
+            private readonly OpenXmlPackage _package;
+            private readonly Dictionary<string, List<string>> _errors;
+
+            public RemoveMalformedHyperlinksRelationshipErrorHandler(OpenXmlPackage package)
+            {
+                _package = package;
+                _errors = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+            }
+
+            public override string Rewrite(Uri partUri, string id, string uri)
+            {
+                var key = partUri.OriginalString
+                    .Replace("_rels/", string.Empty)
+                    .Replace(".rels", string.Empty);
+
+                if (!_errors.ContainsKey(key))
+                {
+                    _errors.Add(key, new List<string>());
+                }
+
+                _errors[key].Add(id);
+
+                return "http://error";
+            }
+
+            public override void OnPackageLoaded()
+            {
+                foreach (var part in _package.GetAllParts())
+                {
+                    if (_errors.TryGetValue(part.Uri.OriginalString, out var ids))
+                    {
+                        foreach (var id in ids)
+                        {
+                            part.DeleteReferenceRelationship(id);
+
+                            if (part is WorksheetPart && part.RootElement is Worksheet ws)
+                            {
+                                foreach (var h in ws.Descendants<Hyperlink>())
+                                {
+                                    var parent = h.Parent;
+
+                                    if (h.Id == id)
+                                    {
+                                        h.Remove();
+                                    }
+
+                                    if (!parent.HasChildren)
+                                    {
+                                        parent.Remove();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Since .NET 4.5, there has been issues using the SDK with relationships that have malformed URIs. Specifically, this seems to be seen when docs have hyperlinks that are not valid URIs. This change adds a handler to rewrite this upon opening a document in case they exist. Subsequent user code can handle any other manipulation that is needed (such as removal of the offending hyperlink).

Fixes #715 