### PR TITLE
Enable nullable reference types at a project level

### DIFF
--- a/src/DocumentFormat.OpenXml/AlternateContentChoice.cs
+++ b/src/DocumentFormat.OpenXml/AlternateContentChoice.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework;
 using DocumentFormat.OpenXml.Framework.Metadata;
 using System.Collections.Generic;

--- a/src/DocumentFormat.OpenXml/AlternateContentFallback.cs
+++ b/src/DocumentFormat.OpenXml/AlternateContentFallback.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework.Metadata;
 using System.Collections.Generic;
 

--- a/src/DocumentFormat.OpenXml/DocumentFormat.OpenXml.csproj
+++ b/src/DocumentFormat.OpenXml/DocumentFormat.OpenXml.csproj
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), DocumentFormat.OpenXml.Package.props))\DocumentFormat.OpenXml.Package.props" />
 
   <PropertyGroup>
+    <Nullable>enable</Nullable>
     <IsShipped>true</IsShipped>
     <TargetFrameworks>$(ProductTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);3003</NoWarn>

--- a/src/DocumentFormat.OpenXml/Framework/Metadata/ElementLookup.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Metadata/ElementLookup.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/DocumentFormat.OpenXml/Framework/Metadata/ElementMetadata.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Metadata/ElementMetadata.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using DocumentFormat.OpenXml.Validation;
+#nullable disable
+
 using DocumentFormat.OpenXml.Validation.Schema;
 using DocumentFormat.OpenXml.Validation.Semantic;
 using System;

--- a/src/DocumentFormat.OpenXml/Framework/NamespaceIdMap.cs
+++ b/src/DocumentFormat.OpenXml/Framework/NamespaceIdMap.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/DocumentFormat.OpenXml/Framework/PartTypeInfo.cs
+++ b/src/DocumentFormat.OpenXml/Framework/PartTypeInfo.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Reflection;
 

--- a/src/DocumentFormat.OpenXml/Framework/ReadOnlyArray.cs
+++ b/src/DocumentFormat.OpenXml/Framework/ReadOnlyArray.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/DocumentFormat.OpenXml/Framework/ReadOnlyList.cs
+++ b/src/DocumentFormat.OpenXml/Framework/ReadOnlyList.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/DocumentFormat.OpenXml/Framework/Schema/CompiledParticle.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Schema/CompiledParticle.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework.Schema;
 using DocumentFormat.OpenXml.Validation.Schema;
 using System;

--- a/src/DocumentFormat.OpenXml/Framework/Schema/ParticleCollection.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Schema/ParticleCollection.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Validation.Schema;
 using System;
 using System.Collections;

--- a/src/DocumentFormat.OpenXml/Framework/Schema/ParticleExtensions.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Schema/ParticleExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework.Schema;
 using DocumentFormat.OpenXml.Validation.Schema;
 

--- a/src/DocumentFormat.OpenXml/Framework/Schema/ParticlePathItem.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Schema/ParticlePathItem.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Validation.Schema;
 using System;
 

--- a/src/DocumentFormat.OpenXml/Framework/Validation/NumberValidator.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Validation/NumberValidator.cs
@@ -1,8 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Validation;
-using System;
 using System.Xml;
 
 namespace DocumentFormat.OpenXml.Framework

--- a/src/DocumentFormat.OpenXml/Framework/Validation/SimpleTypeValidator{TSimpleType}.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Validation/SimpleTypeValidator{TSimpleType}.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Validation;
 
 namespace DocumentFormat.OpenXml.Framework

--- a/src/DocumentFormat.OpenXml/Framework/Validation/StringValidator.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Validation/StringValidator.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Validation;
 using DocumentFormat.OpenXml.Validation.Schema.Restrictions;
 using System.Collections.Generic;

--- a/src/DocumentFormat.OpenXml/MCContext.cs
+++ b/src/DocumentFormat.OpenXml/MCContext.cs
@@ -1,8 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Xml;

--- a/src/DocumentFormat.OpenXml/MarkupCompatibilityAttributes.cs
+++ b/src/DocumentFormat.OpenXml/MarkupCompatibilityAttributes.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework;
 
 namespace DocumentFormat.OpenXml

--- a/src/DocumentFormat.OpenXml/MiscAttrContainer.cs
+++ b/src/DocumentFormat.OpenXml/MiscAttrContainer.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System.Collections.Generic;
 
 namespace DocumentFormat.OpenXml

--- a/src/DocumentFormat.OpenXml/Office/CustomUI/CustomUI.cs
+++ b/src/DocumentFormat.OpenXml/Office/CustomUI/CustomUI.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Packaging;
 
 namespace DocumentFormat.OpenXml.Office.CustomUI

--- a/src/DocumentFormat.OpenXml/OpenXmlAttribute.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework;
 using System;
 using System.Xml;

--- a/src/DocumentFormat.OpenXml/OpenXmlCompositeElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlCompositeElement.cs
@@ -1,8 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework;
-using DocumentFormat.OpenXml.Validation.Schema;
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/DocumentFormat.OpenXml/OpenXmlDomReader.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlDomReader.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework;
 using System;
 using System.Collections.Generic;

--- a/src/DocumentFormat.OpenXml/OpenXmlElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlElement.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework;
 using DocumentFormat.OpenXml.Framework.Metadata;
 using DocumentFormat.OpenXml.Packaging;
-using DocumentFormat.OpenXml.Validation.Semantic;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/DocumentFormat.OpenXml/OpenXmlElementContext.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlElementContext.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Packaging;
 using System;
 using System.Xml;

--- a/src/DocumentFormat.OpenXml/OpenXmlElementExtensionMethods.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlElementExtensionMethods.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using DocumentFormat.OpenXml.Framework;
+#nullable disable
+
 using DocumentFormat.OpenXml.Packaging;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
-using System.Xml;
 
 namespace DocumentFormat.OpenXml
 {

--- a/src/DocumentFormat.OpenXml/OpenXmlElementList.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlElementList.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 

--- a/src/DocumentFormat.OpenXml/OpenXmlLeafElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlLeafElement.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 using System.Xml;

--- a/src/DocumentFormat.OpenXml/OpenXmlLeafTextElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlLeafTextElement.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 using System.Globalization;

--- a/src/DocumentFormat.OpenXml/OpenXmlMiscNode.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlMiscNode.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using DocumentFormat.OpenXml.Framework;
+#nullable disable
+
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/src/DocumentFormat.OpenXml/OpenXmlPartReader.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlPartReader.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework;
 using DocumentFormat.OpenXml.Framework.Metadata;
 using DocumentFormat.OpenXml.Packaging;

--- a/src/DocumentFormat.OpenXml/OpenXmlPartRootElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlPartRootElement.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework;
 using DocumentFormat.OpenXml.Packaging;
 using System;

--- a/src/DocumentFormat.OpenXml/OpenXmlReader.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlReader.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Packaging;
 using System;
 using System.Collections.Generic;

--- a/src/DocumentFormat.OpenXml/OpenXmlUnknownElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlUnknownElement.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework;
 using System;
 using System.Diagnostics;

--- a/src/DocumentFormat.OpenXml/Packaging/CustomUIPart.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/CustomUIPart.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 
 namespace DocumentFormat.OpenXml.Packaging

--- a/src/DocumentFormat.OpenXml/Packaging/DataPart.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/DataPart.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/DocumentFormat.OpenXml/Packaging/DataPartReferenceRelationship.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/DataPartReferenceRelationship.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 

--- a/src/DocumentFormat.OpenXml/Packaging/ExtendedPart.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/ExtendedPart.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 
 namespace DocumentFormat.OpenXml.Packaging

--- a/src/DocumentFormat.OpenXml/Packaging/GlobalPartFactory.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/GlobalPartFactory.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 
 namespace DocumentFormat.OpenXml.Packaging

--- a/src/DocumentFormat.OpenXml/Packaging/IdPartPair.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/IdPartPair.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 
 namespace DocumentFormat.OpenXml.Packaging

--- a/src/DocumentFormat.OpenXml/Packaging/MailMergeRecipientDataPart.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/MailMergeRecipientDataPart.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Office.Word;
 using System;
 

--- a/src/DocumentFormat.OpenXml/Packaging/OpenSettings.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenSettings.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 
 namespace DocumentFormat.OpenXml.Packaging

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Framework;
 using System;

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackageValidationEventArgs.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackageValidationEventArgs.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.ComponentModel;
 

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackageValidationSettings.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackageValidationSettings.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.ComponentModel;
 

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPart.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPart.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPartContainer.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPartContainer.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework;
 using System;
 using System.Collections.Generic;

--- a/src/DocumentFormat.OpenXml/Packaging/PresentationDocument.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/PresentationDocument.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework;
 using System;
 using System.Collections.Generic;

--- a/src/DocumentFormat.OpenXml/Packaging/ReferenceRelationship.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/ReferenceRelationship.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 using System.IO.Packaging;

--- a/src/DocumentFormat.OpenXml/Packaging/RelationshipCollection.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/RelationshipCollection.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework;
 using System;
 using System.Collections.Generic;

--- a/src/DocumentFormat.OpenXml/Packaging/RelationshipErrorHandler.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/RelationshipErrorHandler.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.IO;
 using System.IO.Packaging;

--- a/src/DocumentFormat.OpenXml/Packaging/RelationshipTypeList.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/RelationshipTypeList.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
+#nullable disable
+
 using System.Collections.Generic;
 
 namespace DocumentFormat.OpenXml.Packaging

--- a/src/DocumentFormat.OpenXml/Packaging/SpreadsheetDocument.FlatOpc.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/SpreadsheetDocument.FlatOpc.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.IO;
 using System.IO.Packaging;

--- a/src/DocumentFormat.OpenXml/Packaging/SpreadsheetDocument.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/SpreadsheetDocument.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework;
 using System;
 using System.Collections.Generic;

--- a/src/DocumentFormat.OpenXml/Packaging/StylesPart.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/StylesPart.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 
 namespace DocumentFormat.OpenXml.Packaging

--- a/src/DocumentFormat.OpenXml/Packaging/WordprocessingDocument.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/WordprocessingDocument.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework;
 using System;
 using System.Collections.Generic;

--- a/src/DocumentFormat.OpenXml/SimpleTypes/Base64BinaryValue.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/Base64BinaryValue.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 

--- a/src/DocumentFormat.OpenXml/SimpleTypes/BooleanValue.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/BooleanValue.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 using System.Xml;

--- a/src/DocumentFormat.OpenXml/SimpleTypes/ByteValue.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/ByteValue.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 using System.Xml;

--- a/src/DocumentFormat.OpenXml/SimpleTypes/DateTimeValue.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/DateTimeValue.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 using System.Xml;

--- a/src/DocumentFormat.OpenXml/SimpleTypes/DecimalValue.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/DecimalValue.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 using System.Xml;

--- a/src/DocumentFormat.OpenXml/SimpleTypes/DoubleValue.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/DoubleValue.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 using System.Xml;

--- a/src/DocumentFormat.OpenXml/SimpleTypes/EnumInfoLookup.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/EnumInfoLookup.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Reflection;

--- a/src/DocumentFormat.OpenXml/SimpleTypes/EnumValue.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/EnumValue.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 

--- a/src/DocumentFormat.OpenXml/SimpleTypes/HexBinaryValue.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/HexBinaryValue.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 

--- a/src/DocumentFormat.OpenXml/SimpleTypes/Int16Value.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/Int16Value.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 using System.Xml;

--- a/src/DocumentFormat.OpenXml/SimpleTypes/Int32Value.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/Int32Value.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 using System.Xml;

--- a/src/DocumentFormat.OpenXml/SimpleTypes/Int64Value.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/Int64Value.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 using System.Xml;

--- a/src/DocumentFormat.OpenXml/SimpleTypes/IntegerValue.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/IntegerValue.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 using System.Xml;

--- a/src/DocumentFormat.OpenXml/SimpleTypes/ListValue.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/ListValue.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/DocumentFormat.OpenXml/SimpleTypes/OnOffValue.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/OnOffValue.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 

--- a/src/DocumentFormat.OpenXml/SimpleTypes/OpenXmlSimpleType.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/OpenXmlSimpleType.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 
 namespace DocumentFormat.OpenXml

--- a/src/DocumentFormat.OpenXml/SimpleTypes/OpenXmlSimpleTypeExtensions.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/OpenXmlSimpleTypeExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Xml;

--- a/src/DocumentFormat.OpenXml/SimpleTypes/OpenXmlSimpleValue.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/OpenXmlSimpleValue.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 

--- a/src/DocumentFormat.OpenXml/SimpleTypes/SByteValue.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/SByteValue.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 using System.Xml;

--- a/src/DocumentFormat.OpenXml/SimpleTypes/SingleValue.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/SingleValue.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 using System.Xml;

--- a/src/DocumentFormat.OpenXml/SimpleTypes/StringValue.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/StringValue.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 

--- a/src/DocumentFormat.OpenXml/SimpleTypes/TrueFalseBlankValue.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/TrueFalseBlankValue.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 

--- a/src/DocumentFormat.OpenXml/SimpleTypes/TrueFalseValue.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/TrueFalseValue.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 

--- a/src/DocumentFormat.OpenXml/SimpleTypes/UInt16Value.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/UInt16Value.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 using System.Xml;

--- a/src/DocumentFormat.OpenXml/SimpleTypes/UInt32Value.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/UInt32Value.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 using System.Xml;

--- a/src/DocumentFormat.OpenXml/SimpleTypes/UInt64Value.cs
+++ b/src/DocumentFormat.OpenXml/SimpleTypes/UInt64Value.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 using System.Xml;

--- a/src/DocumentFormat.OpenXml/System/Lazy{T}.cs
+++ b/src/DocumentFormat.OpenXml/System/Lazy{T}.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 
 namespace DocumentFormat.OpenXml

--- a/src/DocumentFormat.OpenXml/Validation/DocumentValidator.cs
+++ b/src/DocumentFormat.OpenXml/Validation/DocumentValidator.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Validation.Schema;
 using System.Collections.Generic;

--- a/src/DocumentFormat.OpenXml/Validation/PackageValidator.cs
+++ b/src/DocumentFormat.OpenXml/Validation/PackageValidator.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Packaging;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 
 #pragma warning disable 0618 // CS0618: A class member was marked with the Obsolete attribute, such that a warning will be issued when the class member is referenced.
 

--- a/src/DocumentFormat.OpenXml/Validation/Schema/AllParticleValidator.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Schema/AllParticleValidator.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/DocumentFormat.OpenXml/Validation/Schema/AlternateContentValidator.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Schema/AlternateContentValidator.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 namespace DocumentFormat.OpenXml.Validation.Schema
 {
     /// <summary>

--- a/src/DocumentFormat.OpenXml/Validation/Schema/AnyParticleValidator.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Schema/AnyParticleValidator.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using DocumentFormat.OpenXml.Validation;
-using System;
+#nullable disable
+
 using System.Diagnostics;
 
 namespace DocumentFormat.OpenXml.Validation.Schema

--- a/src/DocumentFormat.OpenXml/Validation/Schema/ChoiceParticleValidator.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Schema/ChoiceParticleValidator.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using DocumentFormat.OpenXml.Validation;
+#nullable disable
+
 using System.Diagnostics;
 
 namespace DocumentFormat.OpenXml.Validation.Schema

--- a/src/DocumentFormat.OpenXml/Validation/Schema/CompatibilityRuleAttributesValidator.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Schema/CompatibilityRuleAttributesValidator.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.Diagnostics;
 

--- a/src/DocumentFormat.OpenXml/Validation/Schema/CompositeParticle.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Schema/CompositeParticle.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework;
 using System;
 using System.Collections;

--- a/src/DocumentFormat.OpenXml/Validation/Schema/CompositeParticleValidator.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Schema/CompositeParticleValidator.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System.Diagnostics;
 
 namespace DocumentFormat.OpenXml.Validation.Schema

--- a/src/DocumentFormat.OpenXml/Validation/Schema/ElementParticle.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Schema/ElementParticle.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework;
 using System;
 using System.Diagnostics;

--- a/src/DocumentFormat.OpenXml/Validation/Schema/ExpectedChildren.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Schema/ExpectedChildren.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/DocumentFormat.OpenXml/Validation/Schema/GroupParticleValidator.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Schema/GroupParticleValidator.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using DocumentFormat.OpenXml.Validation;
+#nullable disable
+
 using System.Diagnostics;
 
 namespace DocumentFormat.OpenXml.Validation.Schema

--- a/src/DocumentFormat.OpenXml/Validation/Schema/NsAnyParticleValidator.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Schema/NsAnyParticleValidator.cs
@@ -1,8 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework;
-using DocumentFormat.OpenXml.Validation;
 using System.Diagnostics;
 
 namespace DocumentFormat.OpenXml.Validation.Schema

--- a/src/DocumentFormat.OpenXml/Validation/Schema/OpenXmlElementExtensionMethods.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Schema/OpenXmlElementExtensionMethods.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.Diagnostics;
 

--- a/src/DocumentFormat.OpenXml/Validation/Schema/ParticleConstraint.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Schema/ParticleConstraint.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework;
 
 namespace DocumentFormat.OpenXml.Validation.Schema

--- a/src/DocumentFormat.OpenXml/Validation/Schema/ParticleMatchInfo.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Schema/ParticleMatchInfo.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System.Diagnostics;
 
 namespace DocumentFormat.OpenXml.Validation.Schema

--- a/src/DocumentFormat.OpenXml/Validation/Schema/ParticleValidator.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Schema/ParticleValidator.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System.Diagnostics;
 
 namespace DocumentFormat.OpenXml.Validation.Schema

--- a/src/DocumentFormat.OpenXml/Validation/Schema/SchemaTypeValidator.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Schema/SchemaTypeValidator.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework;
 using DocumentFormat.OpenXml.Framework.Metadata;
 using System;

--- a/src/DocumentFormat.OpenXml/Validation/Schema/SequenceParticleValidator.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Schema/SequenceParticleValidator.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System.Diagnostics;
 
 namespace DocumentFormat.OpenXml.Validation.Schema

--- a/src/DocumentFormat.OpenXml/Validation/Schema/ValidationContextExtension.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Schema/ValidationContextExtension.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 namespace DocumentFormat.OpenXml.Validation.Schema
 {
     internal static class ValidationContextExtension

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeAbsentConditionToNonValue.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeAbsentConditionToNonValue.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Validation;
 
 namespace DocumentFormat.OpenXml.Validation.Semantic

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeAbsentConditionToValue.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeAbsentConditionToValue.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 namespace DocumentFormat.OpenXml.Validation.Semantic
 {
     /// <summary>

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeCannotOmitConstraint.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeCannotOmitConstraint.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 namespace DocumentFormat.OpenXml.Validation.Semantic
 {
     internal class AttributeCannotOmitConstraint : SemanticConstraint

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeMinMaxConstraint.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeMinMaxConstraint.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System.Diagnostics;
 
 namespace DocumentFormat.OpenXml.Validation.Semantic

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeMutualExclusive.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeMutualExclusive.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 namespace DocumentFormat.OpenXml.Validation.Semantic
 {
     /// <summary>

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/AttributePairConstraint.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/AttributePairConstraint.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System.Diagnostics;
 
 namespace DocumentFormat.OpenXml.Validation.Semantic

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeRequiredConditionToValue.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeRequiredConditionToValue.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 namespace DocumentFormat.OpenXml.Validation.Semantic
 {
     /// <summary>

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeValueConditionToAnother.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeValueConditionToAnother.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using DocumentFormat.OpenXml.Validation;
+#nullable disable
 
 namespace DocumentFormat.OpenXml.Validation.Semantic
 {

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeValueLengthConstraint.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeValueLengthConstraint.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System.Diagnostics;
 
 namespace DocumentFormat.OpenXml.Validation.Semantic

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeValueLessEqualToAnother.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeValueLessEqualToAnother.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 namespace DocumentFormat.OpenXml.Validation.Semantic
 {
     /// <summary>

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeValuePatternConstraint.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeValuePatternConstraint.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 using System.Text.RegularExpressions;

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeValueRangeConstraint.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeValueRangeConstraint.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System.Diagnostics;
 
 namespace DocumentFormat.OpenXml.Validation.Semantic

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeValueSetConstraint.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/AttributeValueSetConstraint.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System.Diagnostics;
 
 namespace DocumentFormat.OpenXml.Validation.Semantic

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/IndexReferenceConstraint.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/IndexReferenceConstraint.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 
 namespace DocumentFormat.OpenXml.Validation.Semantic

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/ParentTypeConstraint.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/ParentTypeConstraint.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/ReferenceExistConstraint.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/ReferenceExistConstraint.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework;
 using System;
 using System.Collections.Generic;

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/RelationshipExistConstraint.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/RelationshipExistConstraint.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 namespace DocumentFormat.OpenXml.Validation.Semantic
 {
     internal class RelationshipExistConstraint : SemanticConstraint

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/RelationshipTypeConstraint.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/RelationshipTypeConstraint.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System.Diagnostics;
 using System.Linq;
 

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/SemanticConstraint.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/SemanticConstraint.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework;
 using DocumentFormat.OpenXml.Packaging;
 using System;

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/UniqueAttributeValueConstraint.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/UniqueAttributeValueConstraint.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using DocumentFormat.OpenXml.Framework;
+#nullable disable
+
 using System;
 
 namespace DocumentFormat.OpenXml.Validation.Semantic

--- a/src/DocumentFormat.OpenXml/Validation/StateManager.cs
+++ b/src/DocumentFormat.OpenXml/Validation/StateManager.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 

--- a/src/DocumentFormat.OpenXml/Validation/ValidationCache.cs
+++ b/src/DocumentFormat.OpenXml/Validation/ValidationCache.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Validation.Schema;
 using System.Collections.Concurrent;
 

--- a/src/DocumentFormat.OpenXml/Validation/ValidationContext.cs
+++ b/src/DocumentFormat.OpenXml/Validation/ValidationContext.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Validation.Schema;
 using System;
 using System.Collections.Generic;

--- a/src/DocumentFormat.OpenXml/Validation/ValidationElement.cs
+++ b/src/DocumentFormat.OpenXml/Validation/ValidationElement.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework.Metadata;
 using DocumentFormat.OpenXml.Packaging;
 using System;

--- a/src/DocumentFormat.OpenXml/Validation/ValidationErrorInfo.cs
+++ b/src/DocumentFormat.OpenXml/Validation/ValidationErrorInfo.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Packaging;
 using System.Diagnostics;
 

--- a/src/DocumentFormat.OpenXml/Validation/ValidationStack.cs
+++ b/src/DocumentFormat.OpenXml/Validation/ValidationStack.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework.Metadata;
 using DocumentFormat.OpenXml.Packaging;
 using System;

--- a/src/DocumentFormat.OpenXml/Validation/ValidationTraverser.cs
+++ b/src/DocumentFormat.OpenXml/Validation/ValidationTraverser.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework;
 using System;
 using System.Collections.Generic;

--- a/src/DocumentFormat.OpenXml/Wordprocessing/Styles.cs
+++ b/src/DocumentFormat.OpenXml/Wordprocessing/Styles.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Packaging;
 
 namespace DocumentFormat.OpenXml.Wordprocessing

--- a/src/DocumentFormat.OpenXml/XmlPath.cs
+++ b/src/DocumentFormat.OpenXml/XmlPath.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable disable
+
 using DocumentFormat.OpenXml.Framework;
 using DocumentFormat.OpenXml.Packaging;
 using System;


### PR DESCRIPTION
This disables nullable checks on files that would otherwise have a warning