### PR TITLE
Add lifetime features and additional library to hold new features

### DIFF
--- a/Open-XML-SDK.sln
+++ b/Open-XML-SDK.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29009.5
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31612.314
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0B53C729-D408-450D-B755-7A57184CDE93}"
 	ProjectSection(SolutionItems) = preProject
@@ -46,6 +46,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DocumentFormat.OpenXml.Linq", "src\DocumentFormat.OpenXml.Linq\DocumentFormat.OpenXml.Linq.csproj", "{8DB6A050-4584-4210-8DE1-CB299A08EA4F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DocumentFormat.OpenXml.CodeGeneration.Linq", "src\DocumentFormat.OpenXml.CodeGeneration.Linq\DocumentFormat.OpenXml.CodeGeneration.Linq.csproj", "{4E3D124A-B027-46C3-B962-6F01B9B03AB8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DocumentFormat.OpenXml.Features", "src\DocumentFormat.OpenXml.Features\DocumentFormat.OpenXml.Features.csproj", "{8D6D3961-9C39-405B-A953-4823D87227D9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DocumentFormat.OpenXml.Framework.Features.Tests", "test\DocumentFormat.OpenXml.Framework.Features.Tests\DocumentFormat.OpenXml.Framework.Features.Tests.csproj", "{E157C5F1-D70B-4939-A199-0B758FED8541}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -93,6 +97,14 @@ Global
 		{4E3D124A-B027-46C3-B962-6F01B9B03AB8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4E3D124A-B027-46C3-B962-6F01B9B03AB8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4E3D124A-B027-46C3-B962-6F01B9B03AB8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D6D3961-9C39-405B-A953-4823D87227D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D6D3961-9C39-405B-A953-4823D87227D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D6D3961-9C39-405B-A953-4823D87227D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D6D3961-9C39-405B-A953-4823D87227D9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E157C5F1-D70B-4939-A199-0B758FED8541}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E157C5F1-D70B-4939-A199-0B758FED8541}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E157C5F1-D70B-4939-A199-0B758FED8541}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E157C5F1-D70B-4939-A199-0B758FED8541}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -108,6 +120,8 @@ Global
 		{5034C012-FED8-4DE5-B422-C1E4DF9EDBF2} = {7DAF7304-40CC-4180-88A5-9A89DD13C565}
 		{8DB6A050-4584-4210-8DE1-CB299A08EA4F} = {A4DF60EB-3AA5-48F0-B4D2-3F94B8E62F03}
 		{4E3D124A-B027-46C3-B962-6F01B9B03AB8} = {A4DF60EB-3AA5-48F0-B4D2-3F94B8E62F03}
+		{8D6D3961-9C39-405B-A953-4823D87227D9} = {A4DF60EB-3AA5-48F0-B4D2-3F94B8E62F03}
+		{E157C5F1-D70B-4939-A199-0B758FED8541} = {0782A132-968D-4BDD-911A-2C3074EAF886}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6F476383-E917-43D1-A1E5-9A61A47DA3F5}

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -1,0 +1,51 @@
+# Features
+
+Features are a new concept in v2.14 and later that allows for behavior and state to be contained within the document or part. This is accessed via `OpenXmlPartContainer.Features` property and a document's features will be inherited into a part. All elements within a part will have a read-only access to the part's features (and thus the document's as well).
+
+## Current Features
+
+The features that are currently available are described below and at what scope they are available. This is important, because and element by itself will not have any features available, while an element in one part may have different features than another part.
+
+### IPartEventsFeature
+
+This feature allows getting event notifications of when an event is being created. This is a feature that is added to the package level feature:
+
+```csharp
+OpenXmlPackage package = GetSomePackage();
+package.AddPartEventsFeature();
+
+var feature = package.Features.GetRequired<IPartEventsFeature>();
+```
+
+### IPackageClosingEventsFeature
+
+This feature allows getting event notifications of when a package is being closed:
+
+```csharp
+OpenXmlPackage package = GetSomePackage();
+package.TryAddPackageEventsFeature();
+
+var feature = package.Features.GetRequired<IPackageClosingEventsFeature>();
+```
+
+## DocumentFormat.OpenXml.Features - unreleased
+
+This library contains additional (non-core) features that build on top of built-in features and functionality.
+
+### IDisposableFeature
+
+This feature allows for registering features that need to be disposed at the same time as the feature goes out of scope. This allows a feature to be created, but its lifetime managed concurrently with the collection it is added to. The recommended way to use it is simply to call the following method:
+
+```csharp
+OpenXmlPackage package = GetSomePackage();
+package.TryAddDisposableFeature();
+
+OpenXmlPart part = GetSomePart();
+part.SetDisposable(new ExampleFeature());
+
+public class ExampleFeature : IDisposable
+{
+}
+```
+
+This will add `ExampleFeature` to the part feature, and register it to be disposed when the part is disposed.

--- a/src/DocumentFormat.OpenXml.Features/Disposable/DisposableFeatureExtensions.cs
+++ b/src/DocumentFormat.OpenXml.Features/Disposable/DisposableFeatureExtensions.cs
@@ -1,0 +1,158 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Packaging;
+using System;
+using System.Collections.Generic;
+
+namespace DocumentFormat.OpenXml.Framework.Features
+{
+    /// <summary>
+    /// Extension methods to add retrieve disposable features.
+    /// </summary>
+    public static class DisposableFeatureExtensions
+    {
+        /// <summary>
+        /// Adds disposable feature.
+        /// </summary>
+        /// <param name="package">Package to add disposable feature to.</param>
+        public static bool TryAddDisposableFeature(this OpenXmlPackage package)
+        {
+            package.TryAddPartEventsFeature();
+            package.TryAddPackageEventsFeature();
+
+            if (package.Features.TryAddDisposableFeature())
+            {
+                // Add feature to all parts already created
+                foreach (var part in package.GetAllParts())
+                {
+                    part.Features.Set<IDisposableFeature>(new DisposableFeature());
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Adds disposable feature.
+        /// </summary>
+        /// <param name="features">Features collection to add disposable feature to.</param>
+        public static bool TryAddDisposableFeature(this IFeatureCollection features)
+        {
+            if (features.Get<IDisposableFeature>() is not null)
+            {
+                return false;
+            }
+
+            var feature = new DisposableFeature();
+
+            features.Set<IDisposableFeature>(feature);
+
+            var packageEvents = features.GetRequired<IPackageEventsFeature>();
+            packageEvents.Change += PackageChanged;
+
+            // Add events to add to any new events
+            var events = features.GetRequired<IPartEventsFeature>();
+
+            events.Change += PartChanged;
+
+            feature.Register(new DelegateDisposable(() =>
+            {
+                events.Change -= PartChanged;
+                packageEvents.Change -= PackageChanged;
+            }));
+
+            return true;
+
+            static void PackageChanged(FeatureEventArgs<OpenXmlPackage> arg)
+            {
+                if (arg.Type == EventType.Closed)
+                {
+                    arg.Argument.Features.Dispose();
+                }
+            }
+
+            static void PartChanged(FeatureEventArgs<OpenXmlPart> arg)
+            {
+                if (arg.Type == EventType.Created)
+                {
+                    arg.Argument.Features.Set<IDisposableFeature>(new DisposableFeature());
+                }
+                else if (arg.Type == EventType.Removed)
+                {
+                    arg.Argument.Features.Dispose();
+                }
+            }
+        }
+
+        private class DelegateDisposable : IDisposable
+        {
+            private readonly Action _action;
+
+            public DelegateDisposable(Action action)
+            {
+                _action = action;
+            }
+
+            public void Dispose() => _action();
+        }
+
+        /// <summary>
+        /// Register a feature into the collection and to be disposed.
+        /// </summary>
+        /// <typeparam name="TFeature">Type of feature.</typeparam>
+        /// <param name="features">Feature collection.</param>
+        /// <param name="feature">Feature to register.</param>
+        public static void SetDisposable<TFeature>(this IFeatureCollection features, TFeature feature)
+        {
+            var disposable = features.GetRequired<IDisposableFeature>();
+
+            if (feature is IDisposable d)
+            {
+                disposable.Register(d);
+            }
+
+            features.Set(feature);
+        }
+
+        internal static void Dispose(this IFeatureCollection features)
+        {
+            if (features.Get<IDisposableFeature>() is IDisposable feature)
+            {
+                feature.Dispose();
+            }
+        }
+
+        private sealed class DisposableFeature : IDisposableFeature, IDisposable
+        {
+            private List<IDisposable>? _list;
+
+            public void Dispose()
+            {
+                if (_list is null)
+                {
+                    return;
+                }
+
+                foreach (var item in _list)
+                {
+                    item.Dispose();
+                }
+
+                _list = null;
+            }
+
+            public void Register(IDisposable disposable)
+            {
+                if (_list is null)
+                {
+                    _list = new();
+                }
+
+                _list.Add(disposable);
+            }
+        }
+    }
+}

--- a/src/DocumentFormat.OpenXml.Features/Disposable/IDisposableFeature.cs
+++ b/src/DocumentFormat.OpenXml.Features/Disposable/IDisposableFeature.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DocumentFormat.OpenXml.Framework.Features
+{
+    /// <summary>
+    /// Feature to track items to dispose when a package is disposed.
+    /// </summary>
+    public interface IDisposableFeature
+    {
+        /// <summary>
+        /// Register a disposable to be tracked.
+        /// </summary>
+        /// <param name="disposable">Disposable to be tracked and disposed when a package is disposed.</param>
+        public void Register(IDisposable disposable);
+    }
+}

--- a/src/DocumentFormat.OpenXml.Features/DocumentFormat.OpenXml.Features.csproj
+++ b/src/DocumentFormat.OpenXml.Features/DocumentFormat.OpenXml.Features.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), DocumentFormat.OpenXml.Package.props))\DocumentFormat.OpenXml.Package.props" />
+
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <IsShipped>true</IsShipped>
+    <TargetFrameworks>$(ProductTargetFrameworks)</TargetFrameworks>
+    <NoWarn>$(NoWarn);3003</NoWarn>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DocumentFormat.OpenXml\DocumentFormat.OpenXml.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/DocumentFormat.OpenXml/ElementEventArgs.cs
+++ b/src/DocumentFormat.OpenXml/ElementEventArgs.cs
@@ -10,9 +10,6 @@ namespace DocumentFormat.OpenXml
     /// </summary>
     public class ElementEventArgs : EventArgs
     {
-        private readonly OpenXmlElement _element;
-        private readonly OpenXmlElement _parentElement;
-
         /// <summary>
         /// Initializes a new instance of the ElementEventArgs class using the
         ///  supplied elements.
@@ -25,24 +22,18 @@ namespace DocumentFormat.OpenXml
         /// </param>
         public ElementEventArgs(OpenXmlElement element, OpenXmlElement parentElement)
         {
-            _element = element;
-            _parentElement = parentElement;
+            Element = element;
+            ParentElement = parentElement;
         }
 
         /// <summary>
         /// Gets the element that caused the event.
         /// </summary>
-        public OpenXmlElement Element
-        {
-            get { return _element; }
-        }
+        public OpenXmlElement Element { get; }
 
         /// <summary>
         /// Gets the parent element of the element that caused the event.
         /// </summary>
-        public OpenXmlElement ParentElement
-        {
-            get { return _parentElement; }
-        }
+        public OpenXmlElement ParentElement { get; }
     }
 }

--- a/src/DocumentFormat.OpenXml/Framework/Features/EventType.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Features/EventType.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DocumentFormat.OpenXml.Framework.Features
+{
+    /// <summary>
+    /// Type of event used for change notification.
+    /// </summary>
+    public enum EventType
+    {
+        /// <summary>
+        /// The default type when there is no event.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// When the item is closed.
+        /// </summary>
+        Closed,
+
+        /// <summary>
+        /// When the item is closing.
+        /// </summary>
+        Closing,
+
+        /// <summary>
+        /// When the item is deleting.
+        /// </summary>
+        Deleting,
+
+        /// <summary>
+        /// When the item is deleted.
+        /// </summary>
+        Deleted,
+
+        /// <summary>
+        /// When the item is being created.
+        /// </summary>
+        Creating,
+
+        /// <summary>
+        /// When the item is created.
+        /// </summary>
+        Created,
+
+        /// <summary>
+        /// When the item is being removed.
+        /// </summary>
+        Removing,
+
+        /// <summary>
+        /// When the item is removed.
+        /// </summary>
+        Removed,
+
+        /// <summary>
+        /// When the item is reloading.
+        /// </summary>
+        Reloading,
+
+        /// <summary>
+        /// When the item is reloaded.
+        /// </summary>
+        Reloaded,
+
+        /// <summary>
+        /// When the item is being saved.
+        /// </summary>
+        Saved,
+
+        /// <summary>
+        /// When the item is saved.
+        /// </summary>
+        Saving,
+    }
+}

--- a/src/DocumentFormat.OpenXml/Framework/Features/FeatureEventArgs.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Features/FeatureEventArgs.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DocumentFormat.OpenXml.Framework.Features
+{
+    /// <summary>
+    /// Holder for feature event args.
+    /// </summary>
+    /// <typeparam name="TArg">The type of the argument.</typeparam>
+    public readonly struct FeatureEventArgs<TArg>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FeatureEventArgs{TArg}"/> struct.
+        /// </summary>
+        /// <param name="type">Type of change.</param>
+        /// <param name="arg">Argument of change.</param>
+        public FeatureEventArgs(EventType type, TArg arg)
+        {
+            Type = type;
+            Argument = arg;
+        }
+
+        /// <summary>
+        /// Gets the event type.
+        /// </summary>
+        public EventType Type { get; }
+
+        /// <summary>
+        /// Gets the argument.
+        /// </summary>
+        public TArg Argument { get; }
+    }
+}

--- a/src/DocumentFormat.OpenXml/Framework/Features/FeatureEvent{TArg}.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Features/FeatureEvent{TArg}.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DocumentFormat.OpenXml.Framework.Features
+{
+    internal abstract class FeatureEvent<TArg> : IFeatureEvent<TArg>, IRaiseFeatureEvent<TArg>
+    {
+        public event Action<FeatureEventArgs<TArg>>? Change;
+
+        public void OnChange(EventType type, TArg arg)
+            => Change?.Invoke(new FeatureEventArgs<TArg>(type, arg));
+    }
+}

--- a/src/DocumentFormat.OpenXml/Framework/Features/IFeatureEvent.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Features/IFeatureEvent.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DocumentFormat.OpenXml.Framework.Features
+{
+    /// <summary>
+    /// Interface for general feature eventing.
+    /// </summary>
+    /// <typeparam name="TArg">Type of the argument.</typeparam>
+    public interface IFeatureEvent<TArg>
+    {
+        /// <summary>
+        /// Event to register to listen to any changes.
+        /// </summary>
+        event Action<FeatureEventArgs<TArg>> Change;
+    }
+}

--- a/src/DocumentFormat.OpenXml/Framework/Features/IPackageEventsFeature.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Features/IPackageEventsFeature.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Packaging;
+using System;
+
+namespace DocumentFormat.OpenXml.Framework.Features
+{
+    /// <summary>
+    /// A feature to track events around the package.
+    /// </summary>
+    public interface IPackageEventsFeature : IFeatureEvent<OpenXmlPackage>
+    {
+    }
+}

--- a/src/DocumentFormat.OpenXml/Framework/Features/IPartEventsFeature.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Features/IPartEventsFeature.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Packaging;
+
+namespace DocumentFormat.OpenXml.Framework.Features
+{
+    /// <summary>
+    /// A feature to track events around parts.
+    /// </summary>
+    public interface IPartEventsFeature : IFeatureEvent<OpenXmlPart>
+    {
+    }
+}

--- a/src/DocumentFormat.OpenXml/Framework/Features/IPartRootEventsFeature.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Features/IPartRootEventsFeature.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Packaging;
+
+namespace DocumentFormat.OpenXml.Framework.Features
+{
+    /// <summary>
+    /// A feature to track events around parts.
+    /// </summary>
+    public interface IPartRootEventsFeature : IFeatureEvent<OpenXmlPart>
+    {
+    }
+}

--- a/src/DocumentFormat.OpenXml/Framework/Features/IRaiseFeatureEvent.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Features/IRaiseFeatureEvent.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DocumentFormat.OpenXml.Framework.Features
+{
+    /// <summary>
+    /// Interface to raise events for <see cref="IFeatureEvent{TArg}"/>.
+    /// </summary>
+    /// <typeparam name="TArg">Type of argument.</typeparam>
+    public interface IRaiseFeatureEvent<TArg>
+    {
+        /// <summary>
+        /// Raise event on underlying event.
+        /// </summary>
+        /// <param name="type">Type of event.</param>
+        /// <param name="arg">Argument of event.</param>
+        void OnChange(EventType type, TArg arg);
+    }
+}

--- a/src/DocumentFormat.OpenXml/Framework/Features/PackageEventExtensions.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Features/PackageEventExtensions.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Packaging;
+
+namespace DocumentFormat.OpenXml.Framework.Features
+{
+    /// <summary>
+    /// Extensions to add events around lifecycle.
+    /// </summary>
+    public static class PackageEventExtensions
+    {
+        /// <summary>
+        /// Adds a feature to track eventing for a package lifecycle events.
+        /// </summary>
+        /// <param name="package">Package to add the feature to.</param>
+        public static bool TryAddPackageEventsFeature(this OpenXmlPackage package)
+        {
+            if (package.Features.Get<IPackageEventsFeature>() is null)
+            {
+                package.Features.Set<IPackageEventsFeature>(new PackageClosingEventsFeature());
+                return true;
+            }
+
+            return false;
+        }
+
+        internal static void OnChange(this IPackageEventsFeature events, OpenXmlPackage package, EventType type)
+        {
+            if (events is IRaiseFeatureEvent<OpenXmlPackage> raise)
+            {
+                raise.OnChange(type, package);
+            }
+        }
+
+        private class PackageClosingEventsFeature : FeatureEvent<OpenXmlPackage>, IPackageEventsFeature
+        {
+        }
+    }
+}

--- a/src/DocumentFormat.OpenXml/Framework/Features/PartEventExtensions.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Features/PartEventExtensions.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Packaging;
+
+namespace DocumentFormat.OpenXml.Framework.Features
+{
+    /// <summary>
+    /// Extensions to add events around parts.
+    /// </summary>
+    public static class PartEventFeatureExtensions
+    {
+        /// <summary>
+        /// Adds a feature to track eventing for a package creating or removing parts.
+        /// </summary>
+        /// <param name="package">Package to add the feature to.</param>
+        public static bool TryAddPartEventsFeature(this OpenXmlPackage package)
+        {
+            if (package.Features.Get<IPartEventsFeature>() is null)
+            {
+                package.Features.Set<IPartEventsFeature>(new PartEventsFeature());
+                return true;
+            }
+
+            return false;
+        }
+
+        internal static void OnChange(this IPartEventsFeature events, OpenXmlPart part, EventType type)
+        {
+            if (events is IRaiseFeatureEvent<OpenXmlPart> raise)
+            {
+                raise.OnChange(type, part);
+            }
+        }
+
+        private class PartEventsFeature : FeatureEvent<OpenXmlPart>, IPartEventsFeature
+        {
+        }
+    }
+}

--- a/src/DocumentFormat.OpenXml/Framework/Features/PartRootEventExtensions.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Features/PartRootEventExtensions.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Packaging;
+
+namespace DocumentFormat.OpenXml.Framework.Features
+{
+    /// <summary>
+    /// Extensions to add events around part roots.
+    /// </summary>
+    public static class PartRootEventExtensions
+    {
+        /// <summary>
+        /// Adds a feature to track eventing for a package lifecycle events.
+        /// </summary>
+        /// <param name="container">Container to add the feature to.</param>
+        public static bool TryAddPartRootEventsFeature(this OpenXmlPartContainer container)
+        {
+            if (container.Features.Get<IPartRootEventsFeature>() is null)
+            {
+                container.Features.Set<IPartRootEventsFeature>(new PartRootEventsFeature());
+                return true;
+            }
+
+            return false;
+        }
+
+        internal static void OnChange(this IPartRootEventsFeature events, EventType type, OpenXmlPart? part)
+        {
+            if (part is not null && events is IRaiseFeatureEvent<OpenXmlPart> raise)
+            {
+                raise.OnChange(type, part);
+            }
+        }
+
+        private class PartRootEventsFeature : FeatureEvent<OpenXmlPart>, IPartRootEventsFeature
+        {
+        }
+    }
+}

--- a/src/DocumentFormat.OpenXml/OpenXmlPartRootElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlPartRootElement.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using DocumentFormat.OpenXml.Framework;
+using DocumentFormat.OpenXml.Framework.Features;
 using DocumentFormat.OpenXml.Packaging;
 using System;
 using System.Collections.Generic;
@@ -115,6 +116,9 @@ namespace DocumentFormat.OpenXml
                 return false;
             }
 
+            var events = openXmlPart.Features.Get<IPartRootEventsFeature>();
+            events?.OnChange(EventType.Reloading, openXmlPart);
+
             var context = RootElementContext;
 
             // set MaxCharactersInDocument to limit the part size on loading DOM.
@@ -173,6 +177,8 @@ namespace DocumentFormat.OpenXml
                 }
             }
 
+            events?.OnChange(EventType.Reloaded, openXmlPart);
+
             return true;
         }
 
@@ -211,6 +217,9 @@ namespace DocumentFormat.OpenXml
                 Encoding = new UTF8Encoding(false),
             };
 
+            var events = Features.Get<IPartRootEventsFeature>();
+            events?.OnChange(EventType.Saving, OpenXmlPart);
+
             using (var xmlWriter = XmlWriter.Create(stream, settings))
             {
                 if (_standaloneDeclaration is not null)
@@ -229,6 +238,8 @@ namespace DocumentFormat.OpenXml
                     xmlWriter.WriteEndDocument();
                 }
             }
+
+            events?.OnChange(EventType.Saved, OpenXmlPart);
         }
 
         /// <summary>

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
@@ -512,6 +512,10 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (disposing)
             {
+                var closing = Features.Get<IPackageEventsFeature>();
+
+                closing?.OnChange(this, EventType.Closing);
+
                 // Try to save contents of every part in the package
                 SavePartContents(AutoSave);
                 DeleteUnusedDataPartOnClose();
@@ -522,6 +526,8 @@ namespace DocumentFormat.OpenXml.Packaging
                 ChildrenRelationshipParts.Clear();
                 ReferenceRelationshipList.Clear();
                 _partUriHelper = null!;
+
+                closing?.OnChange(this, EventType.Closed);
             }
 
             _disposed = true;

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackageExtensions.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackageExtensions.cs
@@ -6,7 +6,10 @@ using System.Collections.Generic;
 
 namespace DocumentFormat.OpenXml.Packaging
 {
-    internal static class OpenXmlPackageExtensions
+    /// <summary>
+    /// Extensions for <see cref="OpenXmlPackage"/> type.
+    /// </summary>
+    public static class OpenXmlPackageExtensions
     {
         /// <summary>
         /// Traverse parts in the <see cref="OpenXmlPackage"/> by breadth-first.

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPartContainer.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPartContainer.cs
@@ -21,7 +21,7 @@ namespace DocumentFormat.OpenXml.Packaging
     /// </summary>
     public abstract class OpenXmlPartContainer
     {
-        private readonly Dictionary<string, OpenXmlPart> _childrenPartsDictionary = new Dictionary<string, OpenXmlPart>(StringComparer.Ordinal);
+        private readonly PartDictionary _childrenPartsDictionary;
         private readonly LinkedList<ReferenceRelationship> _referenceRelationships = new LinkedList<ReferenceRelationship>();
         private object? _annotations;
 
@@ -30,12 +30,13 @@ namespace DocumentFormat.OpenXml.Packaging
         /// </summary>
         protected OpenXmlPartContainer()
         {
+            _childrenPartsDictionary = new(this);
         }
 
         /// <summary>
         /// Gets the children parts IDictionary.
         /// </summary>
-        internal Dictionary<string, OpenXmlPart> ChildrenRelationshipParts
+        internal PartDictionary ChildrenRelationshipParts
         {
             get
             {
@@ -1816,6 +1817,9 @@ namespace DocumentFormat.OpenXml.Packaging
                 return false;
             }
 
+            var events = Features.Get<IPartEventsFeature>();
+            events?.OnChange(child, EventType.Deleting);
+
             child.FindAllReachableParts(processedParts);
 
             // remove from the collection
@@ -1858,6 +1862,8 @@ namespace DocumentFormat.OpenXml.Packaging
                     }
                 }
             }
+
+            events?.OnChange(child, EventType.Deleted);
 
             return true;
         }

--- a/src/DocumentFormat.OpenXml/Packaging/PartDictionary.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/PartDictionary.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Framework.Features;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace DocumentFormat.OpenXml.Packaging
+{
+    internal class PartDictionary
+    {
+        private readonly OpenXmlPartContainer _container;
+        private readonly Dictionary<string, OpenXmlPart> _parts = new(StringComparer.Ordinal);
+
+        private IPartEventsFeature? _events;
+
+        public PartDictionary(OpenXmlPartContainer container)
+        {
+            _container = container;
+        }
+
+        public IPartEventsFeature? Events
+        {
+            get
+            {
+                if (_events is null)
+                {
+                    _events = _container.Features.Get<IPartEventsFeature>();
+                }
+
+                return _events;
+            }
+        }
+
+        public Dictionary<string, OpenXmlPart>.ValueCollection Values => _parts.Values;
+
+        public void Add(string uri, OpenXmlPart part)
+        {
+            Events?.OnChange(part, EventType.Creating);
+            _parts.Add(uri, part);
+            Events?.OnChange(part, EventType.Created);
+        }
+
+        public void Clear()
+        {
+            if (Events is null)
+            {
+                _parts.Clear();
+            }
+            else
+            {
+                foreach (var kv in _parts)
+                {
+                    Events.OnChange(kv.Value, EventType.Removing);
+                    Remove(kv.Key);
+                    Events.OnChange(kv.Value, EventType.Removed);
+                }
+            }
+        }
+
+        public int Count => _parts.Count;
+
+        public bool ContainsValue(OpenXmlPart part) => _parts.ContainsValue(part);
+
+        public bool ContainsKey(string uri) => _parts.ContainsKey(uri);
+
+        public bool TryGetValue(string uri, [MaybeNullWhen(false)] out OpenXmlPart part) => _parts.TryGetValue(uri, out part);
+
+        public Dictionary<string, OpenXmlPart>.Enumerator GetEnumerator() => _parts.GetEnumerator();
+
+        public void Remove(string uri)
+        {
+            if (_parts.TryGetValue(uri, out var part))
+            {
+                Events?.OnChange(part, EventType.Removing);
+                _parts.Remove(uri);
+                Events?.OnChange(part, EventType.Removed);
+            }
+        }
+    }
+}

--- a/test/DocumentFormat.OpenXml.Framework.Features.Tests/DisposableFeatureTests.cs
+++ b/test/DocumentFormat.OpenXml.Framework.Features.Tests/DisposableFeatureTests.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Packaging;
+using NSubstitute;
+using NSubstitute.Extensions;
+using System;
+using Xunit;
+
+namespace DocumentFormat.OpenXml.Framework.Features.Tests
+{
+    public class DisposableFeatureTests
+    {
+        [Fact]
+        public void ThrowsIfNotSet()
+        {
+            var features = Substitute.For<IFeatureCollection>();
+            features.Get<IDisposableFeature>().Returns(default(IDisposableFeature));
+
+            Assert.Throws<NotSupportedException>(() => features.SetDisposable(Substitute.For<IDisposable>()));
+        }
+
+        [Fact]
+        public void PackageLevelDisposables()
+        {
+            // Arrange
+            var features = new TestFeatureCollection();
+            features.AddMock<IPackageEventsFeature>();
+            features.AddMock<IPartEventsFeature>();
+
+            var feature = Substitute.For<IDisposable>();
+
+            features.TryAddDisposableFeature();
+            features.SetDisposable(feature);
+
+            var package = Substitute.ForPartsOf<OpenXmlPackage>();
+            package.Configure().Features.Returns(features);
+
+            // Act
+            features.GetRequired<IPackageEventsFeature>().Change += Raise.Event<Action<FeatureEventArgs<OpenXmlPackage>>>(new FeatureEventArgs<OpenXmlPackage>(EventType.Closed, package));
+
+            // Assert
+            feature.Received(1).Dispose();
+        }
+
+        [Fact]
+        public void PartLevelDisposables()
+        {
+            // Arrange
+            var features = new TestFeatureCollection();
+            features.AddMock<IPackageEventsFeature>();
+            features.AddMock<IPartEventsFeature>();
+
+            var feature = Substitute.For<IDisposable>();
+
+            features.TryAddDisposableFeature();
+            features.SetDisposable(feature);
+
+            var part = Substitute.ForPartsOf<OpenXmlPart>();
+            part.Configure().Features.Returns(features);
+
+            // Act
+            features.GetRequired<IPartEventsFeature>().Change += Raise.Event<Action<FeatureEventArgs<OpenXmlPart>>>(new FeatureEventArgs<OpenXmlPart>(EventType.Removed, part));
+
+            // Assert
+            feature.Received(1).Dispose();
+        }
+
+        [Fact]
+        public void PartAdded()
+        {
+            // Arrange
+            var features = new TestFeatureCollection();
+            features.AddMock<IPackageEventsFeature>();
+            features.AddMock<IPartEventsFeature>();
+
+            var feature = Substitute.For<IDisposable>();
+
+            features.TryAddDisposableFeature();
+            features.SetDisposable(feature);
+
+            var part = Substitute.ForPartsOf<OpenXmlPart>();
+            part.Configure().Features.Returns(new TestFeatureCollection());
+
+            // Act
+            features.GetRequired<IPartEventsFeature>().Change += Raise.Event<Action<FeatureEventArgs<OpenXmlPart>>>(new FeatureEventArgs<OpenXmlPart>(EventType.Created, part));
+
+            // Assert
+            Assert.NotNull(part.Features.Get<IDisposableFeature>());
+        }
+    }
+}

--- a/test/DocumentFormat.OpenXml.Framework.Features.Tests/DocumentFormat.OpenXml.Framework.Features.Tests.csproj
+++ b/test/DocumentFormat.OpenXml.Framework.Features.Tests/DocumentFormat.OpenXml.Framework.Features.Tests.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
+    <IsTestProject>true</IsTestProject>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DocumentFormat.OpenXml.Features\DocumentFormat.OpenXml.Features.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/DocumentFormat.OpenXml.Framework.Features.Tests/TestFeatureCollection.cs
+++ b/test/DocumentFormat.OpenXml.Framework.Features.Tests/TestFeatureCollection.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using NSubstitute;
+using System;
+using System.Collections.Generic;
+
+namespace DocumentFormat.OpenXml.Framework.Features.Tests
+{
+    internal class TestFeatureCollection : IFeatureCollection
+    {
+        private readonly Dictionary<Type, object?> _types = new();
+
+        public object? this[Type key]
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+
+        public bool IsReadOnly => false;
+
+        public int Revision => throw new NotImplementedException();
+
+        public TFeature? Get<TFeature>()
+        {
+            if (_types.TryGetValue(typeof(TFeature), out var result) && result is TFeature t)
+            {
+                return t;
+            }
+
+            return default;
+        }
+
+        public void AddMock<T>()
+            where T : class => Set(Substitute.For<T>());
+
+        public void Set<TFeature>(TFeature? instance)
+        {
+            _types[typeof(TFeature)] = instance;
+        }
+    }
+}

--- a/test/DocumentFormat.OpenXml.Framework.Tests/Features/PackageEventsTests.cs
+++ b/test/DocumentFormat.OpenXml.Framework.Tests/Features/PackageEventsTests.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Packaging;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace DocumentFormat.OpenXml.Framework.Features.Tests
+{
+    public class PackageEventsTests
+    {
+        [Fact]
+        public void PackageEventCalledOnClose()
+        {
+            var events = new List<EventType>();
+
+            using (var ms = new MemoryStream())
+            using (var package = WordprocessingDocument.Create(ms, WordprocessingDocumentType.Document))
+            {
+                package.TryAddPackageEventsFeature();
+                package.Features.Get<IPackageEventsFeature>().Change += a => events.Add(a.Type);
+            }
+
+            Assert.Collection(
+                events,
+                e => Assert.Equal(EventType.Closing, e),
+                e => Assert.Equal(EventType.Closed, e));
+        }
+
+        [Fact]
+        public void PartIdentifiedOpening()
+        {
+            var events = new List<EventType>();
+
+            using (var ms = new MemoryStream())
+            using (var package = WordprocessingDocument.Create(ms, WordprocessingDocumentType.Document))
+            {
+                package.TryAddPartEventsFeature();
+
+                var creating = default(OpenXmlPart);
+                var created = default(OpenXmlPart);
+                var removing = default(OpenXmlPart);
+                var removed = default(OpenXmlPart);
+                var deleting = default(OpenXmlPart);
+                var deleted = default(OpenXmlPart);
+
+                package.Features.Get<IPartEventsFeature>().Change += a =>
+                {
+                    events.Add(a.Type);
+
+                    switch (a.Type)
+                    {
+                        case EventType.Creating:
+                            creating = a.Argument;
+                            break;
+                        case EventType.Created:
+                            created = a.Argument;
+                            break;
+                        case EventType.Removed:
+                            removed = a.Argument;
+                            break;
+                        case EventType.Removing:
+                            removing = a.Argument;
+                            break;
+                        case EventType.Deleting:
+                            deleting = a.Argument;
+                            break;
+                        case EventType.Deleted:
+                            deleted = a.Argument;
+                            break;
+                    }
+                };
+
+                var doc = package.AddMainDocumentPart();
+
+                Assert.Same(doc, creating);
+                Assert.Same(doc, created);
+                Assert.Null(removed);
+                Assert.Null(removing);
+
+                package.DeletePart(doc);
+
+                Assert.Same(doc, removed);
+                Assert.Same(doc, removing);
+                Assert.Same(doc, deleted);
+                Assert.Same(doc, deleting);
+            }
+
+            Assert.Collection(
+                events,
+                e => Assert.Equal(EventType.Creating, e),
+                e => Assert.Equal(EventType.Created, e),
+                e => Assert.Equal(EventType.Deleting, e),
+                e => Assert.Equal(EventType.Removing, e),
+                e => Assert.Equal(EventType.Removed, e),
+                e => Assert.Equal(EventType.Deleted, e));
+        }
+    }
+}


### PR DESCRIPTION
This adds a couple of features that require changes to the internal
implementation of the parts/packages to provide notifications of
changes such as parts being added/removed or the package being
closed.

An additional feature that is implemented in a separate
assembly allows to register items that need to be disposed when the
feature is done which builds on the lifecycle features added in the
main assembly.