### PR TITLE
Update README.md to point to new Q&A forums

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you want to report a problem (bug, behavior, build, distribution, feature req
 
 If you have "how-to" questions please post to one of the following resources:
 
-- [Open XML SDK forum](https://social.msdn.microsoft.com/Forums/office/en-US/home?forum=oxmlsdk)
+- [Microsoft Q&A Forums](https://docs.microsoft.com/en-us/answers/topics/office-addins-dev.html) (tag: **office-addins-dev**)
 - [Stack Overflow](http://stackoverflow.com) (tags: **openxml** or **openxml-sdk**)
 
 Known Issues


### PR DESCRIPTION
The msdn forums are deprecated and new forum questions should be posted to the "office-addins-dev" tag per https://docs.microsoft.com/en-us/answers/products/m365 under Office Client development