### PR TITLE
Allow exponents for numeric cell values

### DIFF
--- a/src/DocumentFormat.OpenXml/Spreadsheet/CellValue.cs
+++ b/src/DocumentFormat.OpenXml/Spreadsheet/CellValue.cs
@@ -92,7 +92,7 @@ namespace DocumentFormat.OpenXml.Spreadsheet
         /// <param name="dbl">The result if successful.</param>
         /// <returns>Success or failure</returns>
         public bool TryGetDouble(out double dbl)
-            => double.TryParse(InnerText, NumberStyles.Number, CultureInfo.InvariantCulture, out dbl);
+            => double.TryParse(InnerText, NumberStyles.Number | NumberStyles.AllowExponent, CultureInfo.InvariantCulture, out dbl);
 
         /// <summary>
         /// Attempts to parse cell value to retrieve a <see cref="int"/>.
@@ -100,7 +100,7 @@ namespace DocumentFormat.OpenXml.Spreadsheet
         /// <param name="value">The result if successful.</param>
         /// <returns>Success or failure</returns>
         public bool TryGetInt(out int value)
-            => int.TryParse(InnerText, NumberStyles.Number, CultureInfo.InvariantCulture, out value);
+            => int.TryParse(InnerText, NumberStyles.Number | NumberStyles.AllowExponent, CultureInfo.InvariantCulture, out value);
 
         /// <summary>
         /// Attempts to parse cell value to retrieve a <see cref="decimal"/>.
@@ -108,7 +108,7 @@ namespace DocumentFormat.OpenXml.Spreadsheet
         /// <param name="value">The result if successful.</param>
         /// <returns>Success or failure</returns>
         public bool TryGetDecimal(out decimal value)
-            => decimal.TryParse(InnerText, NumberStyles.Number, CultureInfo.InvariantCulture, out value);
+            => decimal.TryParse(InnerText, NumberStyles.Number | NumberStyles.AllowExponent, CultureInfo.InvariantCulture, out value);
 
         /// <summary>
         /// Attempts to parse cell value to retrieve a <see cref="bool"/>.

--- a/test/DocumentFormat.OpenXml.Tests/Spreadsheet/CellTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/Spreadsheet/CellTests.cs
@@ -14,6 +14,8 @@ namespace DocumentFormat.OpenXml.Tests
         [InlineData("1", CellValues.Number, true)]
         [InlineData("1.0", CellValues.Number, true)]
         [InlineData("-1.0", CellValues.Number, true)]
+        [InlineData("9.999E+307", CellValues.Number, true)]
+        [InlineData("-2.4E-6", CellValues.Number, true)]
 
         // Boolean
         [InlineData("false", CellValues.Boolean, true)]

--- a/test/DocumentFormat.OpenXml.Tests/Spreadsheet/CellValueTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/Spreadsheet/CellValueTests.cs
@@ -74,6 +74,20 @@ namespace DocumentFormat.OpenXml.Tests
             Assert.Equal(num, result);
         }
 
+        [InlineData("987.6E+30", 9.876E+32)]
+        [InlineData("-12.34E-20", -1.234E-19)]
+        [Theory]
+        public void CellDoubleTestExponential(string num, double expected)
+        {
+            var value = new CellValue(num);
+
+            Assert.Equal(num, value.Text);
+            Assert.Equal(num, value.InnerText);
+            Assert.Equal(@$"<x:v xmlns:x=""http://schemas.openxmlformats.org/spreadsheetml/2006/main"">{num}</x:v>", value.OuterXml);
+            Assert.True(value.TryGetDouble(out var result));
+            Assert.Equal(expected, result);
+        }
+
         [InlineData(null)]
         [InlineData("")]
         [InlineData("other")]
@@ -104,6 +118,19 @@ namespace DocumentFormat.OpenXml.Tests
             Assert.Equal(num, result);
         }
 
+        [InlineData("987E+5", 98700000)]
+        [Theory]
+        public void CellIntTestExponential(string num, int expected)
+        {
+            var value = new CellValue(num);
+
+            Assert.Equal(num, value.Text);
+            Assert.Equal(num, value.InnerText);
+            Assert.Equal(@$"<x:v xmlns:x=""http://schemas.openxmlformats.org/spreadsheetml/2006/main"">{num}</x:v>", value.OuterXml);
+            Assert.True(value.TryGetInt(out var result));
+            Assert.Equal(expected, result);
+        }
+
         [InlineData(null)]
         [InlineData("")]
         [InlineData("other")]
@@ -126,6 +153,20 @@ namespace DocumentFormat.OpenXml.Tests
             Assert.Equal(@$"<x:v xmlns:x=""http://schemas.openxmlformats.org/spreadsheetml/2006/main"">{num}</x:v>", value.OuterXml);
             Assert.True(value.TryGetDecimal(out var result));
             Assert.Equal(num, result);
+        }
+
+        [InlineData("987.6E+8", 9.876E+10)]
+        [InlineData("-12.34E-7", -1.234E-6)]
+        [Theory]
+        public void CellDecimalTestExponential(string num, decimal expected)
+        {
+            var value = new CellValue(num);
+
+            Assert.Equal(num, value.Text);
+            Assert.Equal(num, value.InnerText);
+            Assert.Equal(@$"<x:v xmlns:x=""http://schemas.openxmlformats.org/spreadsheetml/2006/main"">{num}</x:v>", value.OuterXml);
+            Assert.True(value.TryGetDecimal(out var result));
+            Assert.Equal(expected, result);
         }
 
         [InlineData(null)]


### PR DESCRIPTION
Follow-up to #890 . This fixes a validation issue where numbers in exponential format were not recognised.