### PR TITLE
Fix broken property setters to allow null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Version 2.12.1 - 2021-01-11
+
+### Fixed
+- Fixed bug where properties on `OpenXmlCompositeElement` instances could not be set to null to remove element (#850)
+
 ## Version 2.12.0 - 2020-12-09
 
 ### Added

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -6,6 +6,7 @@ pr:
   branches:
     include:
     - master
+    - release/*
 
 variables:
   RunPeVerify: true

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -1,5 +1,6 @@
 trigger:
 - master
+- release/*
 
 pr:
   autoCancel: true

--- a/src/DocumentFormat.OpenXml/AppendOption.cs
+++ b/src/DocumentFormat.OpenXml/AppendOption.cs
@@ -1,11 +1,16 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.ComponentModel;
+
 namespace DocumentFormat.OpenXml
 {
     /// <summary>
     /// Options to define how an element should be appeneded.
     /// </summary>
+    [Obsolete("This is not used and will be removed in a future version.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public enum AppendOption
     {
         /// <summary>

--- a/src/DocumentFormat.OpenXml/Framework/Schema/ParticleExtensions.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Schema/ParticleExtensions.cs
@@ -3,6 +3,7 @@
 
 using DocumentFormat.OpenXml.Framework.Schema;
 using DocumentFormat.OpenXml.Validation.Schema;
+using System;
 
 namespace DocumentFormat.OpenXml.Framework
 {
@@ -43,19 +44,23 @@ namespace DocumentFormat.OpenXml.Framework
             return null;
         }
 
-        public static bool Set(this CompiledParticle compiled, OpenXmlCompositeElement parent, OpenXmlElement value)
+        public static bool Set<T>(this CompiledParticle compiled, OpenXmlCompositeElement parent, T value)
+            where T : OpenXmlElement
+            => Set(compiled, parent, value, typeof(T));
+
+        public static bool Set(this CompiledParticle compiled, OpenXmlCompositeElement parent, OpenXmlElement value, Type type)
         {
+            if (type is null)
+            {
+                return false;
+            }
+
             if (compiled is null)
             {
                 return false;
             }
 
-            if (value is null)
-            {
-                return false;
-            }
-
-            var collection = new ParticleCollection(value.GetType(), compiled, parent);
+            var collection = new ParticleCollection(type, compiled, parent);
 
             collection.Clear();
             return collection.Add(value);

--- a/src/DocumentFormat.OpenXml/OpenXmlCompositeElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlCompositeElement.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using DocumentFormat.OpenXml.Framework;
-using DocumentFormat.OpenXml.Validation.Schema;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -222,7 +221,7 @@ namespace DocumentFormat.OpenXml
                 return false;
             }
 
-            var wasAdded = SetElement(newChild);
+            var wasAdded = Metadata.Particle.Set(this, newChild, newChild?.GetType());
 
             if (throwOnError && !wasAdded)
             {
@@ -789,7 +788,8 @@ namespace DocumentFormat.OpenXml
         private protected TElement GetElement<TElement>()
             where TElement : OpenXmlElement => Metadata.Particle.Get<TElement>(this);
 
-        private protected bool SetElement(OpenXmlElement value)
+        private protected bool SetElement<TElement>(TElement value)
+            where TElement : OpenXmlElement
             => Metadata.Particle.Set(this, value);
 
         private void AddANode(OpenXmlElement node)

--- a/test/DocumentFormat.OpenXml.Tests/FileFormatVersionExtensionsTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/FileFormatVersionExtensionsTests.cs
@@ -176,7 +176,7 @@ namespace DocumentFormat.OpenXml.Tests
             }
         }
 
-        private class OfficeNonElement : MockedXmlElement
+        private class OfficeNonElement : MockedOpenXmlElement
         {
             internal override void ConfigureMetadata(ElementMetadata.Builder builder)
             {
@@ -184,23 +184,12 @@ namespace DocumentFormat.OpenXml.Tests
             }
         }
 
-        private class Office2007Element : MockedXmlElement
+        private class Office2007Element : MockedOpenXmlElement
         {
             internal override void ConfigureMetadata(ElementMetadata.Builder builder)
             {
                 builder.Availability = FileFormatVersions.Office2007;
             }
-        }
-
-        private class MockedXmlElement : OpenXmlElement
-        {
-            public override bool HasChildren => throw new NotImplementedException();
-
-            public override void RemoveAllChildren() => throw new NotImplementedException();
-
-            internal override void WriteContentTo(XmlWriter w) => throw new NotImplementedException();
-
-            private protected override void Populate(XmlReader xmlReader, OpenXmlLoadMode loadMode) => throw new NotImplementedException();
         }
     }
 }

--- a/test/DocumentFormat.OpenXml.Tests/MockedOpenXmlElement.cs
+++ b/test/DocumentFormat.OpenXml.Tests/MockedOpenXmlElement.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Xml;
+
+namespace DocumentFormat.OpenXml.Tests
+{
+    internal class MockedOpenXmlElement : OpenXmlElement
+    {
+        public override bool HasChildren => throw new NotImplementedException();
+
+        public override void RemoveAllChildren() => throw new NotImplementedException();
+
+        internal override void WriteContentTo(XmlWriter w) => throw new NotImplementedException();
+
+        private protected override void Populate(XmlReader xmlReader, OpenXmlLoadMode loadMode) => throw new NotImplementedException();
+    }
+}

--- a/test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlElementTest2.cs
+++ b/test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlElementTest2.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using DocumentFormat.OpenXml.Framework.Metadata;
 using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Validation.Schema;
 using DocumentFormat.OpenXml.Wordprocessing;
 using System;
 using System.IO;
@@ -89,7 +91,7 @@ namespace DocumentFormat.OpenXml.Tests
             target = p.GetPartUri();
             Assert.Null(target);
 
-            using ( var stream = new MemoryStream() )
+            using (var stream = new MemoryStream())
             using (var doc = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document))
             {
                 doc.AddMainDocumentPart();
@@ -117,12 +119,12 @@ namespace DocumentFormat.OpenXml.Tests
             target = p.FirstChild.GetXPathIndex();
             Assert.Equal(1, target);
 
-            var run1 = p.AppendChild( new Run() );
-            var run2 = p.AppendChild( new Run() );
-            var bk1 = p.AppendChild( new BookmarkStart());
-            var unknown1 = p.AppendChild( new OpenXmlUnknownElement("unknown") );
-            var unknown2 = p.AppendChild( new OpenXmlUnknownElement("unknown") );
-            var run3 = p.AppendChild(new Run() );
+            var run1 = p.AppendChild(new Run());
+            var run2 = p.AppendChild(new Run());
+            var bk1 = p.AppendChild(new BookmarkStart());
+            var unknown1 = p.AppendChild(new OpenXmlUnknownElement("unknown"));
+            var unknown2 = p.AppendChild(new OpenXmlUnknownElement("unknown"));
+            var run3 = p.AppendChild(new Run());
 
             target = run1.GetXPathIndex();
             Assert.Equal(1, target);
@@ -141,6 +143,42 @@ namespace DocumentFormat.OpenXml.Tests
 
             target = unknown2.GetXPathIndex();
             Assert.Equal(2, target);
+        }
+
+        [Fact]
+        public void CanSetNullValue()
+        {
+            var cell = new WithChildElement
+            {
+                Child = new ChildElement(),
+            };
+
+            Assert.NotNull(cell.Child);
+
+            cell.Child = null;
+
+            Assert.Null(cell.Child);
+        }
+
+        private class WithChildElement : OpenXmlCompositeElement
+        {
+            public ChildElement Child
+            {
+                get => GetElement<ChildElement>();
+                set => SetElement(value);
+            }
+
+            internal override void ConfigureMetadata(ElementMetadata.Builder builder)
+            {
+                builder.Particle = new CompositeParticle(ParticleType.Sequence, 1, 1)
+                {
+                    new ElementParticle(typeof(ChildElement), 0, 1),
+                };
+            }
+        }
+
+        private class ChildElement : OpenXmlLeafElement
+        {
         }
     }
 }


### PR DESCRIPTION
A previous change had added a null check which inadvertantly caused properties to not be able to be set to null. This fixes that so that children properties can again be set to null.

Fixes #829