### PR TITLE
add Svg to ImagePartType enum

### DIFF
--- a/src/DocumentFormat.OpenXml/Packaging/ImagePartType.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/ImagePartType.cs
@@ -25,6 +25,7 @@ namespace DocumentFormat.OpenXml.Packaging
     /// L".jpeg",   L"image/jpeg",
     /// L".emf",    L"image/x-emf",
     /// L".wmf",    L"image/x-wmf",
+    /// L".svg",    L"image/svg+xml",
     /// ]]>
     /// </summary>
     public enum ImagePartType
@@ -87,5 +88,10 @@ namespace DocumentFormat.OpenXml.Packaging
         /// Windows Metafile (.wmf).
         /// </summary>
         Wmf,
+
+        /// <summary>
+        /// Scalable Vector Graphics (.svg).
+        /// </summary>
+        Svg,
     }
 }

--- a/src/DocumentFormat.OpenXml/Packaging/ImagePartTypeInfo.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/ImagePartTypeInfo.cs
@@ -24,6 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 ImagePartType.Jpeg => "image/jpeg",
                 ImagePartType.Emf => "image/x-emf",
                 ImagePartType.Wmf => "image/x-wmf",
+                ImagePartType.Svg => "image/svg+xml",
                 _ => throw new ArgumentOutOfRangeException(nameof(imageType)),
             };
 
@@ -44,6 +45,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 ImagePartType.Jpeg => ".jpg",
                 ImagePartType.Emf => ".emf",
                 ImagePartType.Wmf => ".wmf",
+                ImagePartType.Svg => ".svg",
                 _ => ".image",
             };
     }


### PR DESCRIPTION
This adds Svg to the ImagePartType enum and updates GetContentType and GetTargetExtension with new enum value, so that image files can be saved with a `.svg` extension.