### PR TITLE
Provide IXmlLineInfo from OpenXmlReader when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `OpenXmlValidator.Validate(..., CancellationToken)` overrides to allow easier cancellation of long running validation on .NET 4.0+ (#773)
 - Added overloads for `CellValue` to take `decimal`, `double`, and `int`, as well as convenience methods to parse them (#782)
 - Added validation for `CellType` for numbers and date formats (#782)
+- Added `OpenXmlReader.GetLineInfo()` to retrieve `IXmlLineInfo` of the underlying reader if available (#804)
 
 ### Removed
 - Removed explicit reference to `System.IO.Packaging` on .NET 4.6 builds (#774)

--- a/src/DocumentFormat.OpenXml/OpenXmlPartReader.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlPartReader.cs
@@ -389,6 +389,9 @@ namespace DocumentFormat.OpenXml
             }
         }
 
+        /// <inheritdoc/>
+        public override IXmlLineInfo GetLineInfo() => XmlLineInfo.Get(_xmlReader);
+
         #region private methods
 
         /// <summary>

--- a/src/DocumentFormat.OpenXml/OpenXmlReader.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlReader.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Xml;
 
 namespace DocumentFormat.OpenXml
 {
@@ -39,10 +40,7 @@ namespace DocumentFormat.OpenXml
         /// </summary>
         /// <param name="openXmlPart">The OpenXmlPart to read.</param>
         /// <returns>The newly created OpenXmlReader.</returns>
-        public static OpenXmlReader Create(OpenXmlPart openXmlPart)
-        {
-            return new OpenXmlPartReader(openXmlPart);
-        }
+        public static OpenXmlReader Create(OpenXmlPart openXmlPart) => new OpenXmlPartReader(openXmlPart);
 
         /// <summary>
         /// Creates an OpenXmlReader from the specified OpenXmlPart and Boolean values.
@@ -50,20 +48,14 @@ namespace DocumentFormat.OpenXml
         /// <param name="openXmlPart">The OpenXmlPart to read.</param>
         /// <param name="readMiscNodes">Specify false to indicate to the reader to skip all miscellaneous nodes. The default value is false.</param>
         /// <returns>The newly created OpenXmlReader.</returns>
-        public static OpenXmlReader Create(OpenXmlPart openXmlPart, bool readMiscNodes)
-        {
-            return new OpenXmlPartReader(openXmlPart, readMiscNodes);
-        }
+        public static OpenXmlReader Create(OpenXmlPart openXmlPart, bool readMiscNodes) => new OpenXmlPartReader(openXmlPart, readMiscNodes);
 
         /// <summary>
         /// Creates an OpenXmlReader from the specified part stream.
         /// </summary>
         /// <param name="partStream">The part stream.</param>
         /// <returns></returns>
-        public static OpenXmlReader Create(Stream partStream)
-        {
-            return new OpenXmlPartReader(partStream);
-        }
+        public static OpenXmlReader Create(Stream partStream) => new OpenXmlPartReader(partStream);
 
         /// <summary>
         /// Creates an OpenXmlReader from the specified part stream and Boolean values.
@@ -71,20 +63,14 @@ namespace DocumentFormat.OpenXml
         /// <param name="partStream">The part stream.</param>
         /// <param name="readMiscNodes">Specify false to indicate to the reader to skip all miscellaneous nodes. The default value is false.</param>
         /// <returns></returns>
-        public static OpenXmlReader Create(Stream partStream, bool readMiscNodes)
-        {
-            return new OpenXmlPartReader(partStream, readMiscNodes);
-        }
+        public static OpenXmlReader Create(Stream partStream, bool readMiscNodes) => new OpenXmlPartReader(partStream, readMiscNodes);
 
         /// <summary>
         /// Creates an OpenXmlReader from the OpenXmlElement (travel the DOM tree).
         /// </summary>
         /// <param name="openXmlElement">The OpenXmlElement to read.</param>
         /// <returns>The newly created OpenXmlReader.</returns>
-        public static OpenXmlReader Create(OpenXmlElement openXmlElement)
-        {
-            return new OpenXmlDomReader(openXmlElement);
-        }
+        public static OpenXmlReader Create(OpenXmlElement openXmlElement) => new OpenXmlDomReader(openXmlElement);
 
         /// <summary>
         /// Creates an OpenXmlReader from the OpenXmlElement (travel the DOM tree).
@@ -92,10 +78,7 @@ namespace DocumentFormat.OpenXml
         /// <param name="openXmlElement">The OpenXmlElement to read.</param>
         /// <param name="readMiscNodes">Specify false to indicate to the reader to skip all miscellaneous nodes. The default value is false.</param>
         /// <returns>The newly created OpenXmlReader.</returns>
-        public static OpenXmlReader Create(OpenXmlElement openXmlElement, bool readMiscNodes)
-        {
-            return new OpenXmlDomReader(openXmlElement, readMiscNodes);
-        }
+        public static OpenXmlReader Create(OpenXmlElement openXmlElement, bool readMiscNodes) => new OpenXmlDomReader(openXmlElement, readMiscNodes);
 
         /// <summary>
         /// Gets a value indicating whether the OpenXmlReader will read or skip all miscellaneous nodes.
@@ -207,6 +190,12 @@ namespace DocumentFormat.OpenXml
         public abstract string Prefix { get; }
 
         /// <summary>
+        /// Gets an instance of <see cref="IXmlLineInfo"/> if available for the current reader.
+        /// </summary>
+        /// <returns>An object for obtaining information about line info</returns>
+        public virtual IXmlLineInfo GetLineInfo() => XmlLineInfo.Empty;
+
+        /// <summary>
         /// Moves to read the next element.
         /// </summary>
         /// <returns>Returns true if the next element was read successfully; false if there are no more elements to read. </returns>
@@ -250,9 +239,9 @@ namespace DocumentFormat.OpenXml
         /// <summary>
         /// Closes the reader.
         /// </summary>
-        public abstract void Close( );
+        public abstract void Close();
 
-#region dispose related methods
+        #region dispose related methods
 
         /// <summary>
         /// Thrown if the object is disposed.
@@ -282,9 +271,9 @@ namespace DocumentFormat.OpenXml
             }
         }
 
-#endregion
+        #endregion
 
-#region IDisposable Members
+        #region IDisposable Members
 
         /// <summary>
         /// Closes the reader, and releases all resources.
@@ -295,6 +284,6 @@ namespace DocumentFormat.OpenXml
             GC.SuppressFinalize(this);
         }
 
-#endregion
+        #endregion
     }
 }

--- a/src/DocumentFormat.OpenXml/XmlConvertingReader.cs
+++ b/src/DocumentFormat.OpenXml/XmlConvertingReader.cs
@@ -10,7 +10,7 @@ namespace DocumentFormat.OpenXml
     /// <summary>
     /// Defines the XmlConvertingReader - This XmlReader tries to replace the Strict namespaces with equivalent Transitional namespaces.
     /// </summary>
-    internal class XmlConvertingReader : XmlReader
+    internal class XmlConvertingReader : XmlReader, IXmlLineInfo
     {
         /// <summary>
         /// Creates an instance of <see cref="XmlConvertingReader"/>
@@ -165,6 +165,12 @@ namespace DocumentFormat.OpenXml
 
         /// <inheritdoc/>
         public override XmlSpace XmlSpace => BaseReader.XmlSpace;
+
+        int IXmlLineInfo.LineNumber => XmlLineInfo.Get(BaseReader).LineNumber;
+
+        int IXmlLineInfo.LinePosition => XmlLineInfo.Get(BaseReader).LinePosition;
+
+        bool IXmlLineInfo.HasLineInfo() => XmlLineInfo.Get(BaseReader).HasLineInfo();
 
         private string ApplyStrictTranslation(string uri)
         {

--- a/src/DocumentFormat.OpenXml/XmlConvertingReaderFactory.cs
+++ b/src/DocumentFormat.OpenXml/XmlConvertingReaderFactory.cs
@@ -20,33 +20,23 @@ namespace DocumentFormat.OpenXml
 
         public static XmlReader Create(Stream partStream, XmlReaderSettings settings, bool strictRelationshipFound)
         {
-            XmlReader xmlReader = XmlReader.Create(partStream, settings);
+            var xmlReader = XmlReader.Create(partStream, settings);
 
             return new XmlConvertingReader(xmlReader, strictRelationshipFound);
         }
 
         public static XmlReader Create(TextReader textReader, XmlReaderSettings settings)
         {
-            return Create(textReader, settings, true);
-        }
+            var xmlReader = XmlReader.Create(textReader, settings);
 
-        public static XmlReader Create(TextReader textReader, XmlReaderSettings settings, bool strictRelationshipFound)
-        {
-            XmlReader xmlReader = XmlReader.Create(textReader, settings);
-
-            return new XmlConvertingReader(xmlReader, strictRelationshipFound);
+            return new XmlConvertingReader(xmlReader, true);
         }
 
         public static XmlReader Create(TextReader textReader)
         {
-            return Create(textReader, true);
-        }
+            var xmlReader = XmlReader.Create(textReader);
 
-        public static XmlReader Create(TextReader textReader, bool strictRelationshipFound)
-        {
-            XmlReader xmlReader = XmlReader.Create(textReader);
-
-            return new XmlConvertingReader(xmlReader, strictRelationshipFound);
+            return new XmlConvertingReader(xmlReader, true);
         }
     }
 }

--- a/src/DocumentFormat.OpenXml/XmlLineInfo.cs
+++ b/src/DocumentFormat.OpenXml/XmlLineInfo.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Xml;
+
+namespace DocumentFormat.OpenXml
+{
+    internal class XmlLineInfo : IXmlLineInfo
+    {
+        public static IXmlLineInfo Empty { get; } = new XmlLineInfo();
+
+        private XmlLineInfo()
+        {
+        }
+
+        public static IXmlLineInfo Get(object obj) => (obj as IXmlLineInfo) ?? Empty;
+
+        public int LineNumber => 0;
+
+        public int LinePosition => 0;
+
+        public bool HasLineInfo() => false;
+    }
+}

--- a/test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlReaderTest.cs
+++ b/test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlReaderTest.cs
@@ -54,6 +54,7 @@ namespace DocumentFormat.OpenXml.Tests
             Assert.False(targetReader.IsMiscNode);
             Assert.Equal(typeof(Run), targetReader.ElementType);
             Assert.True(string.IsNullOrEmpty(targetReader.GetText()));
+            Assert.False(targetReader.GetLineInfo().HasLineInfo());
 
             // loaded element is Run
             Assert.NotNull(element);
@@ -193,7 +194,7 @@ namespace DocumentFormat.OpenXml.Tests
         public void DomReaderMiscNodeTest()
         {
             Body body = new Body(new Paragraph(new ParagraphProperties(), new Run(new Text("test"))));
-            body.PrependChild( new OpenXmlMiscNode(System.Xml.XmlNodeType.Comment, "<!-- start body -->"));
+            body.PrependChild(new OpenXmlMiscNode(System.Xml.XmlNodeType.Comment, "<!-- start body -->"));
 
             //======== new test with a new reader ========
             using (OpenXmlReader reader = OpenXmlReader.Create(body, true)) // read misc node
@@ -363,6 +364,9 @@ namespace DocumentFormat.OpenXml.Tests
             Assert.True(reader.IsStartElement);
             Assert.False(reader.IsEndElement);
             Assert.False(reader.IsMiscNode);
+            Assert.True(reader.GetLineInfo().HasLineInfo());
+            Assert.Equal(1, reader.GetLineInfo().LineNumber);
+            Assert.Equal(2, reader.GetLineInfo().LinePosition);
 
             moved = reader.Read();
             Assert.True(moved);
@@ -371,6 +375,9 @@ namespace DocumentFormat.OpenXml.Tests
             Assert.False(reader.IsStartElement);
             Assert.False(reader.IsEndElement);
             Assert.True(reader.IsMiscNode);
+            Assert.True(reader.GetLineInfo().HasLineInfo());
+            Assert.Equal(1, reader.GetLineInfo().LineNumber);
+            Assert.Equal(88, reader.GetLineInfo().LinePosition);
 
             Assert.Equal(string.Empty, reader.Prefix);
             Assert.Equal(string.Empty, reader.NamespaceUri);
@@ -384,7 +391,7 @@ namespace DocumentFormat.OpenXml.Tests
         [Fact]
         public void PartReaderBasicTest()
         {
-            string partText =  "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+            string partText = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
                                "<w:document xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\">" +
                                "<w:body>" +
                                "<w:p w:rsidP=\"001\"><w:r><w:t>Run Text.</w:t><w:t>Run 2.</w:t></w:r></w:p>" +
@@ -393,7 +400,7 @@ namespace DocumentFormat.OpenXml.Tests
                                "</w:document>";
 
             UTF8Encoding utf8Encoding = new UTF8Encoding();
-            Stream stream = new MemoryStream( utf8Encoding.GetBytes(partText), false );
+            Stream stream = new MemoryStream(utf8Encoding.GetBytes(partText), false);
 
             OpenXmlReader targetReader = OpenXmlReader.Create(stream);
             targetReader.Read();
@@ -422,6 +429,9 @@ namespace DocumentFormat.OpenXml.Tests
             Assert.False(targetReader.IsMiscNode);
             Assert.Equal(typeof(Paragraph), targetReader.ElementType);
             Assert.True(string.IsNullOrEmpty(targetReader.GetText()));
+            Assert.True(targetReader.GetLineInfo().HasLineInfo());
+            Assert.Equal(1, targetReader.GetLineInfo().LineNumber);
+            Assert.Equal(216, targetReader.GetLineInfo().LinePosition);
 
             targetReader.ReadNextSibling(); // next <w:p>
 
@@ -437,12 +447,14 @@ namespace DocumentFormat.OpenXml.Tests
             Assert.False(targetReader.IsMiscNode);
             Assert.Equal(typeof(Paragraph), targetReader.ElementType);
             Assert.True(string.IsNullOrEmpty(targetReader.GetText()));
+            Assert.Equal(1, targetReader.GetLineInfo().LineNumber);
+            Assert.Equal(295, targetReader.GetLineInfo().LinePosition);
 
             // loaded element is Run
             Assert.NotNull(element);
             Assert.IsType<Paragraph>(element);
 
-            Run run = (Run) element.FirstChild;
+            Run run = (Run)element.FirstChild;
             Assert.Equal("Run Text.", (run.FirstChild as Text).Text);
             Assert.Equal("Run 2.", (run.LastChild as Text).Text);
 


### PR DESCRIPTION
Provides ability to track the line number and position while reading a part. This is only available on implementations that operate on text itself; implementations such as the `OpenXmlDomReader` operate on nodes which don't have line information anymore.

Fixes #803 