### PR TITLE
Fix bug: System.Xml.XmlException thrown when opening SDK-authored document containing an empty URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Version 2.12.1
+
+### Fixed
+- Allow rewriting of all malformed URIs regardless of target value (#835)
+
 ## Version 2.12.0 - 2020-12-09
 
 ### Added

--- a/src/DocumentFormat.OpenXml/Packaging/RelationshipErrorHandler.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/RelationshipErrorHandler.cs
@@ -122,7 +122,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             var target = child.Attribute(TargetAttributeName)?.Value;
 
-            if (Uri.TryCreate(target, UriHelper.RelativeOrAbsolute, out _))
+            if (!string.IsNullOrEmpty(target) && Uri.TryCreate(target, UriHelper.RelativeOrAbsolute, out _))
             {
                 return false;
             }


### PR DESCRIPTION
* An empty string is a valid relative URI (https://tools.ietf.org/html/rfc3986#section-4.2)
* System.IO.Packaging.InternalRelationshipCollection rejects empty `Target` attributes as the absence of a required attribute (https://github.com/dotnet/runtime/blob/7ed93fa9211fcb8719fde13c540a46aa5b5d74fe/src/libraries/System.IO.Packaging/src/System/IO/Packaging/InternalRelationshipCollection.cs#L338-L340)
* Instead of throwing an exception and failing to open the file, provide users with the opportunity to rewrite empty URIs in the same manner as other invalid URIs

Resolves #834 