### PR TITLE
Added basic support for SVG files

### DIFF
--- a/src/DocumentFormat.OpenXml/Framework/NamespaceIdMap.cs
+++ b/src/DocumentFormat.OpenXml/Framework/NamespaceIdMap.cs
@@ -107,6 +107,7 @@ namespace DocumentFormat.OpenXml.Framework
             { "http://schemas.microsoft.com/office/spreadsheetml/2014/11/main", "x16", FileFormatVersions.Office2016 },
             { "http://schemas.microsoft.com/office/spreadsheetml/2015/02/main", "x16r2", FileFormatVersions.Office2016 },
             { "http://schemas.microsoft.com/office/word/2015/wordml/symex", "w16se", FileFormatVersions.Office2016 },
+            { "http://schemas.microsoft.com/office/drawing/2016/SVG/main", "asvg", FileFormatVersions.Office2016 },
         };
 
         // This dictionary contains the Strict and Transitional namespaces pairs to be interpreted equivalent.

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2016_svg.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2016_svg.cs
@@ -1,4 +1,7 @@
-﻿using DocumentFormat.OpenXml.Framework.Metadata;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Framework.Metadata;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -10,7 +13,6 @@ namespace DocumentFormat.OpenXml.Drawing.Pictures.SVG
     /// <para>This class is available in Office 2016 or above.</para>
     /// <para>When the object is serialized out as xml, it's qualified name is asvg:svgBlip.</para>
     /// </summary>
-    /// <remark>
     public partial class SvgBlip : OpenXmlCompositeElement
     {
         /// <summary>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2016_svg.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2016_svg.cs
@@ -1,0 +1,71 @@
+﻿using DocumentFormat.OpenXml.Framework.Metadata;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DocumentFormat.OpenXml.Drawing.Pictures.SVG
+{
+    /// <summary>
+    /// <para>Defines the SvgBlip Class.</para>
+    /// <para>This class is available in Office 2016 or above.</para>
+    /// <para>When the object is serialized out as xml, it's qualified name is asvg:svgBlip.</para>
+    /// </summary>
+    /// <remark>
+    public partial class SvgBlip : OpenXmlCompositeElement
+    {
+        /// <summary>
+        /// Initializes a new instance of the SvgBlip class.
+        /// </summary>
+        public SvgBlip() : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the SvgBlip class with the specified child elements.
+        /// </summary>
+        /// <param name="childElements">Specifies the child elements.</param>
+        public SvgBlip(IEnumerable<OpenXmlElement> childElements) : base(childElements)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the SvgBlip class with the specified child elements.
+        /// </summary>
+        /// <param name="childElements">Specifies the child elements.</param>
+        public SvgBlip(params OpenXmlElement[] childElements) : base(childElements)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the SvgBlip class from outer XML.
+        /// </summary>
+        /// <param name="outerXml">Specifies the outer XML of the element.</param>
+        public SvgBlip(string outerXml) : base(outerXml)
+        {
+        }
+
+        /// <summary>
+        /// <para>Embedded Picture Reference</para>
+        /// <para>Represents the following attribute in the schema: r:embed</para>
+        /// </summary>
+        /// <remark>
+        /// xmlns:r=http://schemas.openxmlformats.org/officeDocument/2006/relationships
+        /// </remark>
+        public StringValue Embed
+        {
+            get => GetAttribute<StringValue>();
+            set => SetAttribute(value);
+        }
+
+        internal override void ConfigureMetadata(ElementMetadata.Builder builder)
+        {
+            base.ConfigureMetadata(builder);
+            builder.SetSchema(87, "svgBlip");
+            builder.AddElement<SvgBlip>()
+.AddAttribute(19, "embed", a => a.Embed);
+        }
+
+        /// <inheritdoc/>
+        public override OpenXmlElement CloneNode(bool deep) => CloneImp<Blip>(deep);
+    }
+}

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2016_svg.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2016_svg.cs
@@ -47,7 +47,7 @@ namespace DocumentFormat.OpenXml.Drawing.Pictures.SVG
         }
 
         /// <summary>
-        /// <para>Embedded Picture Reference</para>
+        /// <para>Gets or sets Embedded Picture Reference</para>
         /// <para>Represents the following attribute in the schema: r:embed</para>
         /// </summary>
         /// <remark>

--- a/src/DocumentFormat.OpenXml/Packaging/ImagePartType.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/ImagePartType.cs
@@ -25,6 +25,7 @@ namespace DocumentFormat.OpenXml.Packaging
     /// L".jpeg",   L"image/jpeg",
     /// L".emf",    L"image/x-emf",
     /// L".wmf",    L"image/x-wmf",
+    /// L".svg",    L"image/svg+xml",
     /// ]]>
     /// </summary>
     public enum ImagePartType
@@ -87,5 +88,10 @@ namespace DocumentFormat.OpenXml.Packaging
         /// Windows Metafile (.wmf).
         /// </summary>
         Wmf,
+
+        /// <summary>
+        /// Scalable Vector Graphics (.svg)
+        /// </summary>
+        Svg,
     }
 }

--- a/src/DocumentFormat.OpenXml/Packaging/ImagePartTypeInfo.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/ImagePartTypeInfo.cs
@@ -45,6 +45,9 @@ namespace DocumentFormat.OpenXml.Packaging
                 case ImagePartType.Wmf:
                     return "image/x-wmf";
 
+                case ImagePartType.Svg:
+                    return "image/svg+xml";
+
                 default:
                     throw new ArgumentOutOfRangeException(nameof(imageType));
             }
@@ -87,6 +90,9 @@ namespace DocumentFormat.OpenXml.Packaging
 
                 case ImagePartType.Wmf:
                     return ".wmf";
+
+                case ImagePartType.Svg:
+                    return ".svg";
 
                 default:
                     return ".image";

--- a/test/DocumentFormat.OpenXml.Framework.Tests/ElementChildren.json
+++ b/test/DocumentFormat.OpenXml.Framework.Tests/ElementChildren.json
@@ -12741,6 +12741,10 @@
     ]
   },
   {
+    "Element": "DocumentFormat.OpenXml.Drawing.Pictures.SVG.SvgBlip",
+    "Children": []
+  },
+  {
     "Element": "DocumentFormat.OpenXml.Drawing.Pictures.ShapeProperties",
     "Children": [
       {

--- a/test/DocumentFormat.OpenXml.Framework.Tests/NamespaceIdMapTests.cs
+++ b/test/DocumentFormat.OpenXml.Framework.Tests/NamespaceIdMapTests.cs
@@ -10,7 +10,7 @@ namespace DocumentFormat.OpenXml.Framework.Tests
         [Fact]
         public void NamespaceCount()
         {
-            Assert.Equal(87, NamespaceIdMap.Count);
+            Assert.Equal(88, NamespaceIdMap.Count);
         }
 
         [InlineData("", "", FileFormatVersions.None, 0)]
@@ -100,6 +100,7 @@ namespace DocumentFormat.OpenXml.Framework.Tests
         [InlineData("http://schemas.microsoft.com/office/spreadsheetml/2014/11/main", "x16", FileFormatVersions.Office2016, 84)]
         [InlineData("http://schemas.microsoft.com/office/spreadsheetml/2015/02/main", "x16r2", FileFormatVersions.Office2016, 85)]
         [InlineData("http://schemas.microsoft.com/office/word/2015/wordml/symex", "w16se", FileFormatVersions.Office2016, 86)]
+        [InlineData("http://schemas.microsoft.com/office/drawing/2016/SVG/main", "asvg", FileFormatVersions.Office2016, 87)]
         [Theory]
         public void NamespacePrefixTest(string ns, string prefix, FileFormatVersions version, byte id)
         {


### PR DESCRIPTION
This patch allowed us to insert SVG files into a word document, adding support for "svgblip" element:
https://docs.microsoft.com/en-us/openspecs/office_standards/ms-odrawxml/2451f45e-5d77-4661-86d1-0a017fced779

