### PR TITLE
Use full qualified name in semantic validation

### DIFF
--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas-microsoft-com_office_excel.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas-microsoft-com_office_excel.g.cs
@@ -290,8 +290,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Vml.Spreadsheet.ScriptLocation), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Vml.Spreadsheet.FormulaTextBox), 1, 1)
             };
-            builder.AddConstraint(new AttributeValueSetConstraint(":ObjectType", false, new string[] { "Movie" }) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueSetConstraint(":ObjectType", false, new string[] { "LineA", "RectA" }) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueSetConstraint("xvml:ObjectType", false, new string[] { "Movie" }) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueSetConstraint("x:ObjectType", false, new string[] { "LineA", "RectA" }) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas-microsoft-com_office_office.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas-microsoft-com_office_office.g.cs
@@ -823,7 +823,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
 .AddAttribute("signinginstructions", a => a.SigningInstructions)
 .AddAttribute("addlxml", a => a.AdditionalXml)
 .AddAttribute("sigprovurl", a => a.SignatureProviderUrl);
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("ovml:id", true, null));
         }
 
         /// <inheritdoc/>
@@ -1826,10 +1826,10 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
 .AddAttribute("lightposition2", a => a.LightPosition2)
 .AddAttribute("lightlevel2", a => a.LightLevel2)
 .AddAttribute("lightharsh2", a => a.LightHarsh2);
-            builder.AddConstraint(new AttributeValueRangeConstraint(":facet", true, 1, true, 65536, true));
-            builder.AddConstraint(new AttributeValuePatternConstraint(":edge", @"(\d{1,5}|1[0-6][0-8]\d{3}|1690[0-8]\d|16909[0-3])pt"));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":orientationangle", true, -32767, true, 32767, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":skewangle", true, -32767, true, 32767, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("ovml:facet", true, 1, true, 65536, true));
+            builder.AddConstraint(new AttributeValuePatternConstraint("ovml:edge", @"(\d{1,5}|1[0-6][0-8]\d{3}|1690[0-8]\d|16909[0-3])pt"));
+            builder.AddConstraint(new AttributeValueRangeConstraint("ovml:orientationangle", true, -32767, true, 32767, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("ovml:skewangle", true, -32767, true, 32767, true));
         }
 
         /// <inheritdoc/>
@@ -2099,7 +2099,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
 .AddAttribute("textborder", a => a.TextBorder)
 .AddAttribute("minusx", a => a.MinusX)
 .AddAttribute("minusy", a => a.MinusY);
-            builder.AddConstraint(new AttributeValueSetConstraint(":type", true, new string[] { "rightAngle", "oneSegment", "twoSegment", "threeSegment" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("ovml:type", true, new string[] { "rightAngle", "oneSegment", "twoSegment", "threeSegment" }));
         }
 
         /// <inheritdoc/>
@@ -2526,7 +2526,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Vml.Office.LockedField), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Vml.Office.FieldCodes), 0, 1)
             };
-            builder.AddConstraint(new AttributeValuePatternConstraint(":ObjectID", @"_(\d{1,9}|1\d{9}|20\d{8}|21[0-3]\d{7}|214[0-6]\d{6}|2147[0-3]\d{5}|21474[0-7]\d{4}|214748[0-2]\d{3}|2147483[0-5]\d{2}|21474836[0-3]\d|214748364[0-7])"));
+            builder.AddConstraint(new AttributeValuePatternConstraint("ovml:ObjectID", @"_(\d{1,9}|1\d{9}|20\d{8}|21[0-3]\d{7}|214[0-6]\d{6}|2147[0-3]\d{5}|21474[0-7]\d{4}|214748[0-2]\d{3}|2147483[0-5]\d{2}|21474836[0-3]\d|214748364[0-7])"));
             builder.AddConstraint(new ReferenceExistConstraint(":ShapeID", ".", "v:shape", "v:shape", ":id"));
         }
 
@@ -2723,8 +2723,8 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("o:bottom");
-            builder.AddConstraint(new AttributeValueRangeConstraint(":weight", true, 0, true, 20116800, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":miterlimit", true, double.NegativeInfinity, true, 32767, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("ovml:weight", true, 0, true, 20116800, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("ovml:miterlimit", true, double.NegativeInfinity, true, 32767, true));
         }
 
         /// <inheritdoc/>
@@ -2752,7 +2752,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("o:column");
-            builder.AddConstraint(new AttributeValueSetConstraint(":dashstyle", true, new string[] { "solid", "shortdash", "shortdot", "shortdashdot", "shortdashdotdot", "dot", "dash", "longdash", "longdashdotdot", "dashdot" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("ovml:dashstyle", true, new string[] { "solid", "shortdash", "shortdot", "shortdashdot", "shortdashdotdot", "dot", "dash", "longdash", "longdashdotdot", "dashdot" }));
         }
 
         /// <inheritdoc/>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas-microsoft-com_vml.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas-microsoft-com_vml.g.cs
@@ -309,7 +309,7 @@ namespace DocumentFormat.OpenXml.Vml
 .AddAttribute("o:connectlocs", a => a.ConnectionPoints)
 .AddAttribute("o:connectangles", a => a.ConnectAngles)
 .AddAttribute("o:extrusionok", a => a.AllowExtrusion);
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("v:id", true, null));
         }
 
         /// <inheritdoc/>
@@ -958,11 +958,11 @@ namespace DocumentFormat.OpenXml.Vml
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Vml.Office.FillExtendedProperties), 0, 1)
             };
             builder.AddConstraint(new RelationshipTypeConstraint("r:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"));
-            builder.AddConstraint(new AttributeValuePatternConstraint(":focus", @"-?(\d{1,2}|100)%"));
+            builder.AddConstraint(new AttributeValuePatternConstraint("v:focus", @"-?(\d{1,2}|100)%"));
             builder.AddConstraint(new UniqueAttributeValueConstraint(":id", false, null));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":angle", true, -32767, true, 32767, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":origin", true, -32767, true, 32767, true));
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:title", false, new string[] { "slashes", "colons" }));
+            builder.AddConstraint(new AttributeValueRangeConstraint("v:angle", true, -32767, true, 32767, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("v:origin", true, -32767, true, 32767, true));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:title", false, new string[] { "slashes", "colons" }));
             builder.AddConstraint(new RelationshipExistConstraint("r:id"));
         }
 
@@ -1545,8 +1545,8 @@ namespace DocumentFormat.OpenXml.Vml
             };
             builder.AddConstraint(new RelationshipTypeConstraint("r:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"));
             builder.AddConstraint(new UniqueAttributeValueConstraint(":id", false, null));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":miterlimit", true, double.NegativeInfinity, true, 32767, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":weight", true, 0, true, 20116800, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("v:miterlimit", true, double.NegativeInfinity, true, 32767, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("v:weight", true, 0, true, 20116800, true));
             builder.AddConstraint(new RelationshipExistConstraint("r:id"));
         }
 
@@ -1828,7 +1828,7 @@ namespace DocumentFormat.OpenXml.Vml
 .AddAttribute("offset2", a => a.Offset2)
 .AddAttribute("origin", a => a.Origin)
 .AddAttribute("matrix", a => a.Matrix);
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("v:id", true, null));
         }
 
         /// <inheritdoc/>
@@ -1964,7 +1964,7 @@ namespace DocumentFormat.OpenXml.Vml
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Wordprocessing.TextBoxContent), 0, 1),
                 new AnyParticle(XsdAny.Local, 1, 1)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("v:id", true, null));
         }
 
         /// <inheritdoc/>
@@ -2129,7 +2129,7 @@ namespace DocumentFormat.OpenXml.Vml
 .AddAttribute("trim", a => a.Trim)
 .AddAttribute("xscale", a => a.XScale)
 .AddAttribute("string", a => a.String);
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("v:id", true, null));
         }
 
         /// <inheritdoc/>
@@ -2499,12 +2499,12 @@ namespace DocumentFormat.OpenXml.Vml
 .AddAttribute("r:id", a => a.RelationshipId)
 .AddAttribute("r:pict", a => a.Picture)
 .AddAttribute("r:href", a => a.RelHref);
-            builder.AddConstraint(new RelationshipTypeConstraint("r:href", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"));
+            builder.AddConstraint(new RelationshipTypeConstraint("v:href", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"));
             builder.AddConstraint(new RelationshipTypeConstraint("r:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"));
-            builder.AddConstraint(new RelationshipTypeConstraint("r:pict", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"));
-            builder.AddConstraint(new RelationshipTypeConstraint("ovml:relid", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"));
+            builder.AddConstraint(new RelationshipTypeConstraint("v:pict", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"));
+            builder.AddConstraint(new RelationshipTypeConstraint("v:relid", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"));
             builder.AddConstraint(new UniqueAttributeValueConstraint(":id", false, null));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":blacklevel", true, -0.5, true, 0.5, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("v:blacklevel", true, -0.5, true, 0.5, true));
             builder.AddConstraint(new RelationshipExistConstraint("r:id"));
             builder.AddConstraint(new RelationshipExistConstraint("r:href"));
         }
@@ -3708,9 +3708,9 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Vml.Office.Ink), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Vml.Presentation.InkAnnotationFlag), 1, 1)
             };
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:dgmlayout", true, new string[] { "0", "1", "2", "3" }));
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:dgmlayoutmru", true, new string[] { "0", "1", "2", "3" }));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", true, null));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:dgmlayout", true, new string[] { "0", "1", "2", "3" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:dgmlayoutmru", true, new string[] { "0", "1", "2", "3" }));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("v:id", true, null));
         }
 
         /// <inheritdoc/>
@@ -4875,9 +4875,9 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
                 },
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Vml.Office.Complex), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:dgmlayout", true, new string[] { "0", "1", "2", "3" }));
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:dgmlayoutmru", true, new string[] { "0", "1", "2", "3" }));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", true, null));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:dgmlayout", true, new string[] { "0", "1", "2", "3" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:dgmlayoutmru", true, new string[] { "0", "1", "2", "3" }));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("v:id", true, null));
         }
 
         /// <inheritdoc/>
@@ -5633,10 +5633,10 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Vml.Wordprocessing.AnchorLock), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Vml.Spreadsheet.ClientData), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:tableproperties", true, new string[] { "1", "2", "3" }));
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:dgmlayout", true, new string[] { "0", "1", "2", "3" }));
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:dgmlayoutmru", true, new string[] { "0", "1", "2", "3" }));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", true, null));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:tableproperties", true, new string[] { "1", "2", "3" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:dgmlayout", true, new string[] { "0", "1", "2", "3" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:dgmlayoutmru", true, new string[] { "0", "1", "2", "3" }));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("v:id", true, null));
         }
 
         /// <inheritdoc/>
@@ -5834,7 +5834,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), MaxLength = (255
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Vml.Fill), 0, 1)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("v:id", true, null));
         }
 
         /// <summary>
@@ -6995,12 +6995,12 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), MaxLength = (255
                     }
                 }
             };
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:dgmlayout", true, new string[] { "0", "1", "2", "3" }));
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:dgmlayoutmru", true, new string[] { "0", "1", "2", "3" }));
-            builder.AddConstraint(new AttributeValueRangeConstraint("ovml:hrpct", true, 0, true, 1000, true));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:dgmlayout", true, new string[] { "0", "1", "2", "3" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:dgmlayoutmru", true, new string[] { "0", "1", "2", "3" }));
+            builder.AddConstraint(new AttributeValueRangeConstraint("v:hrpct", true, 0, true, 1000, true));
             builder.AddConstraint(new AttributeValueRangeConstraint("ovml:dgmnodekind", true, 0, true, 6, true));
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:spt", true, new string[] { "19" }));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", true, null));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:spt", true, new string[] { "19" }));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("v:id", true, null));
         }
 
         /// <inheritdoc/>
@@ -8196,10 +8196,10 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
                     }
                 }
             };
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:dgmlayout", true, new string[] { "0", "1", "2", "3" }));
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:dgmlayoutmru", true, new string[] { "0", "1", "2", "3" }));
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:spt", true, new string[] { "0" }));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", true, null));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:dgmlayout", true, new string[] { "0", "1", "2", "3" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:dgmlayoutmru", true, new string[] { "0", "1", "2", "3" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:spt", true, new string[] { "0" }));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("v:id", true, null));
         }
 
         /// <inheritdoc/>
@@ -9480,10 +9480,10 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
                     }
                 }
             };
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:dgmlayout", true, new string[] { "0", "1", "2", "3" }));
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:dgmlayoutmru", true, new string[] { "0", "1", "2", "3" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:dgmlayout", true, new string[] { "0", "1", "2", "3" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:dgmlayoutmru", true, new string[] { "0", "1", "2", "3" }));
             builder.AddConstraint(new UniqueAttributeValueConstraint(":id", true, null));
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:spt", true, new string[] { "75" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:spt", true, new string[] { "75" }));
         }
 
         /// <inheritdoc/>
@@ -10645,8 +10645,8 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
                     }
                 }
             };
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:dgmlayout", true, new string[] { "0", "1", "2", "3" }));
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:spt", true, new string[] { "20" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:dgmlayout", true, new string[] { "0", "1", "2", "3" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:spt", true, new string[] { "20" }));
         }
 
         /// <inheritdoc/>
@@ -11774,10 +11774,10 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
                     }
                 }
             };
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:dgmlayout", true, new string[] { "0", "1", "2", "3" }));
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:dgmlayoutmru", true, new string[] { "0", "1", "2", "3" }));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", true, null));
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:spt", true, new string[] { "3" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:dgmlayout", true, new string[] { "0", "1", "2", "3" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:dgmlayoutmru", true, new string[] { "0", "1", "2", "3" }));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("v:id", true, null));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:spt", true, new string[] { "3" }));
         }
 
         /// <inheritdoc/>
@@ -12925,9 +12925,9 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
                 },
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Vml.Office.Ink), 1, 1)
             };
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:dgmlayout", true, new string[] { "0", "1", "2", "3" }));
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:dgmlayoutmru", true, new string[] { "0", "1", "2", "3" }));
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:spt", true, new string[] { "0" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:dgmlayout", true, new string[] { "0", "1", "2", "3" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:dgmlayoutmru", true, new string[] { "0", "1", "2", "3" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:spt", true, new string[] { "0" }));
         }
 
         /// <inheritdoc/>
@@ -14055,10 +14055,10 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
                     }
                 }
             };
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:dgmlayout", true, new string[] { "0", "1", "2", "3" }));
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:dgmlayoutmru", true, new string[] { "0", "1", "2", "3" }));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", true, null));
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:spt", true, new string[] { "1" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:dgmlayout", true, new string[] { "0", "1", "2", "3" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:dgmlayoutmru", true, new string[] { "0", "1", "2", "3" }));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("v:id", true, null));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:spt", true, new string[] { "1" }));
         }
 
         /// <inheritdoc/>
@@ -15186,10 +15186,10 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
                     }
                 }
             };
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:dgmlayout", true, new string[] { "0", "1", "2", "3" }));
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:dgmlayoutmru", true, new string[] { "0", "1", "2", "3" }));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", true, null));
-            builder.AddConstraint(new AttributeValueSetConstraint("ovml:spt", true, new string[] { "2" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:dgmlayout", true, new string[] { "0", "1", "2", "3" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:dgmlayoutmru", true, new string[] { "0", "1", "2", "3" }));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("v:id", true, null));
+            builder.AddConstraint(new AttributeValueSetConstraint("v:spt", true, new string[] { "2" }));
         }
 
         /// <inheritdoc/>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_2009_07_customui.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_2009_07_customui.g.cs
@@ -546,7 +546,7 @@ aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (102
 {
 aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
-            builder.AddConstraint(new AttributeMutualExclusive(":size", ":getSize") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeMutualExclusive("mso14:size", "mso14:getSize") { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -1164,8 +1164,8 @@ aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (102
 {
 aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
-            builder.AddConstraint(new AttributeMutualExclusive(":insertAfterMso", ":insertAfterQ", ":insertBeforeMso", ":insertBeforeQ") { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeMutualExclusive(":size", ":getSize") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeMutualExclusive("mso14:insertAfterMso", "mso14:insertAfterQ", "mso14:insertBeforeMso", "mso14:insertBeforeQ") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeMutualExclusive("mso14:size", "mso14:getSize") { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -7118,7 +7118,7 @@ aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (102
 {
 aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
-            builder.AddConstraint(new AttributeMutualExclusive(":size", ":getSize") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeMutualExclusive("mso14:size", "mso14:getSize") { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -8193,8 +8193,8 @@ aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (102
 {
 aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
-            builder.AddConstraint(new AttributeMutualExclusive(":insertAfterMso", ":insertAfterQ", ":insertBeforeMso", ":insertBeforeQ") { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeMutualExclusive(":size", ":getSize") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeMutualExclusive("mso14:insertAfterMso", "mso14:insertAfterQ", "mso14:insertBeforeMso", "mso14:insertBeforeQ") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeMutualExclusive("mso14:size", "mso14:getSize") { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -15011,8 +15011,8 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true
 {
 aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
-            builder.AddConstraint(new AttributeMutualExclusive(":insertAfterMso", ":insertAfterQ", ":insertBeforeMso", ":insertBeforeQ") { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeMutualExclusive(":size", ":getSize") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeMutualExclusive("mso14:insertAfterMso", "mso14:insertAfterQ", "mso14:insertBeforeMso", "mso14:insertBeforeQ") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeMutualExclusive("mso14:size", "mso14:getSize") { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -16557,8 +16557,8 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true
 {
 aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
-            builder.AddConstraint(new AttributeMutualExclusive(":insertAfterMso", ":insertAfterQ", ":insertBeforeMso", ":insertBeforeQ") { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeMutualExclusive(":size", ":getSize") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeMutualExclusive("mso14:insertAfterMso", "mso14:insertAfterQ", "mso14:insertBeforeMso", "mso14:insertBeforeQ") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeMutualExclusive("mso14:size", "mso14:getSize") { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -22018,8 +22018,8 @@ aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (102
 {
 aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
-            builder.AddConstraint(new AttributeMutualExclusive(":insertAfterMso", ":insertAfterQ", ":insertBeforeMso", ":insertBeforeQ") { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeMutualExclusive(":size", ":getSize") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeMutualExclusive("mso14:insertAfterMso", "mso14:insertAfterQ", "mso14:insertBeforeMso", "mso14:insertBeforeQ") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeMutualExclusive("mso14:size", "mso14:getSize") { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -24088,7 +24088,7 @@ aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (102
 {
 aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
-            builder.AddConstraint(new AttributeMutualExclusive(":size", ":getSize") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeMutualExclusive("mso14:size", "mso14:getSize") { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -25746,8 +25746,8 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true
 {
 aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
-            builder.AddConstraint(new AttributeMutualExclusive(":insertAfterMso", ":insertAfterQ", ":insertBeforeMso", ":insertBeforeQ") { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeMutualExclusive(":size", ":getSize") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeMutualExclusive("mso14:insertAfterMso", "mso14:insertAfterQ", "mso14:insertBeforeMso", "mso14:insertBeforeQ") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeMutualExclusive("mso14:size", "mso14:getSize") { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -29725,8 +29725,8 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), IsNcName = (true
 {
 aBuilder.AddValidator(new StringValidator() { MinLength = (1L), MaxLength = (1024L) });
 });
-            builder.AddConstraint(new AttributeMutualExclusive(":insertAfterMso", ":insertAfterQ", ":insertBeforeMso", ":insertBeforeQ") { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeMutualExclusive(":size", ":getSize") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeMutualExclusive("mso14:insertAfterMso", "mso14:insertAfterQ", "mso14:insertBeforeMso", "mso14:insertBeforeQ") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeMutualExclusive("mso14:size", "mso14:getSize") { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2010_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2010_main.g.cs
@@ -73,7 +73,7 @@ namespace DocumentFormat.OpenXml.Office2010.Drawing
             builder.AddElement<CameraTool>()
 .AddAttribute("cellRange", a => a.CellRange)
 .AddAttribute("spid", a => a.ShapeId);
-            builder.AddConstraint(new AttributeValuePatternConstraint(":spid", @"_x0000_s(102[5-9]|10[3-9][0-9]|1[1-9][0-9]{2}|[1-9][0-9]{3,7}|1[0-9]{8}|2[0-5][0-9]{7}|26[0-7][0-9]{6}|268[0-3][0-9]{5}|2684[0-2][0-9]{4}|26843[0-4][0-9]{3}|268435[0-3][0-9]{2}|2684354[0-4][0-9]|26843545[0-6])") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValuePatternConstraint("a14:spid", @"_x0000_s(102[5-9]|10[3-9][0-9]|1[1-9][0-9]{2}|[1-9][0-9]{3,7}|1[0-9]{8}|2[0-5][0-9]{7}|26[0-7][0-9]{6}|268[0-3][0-9]{5}|2684[0-2][0-9]{4}|26843[0-4][0-9]{3}|268435[0-3][0-9]{2}|2684354[0-4][0-9]|26843545[0-6])") { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -120,7 +120,7 @@ namespace DocumentFormat.OpenXml.Office2010.Drawing
             builder.Availability = FileFormatVersions.Office2010;
             builder.AddElement<CompatExtension>()
 .AddAttribute("spid", a => a.ShapeId);
-            builder.AddConstraint(new AttributeValuePatternConstraint(":spid", @"_x0000_s(102[5-9]|10[3-9][0-9]|1[1-9][0-9]{2}|[1-9][0-9]{3,7}|1[0-9]{8}|2[0-5][0-9]{7}|26[0-7][0-9]{6}|268[0-3][0-9]{5}|2684[0-2][0-9]{4}|26843[0-4][0-9]{3}|268435[0-3][0-9]{2}|2684354[0-4][0-9]|26843545[0-6])") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValuePatternConstraint("a14:spid", @"_x0000_s(102[5-9]|10[3-9][0-9]|1[1-9][0-9]{2}|[1-9][0-9]{3,7}|1[0-9]{8}|2[0-5][0-9]{7}|26[0-7][0-9]{6}|268[0-3][0-9]{5}|2684[0-2][0-9]{4}|26843[0-4][0-9]{3}|268435[0-3][0-9]{2}|2684354[0-4][0-9]|26843545[0-6])") { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_powerpoint_2010_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_powerpoint_2010_main.g.cs
@@ -2866,8 +2866,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             builder.AddElement<MediaBookmark>()
 .AddAttribute("name", a => a.Name)
 .AddAttribute("time", a => a.Time);
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", true, "p14:bmkLst") { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":time", true, "p14:bmkLst") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("p14:name", true, "p14:bmkLst") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("p14:time", true, "p14:bmkLst") { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_powerpoint_2012_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_powerpoint_2012_main.g.cs
@@ -160,8 +160,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
 aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":providerId", 1, 100) { Application = ApplicationType.PowerPoint, Version = FileFormatVersions.Office2013 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":userId", 1, 300) { Application = ApplicationType.PowerPoint, Version = FileFormatVersions.Office2013 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("p15:providerId", 1, 100) { Application = ApplicationType.PowerPoint, Version = FileFormatVersions.Office2013 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("p15:userId", 1, 300) { Application = ApplicationType.PowerPoint, Version = FileFormatVersions.Office2013 });
         }
 
         /// <inheritdoc/>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2009_9_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2009_9_main.g.cs
@@ -206,8 +206,8 @@ namespace DocumentFormat.OpenXml.Office2010.Excel
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.DataValidation), 1, 0, version: FileFormatVersions.Office2010)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":xWindow", true, double.NegativeInfinity, true, 65535, true) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":yWindow", true, double.NegativeInfinity, true, 65535, true) { Application = ApplicationType.Excel, Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x14:xWindow", true, double.NegativeInfinity, true, 65535, true) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x14:yWindow", true, double.NegativeInfinity, true, 65535, true) { Application = ApplicationType.Excel, Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -732,7 +732,7 @@ namespace DocumentFormat.OpenXml.Office2010.Excel
 .AddAttribute("defaultImageDpi", a => a.DefaultImageDpi)
 .AddAttribute("discardImageEditData", a => a.DiscardImageEditData)
 .AddAttribute("accuracyVersion", a => a.AccuracyVersion);
-            builder.AddConstraint(new AttributeValueSetConstraint(":defaultImageDpi", true, new string[] { "96", "150", "220" }) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueSetConstraint("x14:defaultImageDpi", true, new string[] { "96", "150", "220" }) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -882,8 +882,8 @@ namespace DocumentFormat.OpenXml.Office2010.Excel
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.TupleSet), 0, 1, version: FileFormatVersions.Office2010)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":displayFolder", 0, 65535) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":mdxLong", 32766, 1073741822) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:displayFolder", 0, 65535) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:mdxLong", 32766, 1073741822) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <summary>
@@ -1029,9 +1029,9 @@ namespace DocumentFormat.OpenXml.Office2010.Excel
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.SetLevels), 0, 1, version: FileFormatVersions.Office2010)
             };
-            builder.AddConstraint(new AttributeValueConditionToAnother(":flattenHierarchies", ":ignore", new string[] { "false" }, new string[] { "true" }) { Application = ApplicationType.Excel, Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueConditionToAnother(":measuresSet", ":ignore", new string[] { "false" }, new string[] { "true" }) { Application = ApplicationType.Excel, Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueConditionToAnother(":hierarchizeDistinct", ":ignore", new string[] { "false" }, new string[] { "true" }) { Application = ApplicationType.Excel, Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueConditionToAnother("x14:flattenHierarchies", "x14:ignore", new string[] { "false" }, new string[] { "true" }) { Application = ApplicationType.Excel, Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueConditionToAnother("x14:measuresSet", "x14:ignore", new string[] { "false" }, new string[] { "true" }) { Application = ApplicationType.Excel, Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueConditionToAnother("x14:hierarchizeDistinct", "x14:ignore", new string[] { "false" }, new string[] { "true" }) { Application = ApplicationType.Excel, Version = FileFormatVersions.Office2010 });
         }
 
         /// <summary>
@@ -1125,8 +1125,8 @@ namespace DocumentFormat.OpenXml.Office2010.Excel
 .AddAttribute("pivotShowAs", a => a.PivotShowAs)
 .AddAttribute("sourceField", a => a.SourceField)
 .AddAttribute("uniqueName", a => a.UniqueName);
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":uniqueName", true, null) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":uniqueName", 0, 65535) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x14:uniqueName", true, null) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:uniqueName", 0, 65535) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -1430,9 +1430,9 @@ namespace DocumentFormat.OpenXml.Office2010.Excel
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.PivotChanges), 0, 1, version: FileFormatVersions.Office2010),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.ConditionalFormats), 0, 1, version: FileFormatVersions.Office2010)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":altText", 0, 2000) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":altTextSummary", 0, 2000) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":weightExpression", 0, 65535) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:altText", 0, 2000) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:altTextSummary", 0, 2000) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:weightExpression", 0, 65535) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <summary>
@@ -1684,8 +1684,8 @@ namespace DocumentFormat.OpenXml.Office2010.Excel
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.CalculatedMembers), 0, 1, version: FileFormatVersions.Office2010)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":culture", 0, 84) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":embeddedDataId", 0, 65535) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:culture", 0, 84) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:embeddedDataId", 0, 65535) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <summary>
@@ -1762,8 +1762,8 @@ namespace DocumentFormat.OpenXml.Office2010.Excel
             builder.AddElement<Table>()
 .AddAttribute("altText", a => a.AltText)
 .AddAttribute("altTextSummary", a => a.AltTextSummary);
-            builder.AddConstraint(new AttributeValueLengthConstraint(":altText", 0, 25000) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":altTextSummary", 0, 50000) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:altText", 0, 25000) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:altTextSummary", 0, 50000) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -1848,7 +1848,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.SlicerStyle), 0, 0, version: FileFormatVersions.Office2010)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":defaultSlicerStyle", 1, 255) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:defaultSlicerStyle", 1, 255) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -2559,9 +2559,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 .AddAttribute("dxfId", a => a.FormatId)
 .AddAttribute("iconSet", a => a.IconSet)
 .AddAttribute("iconId", a => a.IconId);
-            builder.AddConstraint(new AttributeAbsentConditionToValue(":dxfId", ":sortBy", "icon", "value") { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeAbsentConditionToNonValue(":iconSet", ":sortBy", "icon") { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeAbsentConditionToNonValue(":iconId", ":sortBy", "icon") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeAbsentConditionToValue("x14:dxfId", "x14:sortBy", "icon", "value") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeAbsentConditionToNonValue("x14:iconSet", "x14:sortBy", "icon") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeAbsentConditionToNonValue("x14:iconId", "x14:sortBy", "icon") { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -2695,7 +2695,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.ExtensionList), 0, 1, version: FileFormatVersions.Office2010)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":id", 0, 65535) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:id", 0, 65535) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <summary>
@@ -3349,11 +3349,11 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.ListItems), 0, 1, version: FileFormatVersions.Office2010),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.ExtensionList), 0, 1, version: FileFormatVersions.Office2010)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":dropLines", true, 0, true, 30000, true) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":inc", true, 0, true, 30000, true) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":max", true, 0, true, 30000, true) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":min", true, 0, true, 30000, true) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":page", true, 0, true, 30000, true) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x14:dropLines", true, 0, true, 30000, true) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x14:inc", true, 0, true, 30000, true) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x14:max", true, 0, true, 30000, true) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x14:min", true, 0, true, 30000, true) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x14:page", true, 0, true, 30000, true) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <summary>
@@ -4092,15 +4092,15 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.DifferentialType), 0, 1, version: FileFormatVersions.Office2010),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.ExtensionList), 0, 1, version: FileFormatVersions.Office2010)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":priority", true, 0, false, double.PositiveInfinity, true) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":priority", true, null) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeAbsentConditionToNonValue(":aboveAverage", ":type", "aboveAverage") { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeAbsentConditionToNonValue(":percent", ":type", "top10") { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeAbsentConditionToNonValue(":bottom", ":type", "top10") { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeAbsentConditionToNonValue(":text", ":type", "beginsWith", "containsText", "endsWith", "notContainsText") { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeAbsentConditionToNonValue(":timePeriod", ":type", "timePeriod") { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeAbsentConditionToNonValue(":stdDev", ":type", "aboveAverage") { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeAbsentConditionToNonValue(":equalAverage", ":type", "aboveAverage") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x14:priority", true, 0, false, double.PositiveInfinity, true) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x14:priority", true, null) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeAbsentConditionToNonValue("x14:aboveAverage", "x14:type", "aboveAverage") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeAbsentConditionToNonValue("x14:percent", "x14:type", "top10") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeAbsentConditionToNonValue("x14:bottom", "x14:type", "top10") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeAbsentConditionToNonValue("x14:text", "x14:type", "beginsWith", "containsText", "endsWith", "notContainsText") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeAbsentConditionToNonValue("x14:timePeriod", "x14:type", "timePeriod") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeAbsentConditionToNonValue("x14:stdDev", "x14:type", "aboveAverage") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeAbsentConditionToNonValue("x14:equalAverage", "x14:type", "aboveAverage") { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -4444,9 +4444,9 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.DataValidationForumla2), 0, 1, version: FileFormatVersions.Office2010),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Excel.ReferenceSequence), 1, 1)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":error", 0, 225) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":promptTitle", 0, 32) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":prompt", 0, 225) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:error", 0, 225) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:promptTitle", 0, 32) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:prompt", 0, 225) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <summary>
@@ -5054,8 +5054,8 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Excel.Formula), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.Sparklines), 1, 1, version: FileFormatVersions.Office2010)
             };
-            builder.AddConstraint(new AttributeValueConditionToAnother(":manualMin", ":minAxisType", new string[] { "0" }, new string[] { "individual", "group" }) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":lineWeight", true, 0, true, 1584, true) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueConditionToAnother("x14:manualMin", "x14:minAxisType", new string[] { "0" }, new string[] { "individual", "group" }) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x14:lineWeight", true, 0, true, 1584, true) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <summary>
@@ -5214,7 +5214,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             base.ConfigureMetadata(builder);
             builder.SetSchema("x14:colorSeries");
             builder.Availability = FileFormatVersions.Office2010;
-            builder.AddConstraint(new AttributeValueSetConstraint(":auto", true, new string[] { "false" }) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueSetConstraint("x14:auto", true, new string[] { "false" }) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -5243,7 +5243,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             base.ConfigureMetadata(builder);
             builder.SetSchema("x14:colorNegative");
             builder.Availability = FileFormatVersions.Office2010;
-            builder.AddConstraint(new AttributeValueSetConstraint(":auto", true, new string[] { "false" }) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueSetConstraint("x14:auto", true, new string[] { "false" }) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -5272,7 +5272,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             base.ConfigureMetadata(builder);
             builder.SetSchema("x14:colorAxis");
             builder.Availability = FileFormatVersions.Office2010;
-            builder.AddConstraint(new AttributeValueSetConstraint(":auto", true, new string[] { "false" }) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueSetConstraint("x14:auto", true, new string[] { "false" }) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -5301,7 +5301,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             base.ConfigureMetadata(builder);
             builder.SetSchema("x14:colorMarkers");
             builder.Availability = FileFormatVersions.Office2010;
-            builder.AddConstraint(new AttributeValueSetConstraint(":auto", true, new string[] { "false" }) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueSetConstraint("x14:auto", true, new string[] { "false" }) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -5330,7 +5330,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             base.ConfigureMetadata(builder);
             builder.SetSchema("x14:colorFirst");
             builder.Availability = FileFormatVersions.Office2010;
-            builder.AddConstraint(new AttributeValueSetConstraint(":auto", true, new string[] { "false" }) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueSetConstraint("x14:auto", true, new string[] { "false" }) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -5359,7 +5359,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             base.ConfigureMetadata(builder);
             builder.SetSchema("x14:colorLast");
             builder.Availability = FileFormatVersions.Office2010;
-            builder.AddConstraint(new AttributeValueSetConstraint(":auto", true, new string[] { "false" }) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueSetConstraint("x14:auto", true, new string[] { "false" }) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -5388,7 +5388,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             base.ConfigureMetadata(builder);
             builder.SetSchema("x14:colorHigh");
             builder.Availability = FileFormatVersions.Office2010;
-            builder.AddConstraint(new AttributeValueSetConstraint(":auto", true, new string[] { "false" }) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueSetConstraint("x14:auto", true, new string[] { "false" }) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -5901,10 +5901,10 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
 {
 aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", false, null) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 1, 32767) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":caption", 1, int.MaxValue) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":columnCount", true, 1, true, 20000, true) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x14:name", false, null) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:name", 1, 32767) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:caption", 1, int.MaxValue) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x14:columnCount", true, 1, true, 20000, true) { Version = FileFormatVersions.Office2010 });
             builder.AddConstraint(new RelationshipExistConstraint("r:id") { Version = FileFormatVersions.Office2010 });
         }
 
@@ -6043,7 +6043,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.ArgumentDescriptions), 0, 1, version: FileFormatVersions.Office2010)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", true, "x14:definedNames") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x14:name", true, "x14:definedNames") { Version = FileFormatVersions.Office2010 });
         }
 
         /// <summary>
@@ -6200,7 +6200,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
 aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":index", true, "x14:argumentDescriptions") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x14:index", true, "x14:argumentDescriptions") { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -6517,8 +6517,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             builder.AddElement<TupleSetHeader>()
 .AddAttribute("uniqueName", a => a.UniqueName)
 .AddAttribute("hierarchyName", a => a.HierarchyName);
-            builder.AddConstraint(new AttributeValueLengthConstraint(":uniqueName", 0, 65535) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":hierarchyName", 0, 65535) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:uniqueName", 0, 65535) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:hierarchyName", 0, 65535) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -6645,8 +6645,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             builder.AddElement<TupleSetRowItem>()
 .AddAttribute("u", a => a.UniqueName)
 .AddAttribute("d", a => a.DisplayName);
-            builder.AddConstraint(new AttributeValueLengthConstraint(":u", 0, 65535) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":d", 0, 65535) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:u", 0, 65535) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:d", 0, 65535) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -6696,7 +6696,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
 aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":hierarchy", true, -2, true, double.PositiveInfinity, true) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x14:hierarchy", true, -2, true, double.PositiveInfinity, true) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -7076,8 +7076,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.NegativeBorderColor), 0, 1, version: FileFormatVersions.Office2010),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.BarAxisColor), 0, 1, version: FileFormatVersions.Office2010)
             };
-            builder.AddConstraint(new AttributeValueLessEqualToAnother(":minLength", ":maxLength", true) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":maxLength", true, double.NegativeInfinity, true, 100, true) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLessEqualToAnother("x14:minLength", "x14:maxLength", true) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x14:maxLength", true, double.NegativeInfinity, true, 100, true) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -8569,7 +8569,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.TupleItems), 1, 1, version: FileFormatVersions.Office2010),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.ExtensionList), 0, 1, version: FileFormatVersions.Office2010)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":weightExpression", 1, 65535) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:weightExpression", 1, 65535) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <summary>
@@ -8671,7 +8671,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
 aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":valueType", 1, 32767) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:valueType", 1, 32767) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -9013,9 +9013,9 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.PivotAreas), 0, 1, version: FileFormatVersions.Office2010),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.ExtensionList), 0, 1, version: FileFormatVersions.Office2010)
             };
-            builder.AddConstraint(new AttributeValueSetConstraint(":type", true, new string[] { "none" }) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":priority", true, 1, true, double.PositiveInfinity, true) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new ReferenceExistConstraint(":priority", "..", "x14:cfRule", "x14:cfRule", ":priority") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueSetConstraint("x14:type", true, new string[] { "none" }) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x14:priority", true, 1, true, double.PositiveInfinity, true) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new ReferenceExistConstraint("x14:priority", "..", "x14:cfRule", "x14:cfRule", "x14:priority") { Version = FileFormatVersions.Office2010 });
         }
 
         /// <summary>
@@ -9207,9 +9207,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.SlicerStyleElements), 0, 1, version: FileFormatVersions.Office2010)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 1, 255) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new ReferenceExistConstraint(":name", ".", "x:tableStyle", "x:tableStyle", ":name") { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", true, "x14:slicerStyles") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:name", 1, 255) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new ReferenceExistConstraint("x14:name", ".", "x:tableStyle", "x:tableStyle", "x:name") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x14:name", true, "x14:slicerStyles") { Version = FileFormatVersions.Office2010 });
         }
 
         /// <summary>
@@ -9289,8 +9289,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute("dxfId", a => a.FormatId);
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":type", true, "x14:slicerStyleElements") { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new IndexReferenceConstraint(":dxfId", ".", null, "x:dxf", "x:dxf", 0) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x14:type", true, "x14:slicerStyleElements") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new IndexReferenceConstraint("x14:dxfId", ".", null, "x:dxf", "x:dxf", 0) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -9710,9 +9710,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Excel.ReferenceSequence), 1, 1)
             };
-            builder.AddConstraint(new AttributeMutualExclusive(":password", ":algorithmName") { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":spinCount", true, double.NegativeInfinity, true, 10000000, true) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 1, 255) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeMutualExclusive("x14:password", "x14:algorithmName") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x14:spinCount", true, double.NegativeInfinity, true, 10000000, true) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:name", 1, 255) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <summary>
@@ -10147,10 +10147,10 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.ExtensionList), 0, 1, version: FileFormatVersions.Office2010)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", false, null) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 1, 32767) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":caption", 1, int.MaxValue) { Version = FileFormatVersions.Office2010 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":columnCount", true, 1, true, 20000, true) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x14:name", false, null) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:name", 1, 32767) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:caption", 1, int.MaxValue) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x14:columnCount", true, 1, true, 20000, true) { Version = FileFormatVersions.Office2010 });
             builder.AddConstraint(new RelationshipExistConstraint("r:id") { Version = FileFormatVersions.Office2010 });
         }
 
@@ -10544,7 +10544,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
 aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new ReferenceExistConstraint(":tabId", "/WorkbookPart", "x:sheet", "x:sheet", ":sheetId") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new ReferenceExistConstraint("x14:tabId", "/WorkbookPart", "x:sheet", "x:sheet", "x:sheetId") { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -10712,7 +10712,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.OlapSlicerCacheItemParent), 0, 0, version: FileFormatVersions.Office2010)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":x", true, "x14:items") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x14:x", true, "x14:items") { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -10797,7 +10797,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.OlapSlicerCacheItem), 1, 0, version: FileFormatVersions.Office2010)
             };
-            builder.AddConstraint(new AttributeValuePatternConstraint(":startItem", @"(0|[1-9][0-9]*000)") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValuePatternConstraint("x14:startItem", @"(0|[1-9][0-9]*000)") { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -11016,7 +11016,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Excel.OlapSlicerCacheRanges), 0, 1, version: FileFormatVersions.Office2010)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":uniqueName", 1, 32767) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x14:uniqueName", 1, 32767) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <summary>
@@ -11440,7 +11440,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute("s", a => a.IsSelected)
 .AddAttribute("nd", a => a.NonDisplay);
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":x", true, "x14:items") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x14:x", true, "x14:items") { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2010_11_ac.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2010_11_ac.g.cs
@@ -59,7 +59,7 @@ namespace DocumentFormat.OpenXml.Office2013.ExcelAc
 {
 aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":url", 1, 1000) { Application = ApplicationType.Excel, Version = FileFormatVersions.Office2013 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x15ac:url", 1, 1000) { Application = ApplicationType.Excel, Version = FileFormatVersions.Office2013 });
         }
 
         /// <inheritdoc/>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2010_11_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2010_11_main.g.cs
@@ -6208,7 +6208,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2013.Excel.ExtensionList), 0, 1, version: FileFormatVersions.Office2013)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 1, 1000) { Application = ApplicationType.Excel, Version = FileFormatVersions.Office2013 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x15:name", 1, 1000) { Application = ApplicationType.Excel, Version = FileFormatVersions.Office2013 });
         }
 
         /// <summary>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_thememl_2012_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_thememl_2012_main.g.cs
@@ -136,7 +136,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2013.Theme.OfficeArtExtensionList), 0, 1, version: FileFormatVersions.Office2013)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":id", 1, 100) { Application = ApplicationType.Excel | ApplicationType.PowerPoint, Version = FileFormatVersions.Office2013 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("thm15:id", 1, 100) { Application = ApplicationType.Excel | ApplicationType.PowerPoint, Version = FileFormatVersions.Office2013 });
         }
 
         /// <summary>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_webextensions_webextension_2010_11.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_webextensions_webextension_2010_11.g.cs
@@ -126,7 +126,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2013.WebExtension.Snapshot), 0, 1, version: FileFormatVersions.Office2013),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2013.WebExtension.OfficeArtExtensionList), 0, 1, version: FileFormatVersions.Office2013)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":id", 1, 1000) { Application = ApplicationType.Word | ApplicationType.Excel, Version = FileFormatVersions.Office2013 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("we:id", 1, 1000) { Application = ApplicationType.Word | ApplicationType.Excel, Version = FileFormatVersions.Office2013 });
         }
 
         /// <summary>
@@ -701,7 +701,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2013.WebExtension.OfficeArtExtensionList), 0, 1, version: FileFormatVersions.Office2013)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":id", 1, 1000) { Application = ApplicationType.Word | ApplicationType.Excel, Version = FileFormatVersions.Office2013 });
+            builder.AddConstraint(new AttributeValueLengthConstraint("we:id", 1, 1000) { Application = ApplicationType.Word | ApplicationType.Excel, Version = FileFormatVersions.Office2013 });
         }
 
         /// <summary>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_chart.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_chart.g.cs
@@ -2384,7 +2384,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("c:idx");
-            builder.AddConstraint(new AttributeValueRangeConstraint(":val", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("c:val", true, double.NegativeInfinity, true, 2147483647, true));
         }
 
         /// <inheritdoc/>
@@ -2412,7 +2412,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("c:order");
-            builder.AddConstraint(new AttributeValueRangeConstraint(":val", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("c:val", true, double.NegativeInfinity, true, 2147483647, true));
         }
 
         /// <inheritdoc/>
@@ -2440,7 +2440,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("c:axId");
-            builder.AddConstraint(new AttributeValueRangeConstraint(":val", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("c:val", true, double.NegativeInfinity, true, 2147483647, true));
         }
 
         /// <inheritdoc/>
@@ -2468,7 +2468,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("c:crossAx");
-            builder.AddConstraint(new AttributeValueRangeConstraint(":val", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("c:val", true, double.NegativeInfinity, true, 2147483647, true));
         }
 
         /// <inheritdoc/>
@@ -2496,7 +2496,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("c:ptCount");
-            builder.AddConstraint(new AttributeValueRangeConstraint(":val", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("c:val", true, double.NegativeInfinity, true, 2147483647, true));
         }
 
         /// <inheritdoc/>
@@ -2524,7 +2524,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("c:secondPiePt");
-            builder.AddConstraint(new AttributeValueRangeConstraint(":val", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("c:val", true, double.NegativeInfinity, true, 2147483647, true));
         }
 
         /// <inheritdoc/>
@@ -2552,7 +2552,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("c:explosion");
-            builder.AddConstraint(new AttributeValueRangeConstraint(":val", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("c:val", true, double.NegativeInfinity, true, 2147483647, true));
         }
 
         /// <inheritdoc/>
@@ -2580,7 +2580,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("c:fmtId");
-            builder.AddConstraint(new AttributeValueRangeConstraint(":val", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("c:val", true, double.NegativeInfinity, true, 2147483647, true));
         }
 
         /// <inheritdoc/>
@@ -4513,7 +4513,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("c:crossesAt");
-            builder.AddConstraint(new AttributeValueSetConstraint(":val", false, new string[] { "INF", "-INF", "NaN" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("c:val", false, new string[] { "INF", "-INF", "NaN" }));
         }
 
         /// <inheritdoc/>
@@ -4649,8 +4649,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("c:forward");
-            builder.AddConstraint(new AttributeValueSetConstraint(":val", false, new string[] { "INF", "-INF", "NaN" }));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":val", true, 0, true, double.PositiveInfinity, true));
+            builder.AddConstraint(new AttributeValueSetConstraint("c:val", false, new string[] { "INF", "-INF", "NaN" }));
+            builder.AddConstraint(new AttributeValueRangeConstraint("c:val", true, 0, true, double.PositiveInfinity, true));
         }
 
         /// <inheritdoc/>
@@ -4678,7 +4678,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("c:backward");
-            builder.AddConstraint(new AttributeValueRangeConstraint(":val", true, 0, true, double.PositiveInfinity, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("c:val", true, 0, true, double.PositiveInfinity, true));
         }
 
         /// <inheritdoc/>
@@ -4760,7 +4760,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("c:splitPos");
-            builder.AddConstraint(new AttributeValueSetConstraint(":val", false, new string[] { "INF", "-INF", "NaN" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("c:val", false, new string[] { "INF", "-INF", "NaN" }));
         }
 
         /// <inheritdoc/>
@@ -4788,7 +4788,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("c:custUnit");
-            builder.AddConstraint(new AttributeValueSetConstraint(":val", false, new string[] { "INF", "-INF", "NaN" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("c:val", false, new string[] { "INF", "-INF", "NaN" }));
         }
 
         /// <inheritdoc/>
@@ -5825,8 +5825,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.Charts.NumericValue), 1, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":idx", true, double.NegativeInfinity, true, 2147483647, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":idx", true, 0, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("c:idx", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("c:idx", true, 0, true, 2147483647, true));
         }
 
         /// <summary>
@@ -7802,7 +7802,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
   aBuilder.AddValidator(RequiredValidator.Instance);
   aBuilder.AddValidator(new NumberValidator() { MinInclusive = (2L), MaxInclusive = (6L) });
 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":val", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("c:val", true, double.NegativeInfinity, true, 2147483647, true));
         }
 
         /// <inheritdoc/>
@@ -10129,12 +10129,12 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
 aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":b", true, 0, true, 49, false));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":footer", true, 0, true, 49, false));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":header", true, 0, true, 49, false));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":l", true, 0, true, 49, false));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":r", true, 0, true, 49, false));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":t", true, 0, true, 49, false));
+            builder.AddConstraint(new AttributeValueRangeConstraint("c:b", true, 0, true, 49, false));
+            builder.AddConstraint(new AttributeValueRangeConstraint("c:footer", true, 0, true, 49, false));
+            builder.AddConstraint(new AttributeValueRangeConstraint("c:header", true, 0, true, 49, false));
+            builder.AddConstraint(new AttributeValueRangeConstraint("c:l", true, 0, true, 49, false));
+            builder.AddConstraint(new AttributeValueRangeConstraint("c:r", true, 0, true, 49, false));
+            builder.AddConstraint(new AttributeValueRangeConstraint("c:t", true, 0, true, 49, false));
         }
 
         /// <inheritdoc/>
@@ -10316,8 +10316,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 .AddAttribute("horizontalDpi", a => a.HorizontalDpi)
 .AddAttribute("verticalDpi", a => a.VerticalDpi)
 .AddAttribute("copies", a => a.Copies);
-            builder.AddConstraint(new AttributeValueRangeConstraint(":copies", true, double.NegativeInfinity, true, 2147483647, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":paperSize", true, double.NegativeInfinity, true, 2147483647, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("c:copies", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("c:paperSize", true, double.NegativeInfinity, true, 2147483647, true) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -13939,8 +13939,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.Charts.NumericValue), 1, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":idx", true, double.NegativeInfinity, true, 2147483647, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":idx", true, 0, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("c:idx", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("c:idx", true, 0, true, 2147483647, true));
         }
 
         /// <summary>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_chartDrawing.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_chartDrawing.g.cs
@@ -387,7 +387,7 @@ namespace DocumentFormat.OpenXml.Drawing.ChartDrawing
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.ChartDrawing.Style), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.ChartDrawing.TextBody), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":macro", 0, 256));
+            builder.AddConstraint(new AttributeValueLengthConstraint("cdr:macro", 0, 256));
         }
 
         /// <summary>
@@ -655,7 +655,7 @@ namespace DocumentFormat.OpenXml.Drawing.ChartDrawing
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.ChartDrawing.Transform), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.Graphic), 1, 1)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":macro", 0, 256));
+            builder.AddConstraint(new AttributeValueLengthConstraint("cdr:macro", 0, 256));
         }
 
         /// <summary>
@@ -798,7 +798,7 @@ namespace DocumentFormat.OpenXml.Drawing.ChartDrawing
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.ChartDrawing.ShapeProperties), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.ChartDrawing.Style), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":macro", 0, 256));
+            builder.AddConstraint(new AttributeValueLengthConstraint("cdr:macro", 0, 256));
         }
 
         /// <summary>
@@ -944,7 +944,7 @@ namespace DocumentFormat.OpenXml.Drawing.ChartDrawing
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.ChartDrawing.ShapeProperties), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.ChartDrawing.Style), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":macro", 0, 256));
+            builder.AddConstraint(new AttributeValueLengthConstraint("cdr:macro", 0, 256));
         }
 
         /// <summary>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_compatibility.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_compatibility.g.cs
@@ -59,7 +59,7 @@ namespace DocumentFormat.OpenXml.Drawing.LegacyCompatibility
 aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":spid", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("comp:spid", true, null));
         }
 
         /// <inheritdoc/>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_diagram.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_diagram.g.cs
@@ -121,7 +121,7 @@ namespace DocumentFormat.OpenXml.Drawing.Diagrams
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.Diagrams.ColorTransformStyleLabel), 0, 0),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.Diagrams.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueSetConstraint(":minVer", true, new string[] { "12.0" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("dgm:minVer", true, new string[] { "12.0" }));
         }
 
         /// <inheritdoc/>
@@ -1002,10 +1002,10 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
 aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new RelationshipTypeConstraint("r:cs", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/diagramColors"));
-            builder.AddConstraint(new RelationshipTypeConstraint("r:dm", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/diagramData"));
-            builder.AddConstraint(new RelationshipTypeConstraint("r:lo", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/diagramLayout"));
-            builder.AddConstraint(new RelationshipTypeConstraint("r:qs", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/diagramQuickStyle"));
+            builder.AddConstraint(new RelationshipTypeConstraint("dgm:cs", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/diagramColors"));
+            builder.AddConstraint(new RelationshipTypeConstraint("dgm:dm", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/diagramData"));
+            builder.AddConstraint(new RelationshipTypeConstraint("dgm:lo", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/diagramLayout"));
+            builder.AddConstraint(new RelationshipTypeConstraint("dgm:qs", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/diagramQuickStyle"));
             builder.AddConstraint(new RelationshipExistConstraint("r:dm"));
         }
 
@@ -2879,8 +2879,8 @@ union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.Diagrams.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":modelId", true, "dgm:cxnLst"));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":parTransId", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("dgm:modelId", true, "dgm:cxnLst"));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("dgm:parTransId", true, null));
         }
 
         /// <summary>
@@ -3921,7 +3921,7 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.OutputShape
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.Diagrams.AdjustList), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.Diagrams.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new RelationshipTypeConstraint("r:blip", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"));
+            builder.AddConstraint(new RelationshipTypeConstraint("dgm:blip", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"));
             builder.AddConstraint(new RelationshipExistConstraint("r:blip"));
         }
 
@@ -4812,7 +4812,7 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.OutputShape
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.Diagrams.Choose), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.Diagrams.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("dgm:name", true, null));
         }
 
         /// <inheritdoc/>
@@ -4974,7 +4974,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.Diagrams.Choose), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.Diagrams.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("dgm:name", true, null));
         }
 
         /// <inheritdoc/>
@@ -5058,7 +5058,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.Diagrams.DiagramChooseIf), 1, 0),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.Diagrams.DiagramChooseElse), 0, 1)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("dgm:name", true, null));
         }
 
         /// <inheritdoc/>
@@ -5360,7 +5360,7 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ResizeHandl
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.Diagrams.Choose), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.Diagrams.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("dgm:name", true, null));
         }
 
         /// <inheritdoc/>
@@ -5465,7 +5465,7 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.Drawing.Diagrams.ResizeHandl
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.Diagrams.Choose), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.Diagrams.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("dgm:name", true, null));
         }
 
         /// <inheritdoc/>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_main.g.cs
@@ -1110,7 +1110,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxIncl
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("a:lum");
-            builder.AddConstraint(new AttributeValueRangeConstraint(":val", true, 0, true, 100000, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("a:val", true, 0, true, 100000, true));
         }
 
         /// <inheritdoc/>
@@ -6388,7 +6388,7 @@ aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (21600000L), MinInc
 {
     aBuilder.AddValidator(new NumberValidator() { MinInclusive = (-100000L), MaxInclusive = (100000L) });
 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":val", true, 0, true, 100000, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("a:val", true, 0, true, 100000, true));
         }
 
         /// <inheritdoc/>
@@ -22687,8 +22687,8 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
      aBuilder.AddValidator(RequiredValidator.Instance);
      aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
  });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":d", true, 1, true, double.PositiveInfinity, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":sp", true, 1, true, double.PositiveInfinity, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("a:d", true, 1, true, double.PositiveInfinity, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("a:sp", true, 1, true, double.PositiveInfinity, true));
         }
 
         /// <inheritdoc/>
@@ -25145,8 +25145,8 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.TableCellProperties), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":rowSpan", true, 1, true, double.PositiveInfinity, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":gridSpan", true, 1, true, double.PositiveInfinity, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("a:rowSpan", true, 1, true, double.PositiveInfinity, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("a:gridSpan", true, 1, true, double.PositiveInfinity, true));
         }
 
         /// <summary>
@@ -25275,7 +25275,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.NorthwestCell), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":styleId", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("a:styleId", true, null));
         }
 
         /// <inheritdoc/>
@@ -25365,7 +25365,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.NorthwestCell), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":styleId", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("a:styleId", true, null));
         }
 
         /// <inheritdoc/>
@@ -33745,7 +33745,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.HyperlinkSound), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.HyperlinkExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeCannotOmitConstraint("r:id"));
+            builder.AddConstraint(new AttributeCannotOmitConstraint("@a:id"));
             builder.AddConstraint(new RelationshipExistConstraint("r:id"));
         }
 
@@ -33810,7 +33810,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.HyperlinkSound), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.HyperlinkExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeCannotOmitConstraint("r:id"));
+            builder.AddConstraint(new AttributeCannotOmitConstraint("@a:id"));
             builder.AddConstraint(new RelationshipExistConstraint("r:id"));
         }
 
@@ -33875,7 +33875,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.HyperlinkSound), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.HyperlinkExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeCannotOmitConstraint("r:id"));
+            builder.AddConstraint(new AttributeCannotOmitConstraint("@a:id"));
         }
 
         /// <inheritdoc/>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_picture.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_picture.g.cs
@@ -310,7 +310,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.HyperlinkOnHover), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.NonVisualDrawingPropertiesExtensionList), 0, 1)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", true, "a:graphicData"));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("pic:id", true, "a:graphicData"));
         }
 
         /// <summary>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_spreadsheetDrawing.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_spreadsheetDrawing.g.cs
@@ -535,7 +535,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.Spreadsheet.ShapeStyle), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.Spreadsheet.TextBody), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":macro", 0, 256));
+            builder.AddConstraint(new AttributeValueLengthConstraint("xdr:macro", 0, 256));
         }
 
         /// <summary>
@@ -803,7 +803,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.Spreadsheet.Transform), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.Graphic), 1, 1)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":macro", 0, 256));
+            builder.AddConstraint(new AttributeValueLengthConstraint("xdr:macro", 0, 256));
         }
 
         /// <summary>
@@ -946,7 +946,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.Spreadsheet.ShapeProperties), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.Spreadsheet.ShapeStyle), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":macro", 0, 256));
+            builder.AddConstraint(new AttributeValueLengthConstraint("xdr:macro", 0, 256));
         }
 
         /// <summary>
@@ -3187,7 +3187,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.HyperlinkOnHover), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.NonVisualDrawingPropertiesExtensionList), 0, 1)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("xdr:id", true, null));
         }
 
         /// <summary>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_wordprocessingDrawing.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_wordprocessingDrawing.g.cs
@@ -2106,7 +2106,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.HyperlinkOnHover), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Drawing.NonVisualDrawingPropertiesExtensionList), 0, 1)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("wp:id", true, null));
         }
 
         /// <summary>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_custom-properties.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_custom-properties.g.cs
@@ -340,8 +340,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.VariantTypes.VTClassId), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.VariantTypes.VTClipboardData), 1, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":pid", true, 2, true, double.PositiveInfinity, true));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", false, null));
+            builder.AddConstraint(new AttributeValueRangeConstraint("op:pid", true, 2, true, double.PositiveInfinity, true));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("op:name", false, null));
         }
 
         /// <summary>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_docPropsVTypes.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_officeDocument_2006_docPropsVTypes.g.cs
@@ -2182,7 +2182,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { Pattern = ("\\s*\\{[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}\\}\\s*") });
 });
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":version", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("vt:version", true, null));
         }
 
         /// <inheritdoc/>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_presentationml_2006_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_presentationml_2006_main.g.cs
@@ -411,7 +411,7 @@ namespace DocumentFormat.OpenXml.Presentation
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("p:sldRg");
-            builder.AddConstraint(new AttributeValueLessEqualToAnother(":st", ":end", true));
+            builder.AddConstraint(new AttributeValueLessEqualToAnother("p:st", "p:end", true));
         }
 
         /// <inheritdoc/>
@@ -575,7 +575,7 @@ namespace DocumentFormat.OpenXml.Presentation
 {
 aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", false, null) { Application = ApplicationType.PowerPoint });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("p:id", false, null) { Application = ApplicationType.PowerPoint });
         }
 
         /// <inheritdoc/>
@@ -2159,7 +2159,7 @@ aBuilder.AddValidator(new NumberValidator() { MaxExclusive = (2147483648L), MinI
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Presentation.ModificationVerifier), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Presentation.PresentationExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":firstSlideNum", true, 0, true, 9999, true) { Application = ApplicationType.PowerPoint });
+            builder.AddConstraint(new AttributeValueRangeConstraint("p:firstSlideNum", true, 0, true, 9999, true) { Application = ApplicationType.PowerPoint });
         }
 
         /// <summary>
@@ -4847,7 +4847,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
   aBuilder.AddValidator(RequiredValidator.Instance);
   aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L) });
 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":val", true, double.NegativeInfinity, true, 2147483625, true) { Application = ApplicationType.PowerPoint });
+            builder.AddConstraint(new AttributeValueRangeConstraint("p:val", true, double.NegativeInfinity, true, 2147483625, true) { Application = ApplicationType.PowerPoint });
         }
 
         /// <inheritdoc/>
@@ -6380,7 +6380,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Presentation.ToPosition), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Presentation.RotationCenter), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":rAng", true, -2147483554, true, 2147483554, true) { Application = ApplicationType.PowerPoint });
+            builder.AddConstraint(new AttributeValueRangeConstraint("p:rAng", true, -2147483554, true, 2147483554, true) { Application = ApplicationType.PowerPoint });
         }
 
         /// <summary>
@@ -6584,9 +6584,9 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Presentation.CommonBehavior), 1, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":by", true, -2147483554, true, 2147483554, true) { Application = ApplicationType.PowerPoint });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":from", true, -2147483554, true, 2147483554, true) { Application = ApplicationType.PowerPoint });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":to", true, -2147483554, true, 2147483554, true) { Application = ApplicationType.PowerPoint });
+            builder.AddConstraint(new AttributeValueRangeConstraint("p:by", true, -2147483554, true, 2147483554, true) { Application = ApplicationType.PowerPoint });
+            builder.AddConstraint(new AttributeValueRangeConstraint("p:from", true, -2147483554, true, 2147483554, true) { Application = ApplicationType.PowerPoint });
+            builder.AddConstraint(new AttributeValueRangeConstraint("p:to", true, -2147483554, true, 2147483554, true) { Application = ApplicationType.PowerPoint });
         }
 
         /// <summary>
@@ -7672,7 +7672,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Presentation.ChildTimeNodeList), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Presentation.SubTimeNodeList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueSetConstraint(":spd", false, new string[] { "0" }) { Application = ApplicationType.PowerPoint });
+            builder.AddConstraint(new AttributeValueSetConstraint("p:spd", false, new string[] { "0" }) { Application = ApplicationType.PowerPoint });
         }
 
         /// <summary>
@@ -9882,8 +9882,8 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Presentation.TimeNodeList), 1, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":lvl", true, double.NegativeInfinity, true, 9, true) { Application = ApplicationType.PowerPoint });
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":lvl", true, "p:tmplLst") { Application = ApplicationType.PowerPoint });
+            builder.AddConstraint(new AttributeValueRangeConstraint("p:lvl", true, double.NegativeInfinity, true, 9, true) { Application = ApplicationType.PowerPoint });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("p:lvl", true, "p:tmplLst") { Application = ApplicationType.PowerPoint });
         }
 
         /// <summary>
@@ -10290,7 +10290,7 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeD
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Presentation.TemplateList), 0, 1)
             };
-            builder.AddConstraint(new ReferenceExistConstraint(":spid", ".", "p:cNvPr", "p:cNvPr", ":id") { Application = ApplicationType.PowerPoint });
+            builder.AddConstraint(new ReferenceExistConstraint("p:spid", ".", "p:cNvPr", "p:cNvPr", "p:id") { Application = ApplicationType.PowerPoint });
         }
 
         /// <summary>
@@ -10412,8 +10412,8 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.Presentation.IndefiniteTimeD
 {
  aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 });
-            builder.AddConstraint(new ReferenceExistConstraint(":grpId", ".", "p:cTn", "p:cTn", ":grpId") { Application = ApplicationType.PowerPoint });
-            builder.AddConstraint(new ReferenceExistConstraint(":spid", ".", "p:cNvPr", "p:cNvPr", ":id") { Application = ApplicationType.PowerPoint });
+            builder.AddConstraint(new ReferenceExistConstraint("p:grpId", ".", "p:cTn", "p:cTn", "p:grpId") { Application = ApplicationType.PowerPoint });
+            builder.AddConstraint(new ReferenceExistConstraint("p:spid", ".", "p:cNvPr", "p:cNvPr", "p:id") { Application = ApplicationType.PowerPoint });
         }
 
         /// <inheritdoc/>
@@ -10539,8 +10539,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 })
 .AddAttribute("animBg", a => a.AnimateBackground);
-            builder.AddConstraint(new ReferenceExistConstraint(":spid", ".", "p:cNvPr", "p:cNvPr", ":id") { Application = ApplicationType.PowerPoint });
-            builder.AddConstraint(new ReferenceExistConstraint(":grpId", ".", "p:cTn", "p:cTn", ":grpId") { Application = ApplicationType.PowerPoint });
+            builder.AddConstraint(new ReferenceExistConstraint("p:spid", ".", "p:cNvPr", "p:cNvPr", "p:id") { Application = ApplicationType.PowerPoint });
+            builder.AddConstraint(new ReferenceExistConstraint("p:grpId", ".", "p:cTn", "p:cTn", "p:grpId") { Application = ApplicationType.PowerPoint });
         }
 
         /// <inheritdoc/>
@@ -10667,8 +10667,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Presentation.BuildAsOne), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Presentation.BuildSubElement), 1, 1)
             };
-            builder.AddConstraint(new ReferenceExistConstraint(":spid", ".", "p:cNvPr", "p:cNvPr", ":id") { Application = ApplicationType.PowerPoint });
-            builder.AddConstraint(new ReferenceExistConstraint(":grpId", ".", "p:cTn", "p:cTn", ":grpId") { Application = ApplicationType.PowerPoint });
+            builder.AddConstraint(new ReferenceExistConstraint("p:spid", ".", "p:cNvPr", "p:cNvPr", "p:id") { Application = ApplicationType.PowerPoint });
+            builder.AddConstraint(new ReferenceExistConstraint("p:grpId", ".", "p:cTn", "p:cTn", "p:grpId") { Application = ApplicationType.PowerPoint });
         }
 
         /// <summary>
@@ -11541,9 +11541,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Presentation.CommentAuthorExtensionList), 0, 1)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", false, null));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":id", true, 0, true, double.PositiveInfinity, true));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":clrIdx", true, "p:cmAuthorLst"));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("p:id", false, null));
+            builder.AddConstraint(new AttributeValueRangeConstraint("p:id", true, 0, true, double.PositiveInfinity, true));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("p:clrIdx", true, "p:cmAuthorLst"));
         }
 
         /// <summary>
@@ -12997,7 +12997,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Presentation.SlideList), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Presentation.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", false, null) { Application = ApplicationType.PowerPoint });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("p:id", false, null) { Application = ApplicationType.PowerPoint });
         }
 
         /// <summary>
@@ -15930,7 +15930,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
     aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", false, "p:tagLst") { Application = ApplicationType.PowerPoint });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("p:name", false, "p:tagLst") { Application = ApplicationType.PowerPoint });
         }
 
         /// <inheritdoc/>
@@ -18433,7 +18433,7 @@ aBuilder.AddValidator(new StringValidator() { InitialVersion = (FileFormatVersio
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Presentation.SoundAction), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Presentation.ExtensionListWithModification), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":advTm", true, 0, true, 2147483647, true) { Application = ApplicationType.PowerPoint });
+            builder.AddConstraint(new AttributeValueRangeConstraint("p:advTm", true, 0, true, 2147483647, true) { Application = ApplicationType.PowerPoint });
         }
 
         /// <inheritdoc/>
@@ -22754,10 +22754,10 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
 {
 aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
-            builder.AddConstraint(new AttributeValueSetConstraint(":cryptAlgorithmSid", true, new string[] { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14" }) { Application = ApplicationType.Word | ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueSetConstraint(":cryptAlgorithmSid", true, new string[] { "1", "2", "3", "4", "12", "13", "14" }) { Application = ApplicationType.PowerPoint });
-            builder.AddConstraint(new AttributeValueSetConstraint(":cryptProviderTypeExtSource", true, new string[] { "wincrypt", "" }) { Application = ApplicationType.PowerPoint });
-            builder.AddConstraint(new AttributeValueSetConstraint(":algIdExtSource", true, new string[] { "wincrypt", "" }) { Application = ApplicationType.PowerPoint });
+            builder.AddConstraint(new AttributeValueSetConstraint("p:cryptAlgorithmSid", true, new string[] { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14" }) { Application = ApplicationType.Word | ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueSetConstraint("p:cryptAlgorithmSid", true, new string[] { "1", "2", "3", "4", "12", "13", "14" }) { Application = ApplicationType.PowerPoint });
+            builder.AddConstraint(new AttributeValueSetConstraint("p:cryptProviderTypeExtSource", true, new string[] { "wincrypt", "" }) { Application = ApplicationType.PowerPoint });
+            builder.AddConstraint(new AttributeValueSetConstraint("p:algIdExtSource", true, new string[] { "wincrypt", "" }) { Application = ApplicationType.PowerPoint });
         }
 
         /// <inheritdoc/>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_spreadsheetml_2006_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_spreadsheetml_2006_main.g.cs
@@ -954,7 +954,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Maps), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.PivotCacheDefinitionExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":refreshedBy", 0, 255));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:refreshedBy", 0, 255));
         }
 
         /// <summary>
@@ -2519,19 +2519,19 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ColumnHierarchiesUsage), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.PivotTableDefinitionExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":autoFormatId", true, 0, true, 16, true));
-            builder.AddConstraint(new ReferenceExistConstraint(":cacheId", "/WorkbookPart", "x:pivotCache", "x:pivotCache", ":cacheId"));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":indent", true, double.NegativeInfinity, true, 127, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":pageWrap", true, double.NegativeInfinity, true, 255, true));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":dataCaption", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:autoFormatId", true, 0, true, 16, true));
+            builder.AddConstraint(new ReferenceExistConstraint("x:cacheId", "/WorkbookPart", "x:pivotCache", "x:pivotCache", "x:cacheId"));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:indent", true, double.NegativeInfinity, true, 127, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:pageWrap", true, double.NegativeInfinity, true, 255, true));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:dataCaption", 0, 255) { Application = ApplicationType.Excel });
             builder.AddConstraint(new AttributeValueLengthConstraint(":grandTotalCaption", 0, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":errorCaption", 0, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":missingCaption", 0, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":pageStyle", 0, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":pivotTableStyle", 0, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":vacatedStyle", 0, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 0, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":tag", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:errorCaption", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:missingCaption", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:pageStyle", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:pivotTableStyle", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:vacatedStyle", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:tag", 0, 255) { Application = ApplicationType.Excel });
         }
 
         /// <summary>
@@ -3230,10 +3230,10 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.QueryTableRefresh), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.QueryTableExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueConditionToAnother(":backgroundRefresh", ":firstBackgroundRefresh", new string[] { "true" }, new string[] { "true" }));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":connectionId", true, 1, true, double.PositiveInfinity, true));
-            builder.AddConstraint(new ReferenceExistConstraint(":connectionId", "/WorkbookPart/ConnectionsPart", "x:connection", "x:connection", ":id"));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 1, 255));
+            builder.AddConstraint(new AttributeValueConditionToAnother("x:backgroundRefresh", "x:firstBackgroundRefresh", new string[] { "true" }, new string[] { "true" }));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:connectionId", true, 1, true, double.PositiveInfinity, true));
+            builder.AddConstraint(new ReferenceExistConstraint("x:connectionId", "/WorkbookPart/ConnectionsPart", "x:connection", "x:connection", "x:id"));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 1, 255));
         }
 
         /// <summary>
@@ -3391,8 +3391,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.SharedStringItem), 0, 0),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":uniqueCount", true, double.NegativeInfinity, true, 2147483647, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":count", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:uniqueCount", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:count", true, double.NegativeInfinity, true, 2147483647, true));
         }
 
         /// <inheritdoc/>
@@ -3698,10 +3698,10 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Header), 1, 0)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":version", true, 1, true, 2147483647, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":preserveHistory", true, 0, true, 32768, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":revisionId", true, double.NegativeInfinity, true, 2147483647, true));
-            builder.AddConstraint(new AttributeValueSetConstraint(":guid", false, new string[] { "00000000-0000-0000-0000-000000000000" }));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:version", true, 1, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:preserveHistory", true, 0, true, 32768, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:revisionId", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueSetConstraint("x:guid", false, new string[] { "00000000-0000-0000-0000-000000000000" }));
         }
 
         /// <inheritdoc/>
@@ -3939,7 +3939,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.UserInfo), 0, 256)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":count", true, double.NegativeInfinity, true, 256, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:count", true, double.NegativeInfinity, true, 256, true) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -5959,21 +5959,21 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.TableStyleInfo), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.TableExtensionList), 0, 1)
             };
-            builder.AddConstraint(new IndexReferenceConstraint(":dataDxfId", "/WorkbookPart/WorkbookStylesPart", null, "x:dxf", "x:dxf", 0));
-            builder.AddConstraint(new IndexReferenceConstraint(":headerRowBorderDxfId", "/WorkbookPart/WorkbookStylesPart", null, "x:dxf", "x:dxf", 0));
-            builder.AddConstraint(new IndexReferenceConstraint(":headerRowDxfId", "/WorkbookPart/WorkbookStylesPart", null, "x:dxf", "x:dxf", 0));
-            builder.AddConstraint(new IndexReferenceConstraint(":tableBorderDxfId", "/WorkbookPart/WorkbookStylesPart", null, "x:dxf", "x:dxf", 0));
-            builder.AddConstraint(new IndexReferenceConstraint(":totalsRowBorderDxfId", "/WorkbookPart/WorkbookStylesPart", null, "x:dxf", "x:dxf", 0));
-            builder.AddConstraint(new IndexReferenceConstraint(":totalsRowDxfId", "/WorkbookPart/WorkbookStylesPart", null, "x:dxf", "x:dxf", 0));
-            builder.AddConstraint(new ReferenceExistConstraint(":connectionId", "/WorkbookPart/ConnectionsPart", "x:connection", "x:connection", ":id"));
-            builder.AddConstraint(new AttributeValueSetConstraint(":id", false, new string[] { "0", "" }));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":id", true, 1, true, 4294967294, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 0, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":comment", 0, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":dataCellStyle", 1, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":headerRowCellStyle", 1, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":totalsRowCellStyle", 1, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":connectionId", true, double.NegativeInfinity, true, 2147483647, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new IndexReferenceConstraint("x:dataDxfId", "/WorkbookPart/WorkbookStylesPart", null, "x:dxf", "x:dxf", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:headerRowBorderDxfId", "/WorkbookPart/WorkbookStylesPart", null, "x:dxf", "x:dxf", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:headerRowDxfId", "/WorkbookPart/WorkbookStylesPart", null, "x:dxf", "x:dxf", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:tableBorderDxfId", "/WorkbookPart/WorkbookStylesPart", null, "x:dxf", "x:dxf", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:totalsRowBorderDxfId", "/WorkbookPart/WorkbookStylesPart", null, "x:dxf", "x:dxf", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:totalsRowDxfId", "/WorkbookPart/WorkbookStylesPart", null, "x:dxf", "x:dxf", 0));
+            builder.AddConstraint(new ReferenceExistConstraint("x:connectionId", "/WorkbookPart/ConnectionsPart", "x:connection", "x:connection", "x:id"));
+            builder.AddConstraint(new AttributeValueSetConstraint("x:id", false, new string[] { "0", "" }));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:id", true, 1, true, 4294967294, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:comment", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:dataCellStyle", 1, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:headerRowCellStyle", 1, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:totalsRowCellStyle", 1, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:connectionId", true, double.NegativeInfinity, true, 2147483647, true) { Application = ApplicationType.Excel });
         }
 
         /// <summary>
@@ -7187,15 +7187,15 @@ aBuilder.AddValidator(RequiredValidator.Instance);
   .AddAttribute("l", a => a.NewLevel)
   .AddAttribute("t", a => a.NewThread)
   .AddAttribute("a", a => a.Array);
-            builder.AddConstraint(new AttributeValueRangeConstraint(":cm", true, double.NegativeInfinity, true, 2147483647, true));
-            builder.AddConstraint(new IndexReferenceConstraint(":cm", "/WorkbookPart/CellMetadataPart", "x:cellMetadata", "x:bk", "x:bk", 1));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":vm", true, double.NegativeInfinity, true, 2147483648, true));
-            builder.AddConstraint(new IndexReferenceConstraint(":vm", "/WorkbookPart/CellMetadataPart", "x:valueMetadata", "x:bk", "x:bk", 1));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":s", true, 0, true, 65490, true));
-            builder.AddConstraint(new IndexReferenceConstraint(":s", "/WorkbookPart/WorkbookStylesPart", "x:cellXfs", "x:xf", "x:xf", 0));
-            builder.AddConstraint(new AttributeMutualExclusive(":l", ":s"));
-            builder.AddConstraint(new ReferenceExistConstraint(":i", "/WorkbookPart", "x:sheet", "x:sheet", ":sheetId"));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":i", true, 1, true, 65534, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:cm", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new IndexReferenceConstraint("x:cm", "/WorkbookPart/CellMetadataPart", "x:cellMetadata", "x:bk", "x:bk", 1));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:vm", true, double.NegativeInfinity, true, 2147483648, true));
+            builder.AddConstraint(new IndexReferenceConstraint("x:vm", "/WorkbookPart/CellMetadataPart", "x:valueMetadata", "x:bk", "x:bk", 1));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:s", true, 0, true, 65490, true));
+            builder.AddConstraint(new IndexReferenceConstraint("x:s", "/WorkbookPart/WorkbookStylesPart", "x:cellXfs", "x:xf", "x:xf", 0));
+            builder.AddConstraint(new AttributeMutualExclusive("x:l", "x:s"));
+            builder.AddConstraint(new ReferenceExistConstraint("x:i", "/WorkbookPart", "x:sheet", "x:sheet", "x:sheetId"));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:i", true, 1, true, 65534, true) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -7466,8 +7466,8 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.CommentText), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.CommentProperties), 0, 1, version: FileFormatVersions.Office2010)
             };
-            builder.AddConstraint(new IndexReferenceConstraint(":authorId", ".", null, "x:author", "x:author", 0));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":guid", false, null));
+            builder.AddConstraint(new IndexReferenceConstraint("x:authorId", ".", null, "x:author", "x:author", 0));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:guid", false, null));
         }
 
         /// <summary>
@@ -7574,10 +7574,10 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("x:t");
-            builder.AddConstraint(new AttributeValueRangeConstraint(":si", true, double.NegativeInfinity, true, 2147483647, true));
-            builder.AddConstraint(new IndexReferenceConstraint(":si", "/WorkbookPart/CellMetadataPart", "x:metadataStrings", "x:s", "x:s", 0));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":c", true, double.NegativeInfinity, true, 2147483647, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":fi", true, double.NegativeInfinity, true, 58, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:si", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new IndexReferenceConstraint("x:si", "/WorkbookPart/CellMetadataPart", "x:metadataStrings", "x:s", "x:s", 0));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:c", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:fi", true, double.NegativeInfinity, true, 58, true));
         }
 
         /// <inheritdoc/>
@@ -8262,10 +8262,10 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
             {
                 new AnyParticle(0, 1)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":ID", true, null));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":ID", 0, 65535) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":SchemaRef", 0, 65535) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":Namespace", 0, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:ID", true, null));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:ID", 0, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:SchemaRef", 0, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:Namespace", 0, 65535) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -8509,10 +8509,10 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.DataBinding), 0, 1)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":SchemaID", true, null));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":Name", 0, 65535));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":RootElement", 0, 65535));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":ID", true, 1, true, 2147483647, true));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:SchemaID", true, null));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:Name", 0, 65535));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:RootElement", 0, 65535));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:ID", true, 1, true, 2147483647, true));
         }
 
         /// <summary>
@@ -8670,15 +8670,15 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new AnyParticle(0, 1)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":DataBindingName", true, null));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":FileBindingName", true, null));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":DataBindingLoadMode", true, 0, true, 4, true));
-            builder.AddConstraint(new AttributeAbsentConditionToValue(":ConnectionID", ":FileBinding", "false"));
-            builder.AddConstraint(new AttributeRequiredConditionToValue(":ConnectionID", ":FileBinding", "true"));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":DataBindingName", 0, 65535) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":FileBindingName", 0, 65535) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":ConnectionID", true, double.NegativeInfinity, true, 2147483647, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeAbsentConditionToValue(":FileBindingName", ":FileBinding", "false") { Application = ApplicationType.Excel });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:DataBindingName", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:FileBindingName", true, null));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:DataBindingLoadMode", true, 0, true, 4, true));
+            builder.AddConstraint(new AttributeAbsentConditionToValue("x:ConnectionID", "x:FileBinding", "false"));
+            builder.AddConstraint(new AttributeRequiredConditionToValue("x:ConnectionID", "x:FileBinding", "true"));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:DataBindingName", 0, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:FileBindingName", 0, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:ConnectionID", true, double.NegativeInfinity, true, 2147483647, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeAbsentConditionToValue("x:FileBindingName", "x:FileBinding", "false") { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -9103,15 +9103,15 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Parameters), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ConnectionExtensionList), 0, 1)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", true, null));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":type", true, 1, true, 8, true));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", true, null));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":interval", true, double.NegativeInfinity, true, 32767, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 1, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":description", 0, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":singleSignOnId", 0, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":odcFile", 0, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":sourceFile", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:name", true, null));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:type", true, 1, true, 8, true));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:id", true, null));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:interval", true, double.NegativeInfinity, true, 32767, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 1, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:description", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:singleSignOnId", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:odcFile", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:sourceFile", 0, 255) { Application = ApplicationType.Excel });
         }
 
         /// <summary>
@@ -9474,11 +9474,11 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 .AddAttribute("integer", a => a.Integer)
 .AddAttribute("string", a => a.String)
 .AddAttribute("cell", a => a.Cell);
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 0, 255));
-            builder.AddConstraint(new AttributeValueSetConstraint(":sqlType", true, new string[] { "-22", "-20", "-11", "-10", "-9", "-8", "-7", "-6", "-5", "-4", "-3", "-2", "-1", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "101", "102", "103", "104", "105", "106", "107", "108", "109", "110", "111", "112", "113" }));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":string", 0, 255));
-            builder.AddConstraint(new AttributeRequiredConditionToValue(":cell", ":parameterType", "cell"));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":prompt", 0, 65535));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 0, 255));
+            builder.AddConstraint(new AttributeValueSetConstraint("x:sqlType", true, new string[] { "-22", "-20", "-11", "-10", "-9", "-8", "-7", "-6", "-5", "-4", "-3", "-2", "-1", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "101", "102", "103", "104", "105", "106", "107", "108", "109", "110", "111", "112", "113" }));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:string", 0, 255));
+            builder.AddConstraint(new AttributeRequiredConditionToValue("x:cell", "x:parameterType", "cell"));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:prompt", 0, 65535));
         }
 
         /// <inheritdoc/>
@@ -9506,8 +9506,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("x:m");
-            builder.AddConstraint(new IndexReferenceConstraint(":in", ".", null, "x:serverFormat", "x:serverFormat", 0));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":c", 0, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new IndexReferenceConstraint("x:in", ".", null, "x:serverFormat", "x:serverFormat", 0));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:c", 0, 65535) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -9556,8 +9556,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
   {
       aBuilder.AddValidator(RequiredValidator.Instance);
   });
-            builder.AddConstraint(new IndexReferenceConstraint(":in", ".", null, "x:serverFormat", "x:serverFormat", 0));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":c", 0, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new IndexReferenceConstraint("x:in", ".", null, "x:serverFormat", "x:serverFormat", 0));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:c", 0, 65535) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -9668,7 +9668,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             builder.AddElement<TextField>()
 .AddAttribute("type", a => a.Type)
 .AddAttribute("position", a => a.Position);
-            builder.AddConstraint(new AttributeValueRangeConstraint(":position", true, 0, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:position", true, 0, true, 2147483647, true));
         }
 
         /// <inheritdoc/>
@@ -9965,7 +9965,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.MemberPropertiesMap), 0, 0),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.CacheFieldExtensionList), 0, 1)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:name", true, null));
         }
 
         /// <summary>
@@ -10447,8 +10447,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 .AddAttribute("name", a => a.Name)
 .AddAttribute("sheet", a => a.Sheet)
 .AddAttribute("r:id", a => a.Id);
-            builder.AddConstraint(new AttributeMutualExclusive(":name", ":ref"));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":sheet", 1, 31));
+            builder.AddConstraint(new AttributeMutualExclusive("x:name", "x:ref"));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:sheet", 1, 31));
         }
 
         /// <inheritdoc/>
@@ -10708,8 +10708,8 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Tuples), 0, 0),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.MemberPropertyIndex), 0, 0)
             };
-            builder.AddConstraint(new IndexReferenceConstraint(":in", ".", null, "x:serverFormat", "x:serverFormat", 0));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":c", 0, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new IndexReferenceConstraint("x:in", ".", null, "x:serverFormat", "x:serverFormat", 0));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:c", 0, 65535) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -10989,11 +10989,11 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Tuples), 0, 0),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.MemberPropertyIndex), 0, 0)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":x", true, 0, true, double.PositiveInfinity, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":x", true, double.NegativeInfinity, true, 2147483647, true));
-            builder.AddConstraint(new IndexReferenceConstraint(":in", ".", null, "x:serverFormat", "x:serverFormat", 0));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":c", 0, 65535) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueSetConstraint(":v", false, new string[] { "INF", "-INF", "NaN" }) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:x", true, 0, true, double.PositiveInfinity, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:x", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new IndexReferenceConstraint("x:in", ".", null, "x:serverFormat", "x:serverFormat", 0));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:c", 0, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueSetConstraint("x:v", false, new string[] { "INF", "-INF", "NaN" }) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -11145,7 +11145,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.MemberPropertyIndex), 0, 0)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":c", 0, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:c", 0, 65535) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -11425,8 +11425,8 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Tuples), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.MemberPropertyIndex), 0, 0)
             };
-            builder.AddConstraint(new IndexReferenceConstraint(":in", ".", null, "x:serverFormat", "x:serverFormat", 0));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":c", 0, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new IndexReferenceConstraint("x:in", ".", null, "x:serverFormat", "x:serverFormat", 0));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:c", 0, 65535) { Application = ApplicationType.Excel });
         }
 
         /// <summary>
@@ -11719,8 +11719,8 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Tuples), 0, 0),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.MemberPropertyIndex), 0, 0)
             };
-            builder.AddConstraint(new IndexReferenceConstraint(":in", ".", null, "x:serverFormat", "x:serverFormat", 0));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":c", 0, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new IndexReferenceConstraint("x:in", ".", null, "x:serverFormat", "x:serverFormat", 0));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:c", 0, 65535) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -11872,7 +11872,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.MemberPropertyIndex), 0, 0)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":c", 0, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:c", 0, 65535) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -12118,7 +12118,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("x:mpMap");
-            builder.AddConstraint(new IndexReferenceConstraint(":v", ".", null, "x:cacheField", "x:cacheField", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:v", ".", null, "x:cacheField", "x:cacheField", 0));
         }
 
         /// <inheritdoc/>
@@ -12444,16 +12444,16 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 .AddAttribute("status", a => a.Status)
 .AddAttribute("trend", a => a.Trend)
 .AddAttribute("weight", a => a.Weight);
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":goal", true, null));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":status", true, null));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":trend", true, null));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":uniqueName", true, null));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":value", true, null));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":weight", true, null));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":caption", 1, 32767) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":displayFolder", 0, 65535) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":measureGroup", 0, 65535) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":parent", 0, 32767) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:goal", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:status", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:trend", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:uniqueName", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:value", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:weight", true, null));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:caption", 1, 32767) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:displayFolder", 0, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:measureGroup", 0, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:parent", 0, 32767) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -12502,8 +12502,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
 aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new IndexReferenceConstraint(":x", ".", null, "x:cacheField", "x:cacheField", 0));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":x", true, -1, true, double.PositiveInfinity, true));
+            builder.AddConstraint(new IndexReferenceConstraint("x:x", ".", null, "x:cacheField", "x:cacheField", 0));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:x", true, -1, true, double.PositiveInfinity, true));
         }
 
         /// <inheritdoc/>
@@ -12644,7 +12644,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Groups), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":uniqueName", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:uniqueName", true, null));
         }
 
         /// <summary>
@@ -12908,10 +12908,10 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.GroupMembers), 1, 1)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", true, "x:groups"));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":id", true, 1, true, double.PositiveInfinity, true));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":uniqueParent", 0, 65535));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":uniqueName", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:id", true, "x:groups"));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:id", true, 1, true, double.PositiveInfinity, true));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:uniqueParent", 0, 65535));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:uniqueName", true, null));
         }
 
         /// <summary>
@@ -13070,8 +13070,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute("group", a => a.Group);
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":uniqueName", true, null));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":uniqueName", 1, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:uniqueName", true, null));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:uniqueName", 1, 65535) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -13463,9 +13463,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             builder.AddElement<ServerFormat>()
 .AddAttribute("culture", a => a.Culture)
 .AddAttribute("format", a => a.Format);
-            builder.AddConstraint(new AttributeMutualExclusive(":culture", ":format"));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":culture", 0, 31));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":format", 0, 65535));
+            builder.AddConstraint(new AttributeMutualExclusive("x:culture", "x:format"));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:culture", 0, 31));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:format", 0, 65535));
         }
 
         /// <inheritdoc/>
@@ -13548,9 +13548,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
     aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new IndexReferenceConstraint(":fld", ".", null, "x:cacheField", "x:cacheField", 0));
-            builder.AddConstraint(new IndexReferenceConstraint(":hier", ".", null, "x:cacheHierarchy", "x:cacheHierarchy", 0));
-            builder.AddConstraint(new AttributeMutualExclusive(":fld", ":hier") { Application = ApplicationType.Excel });
+            builder.AddConstraint(new IndexReferenceConstraint("x:fld", ".", null, "x:cacheField", "x:cacheField", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:hier", ".", null, "x:cacheHierarchy", "x:cacheHierarchy", 0));
+            builder.AddConstraint(new AttributeMutualExclusive("x:fld", "x:hier") { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -13708,8 +13708,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Tuples), 0, 0),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.SortByTuple), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":setDefinition", 0, 65535) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":maxRank", true, 0, true, 1048576, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:setDefinition", 0, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:maxRank", true, 0, true, 1048576, true) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -13793,7 +13793,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Tuples), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":mdx", 0, 65535));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:mdx", 0, 65535));
         }
 
         /// <summary>
@@ -14203,7 +14203,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.PivotAreaReferences), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":fieldPosition", true, 0, true, 255, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:fieldPosition", true, 0, true, 255, true));
         }
 
         /// <summary>
@@ -14418,15 +14418,15 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.CalculatedMemberExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 1, 63999));
-            builder.AddConstraint(new AttributeAbsentConditionToValue(":hierarchy", ":set", "1"));
-            builder.AddConstraint(new AttributeRequiredConditionToValue(":hierarchy", ":set", "0"));
-            builder.AddConstraint(new AttributeAbsentConditionToValue(":parent", ":set", "1"));
-            builder.AddConstraint(new AttributeAbsentConditionToValue(":memberName", ":set", "1"));
-            builder.AddConstraint(new AttributeRequiredConditionToValue(":memberName", ":set", "0"));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":memberName", 1, 65535) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":hierarchy", 1, 65535) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":parent", 1, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 1, 63999));
+            builder.AddConstraint(new AttributeAbsentConditionToValue("x:hierarchy", "x:set", "1"));
+            builder.AddConstraint(new AttributeRequiredConditionToValue("x:hierarchy", "x:set", "0"));
+            builder.AddConstraint(new AttributeAbsentConditionToValue("x:parent", "x:set", "1"));
+            builder.AddConstraint(new AttributeAbsentConditionToValue("x:memberName", "x:set", "1"));
+            builder.AddConstraint(new AttributeRequiredConditionToValue("x:memberName", "x:set", "0"));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:memberName", 1, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:hierarchy", 1, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:parent", 1, 65535) { Application = ApplicationType.Excel });
         }
 
         /// <summary>
@@ -15325,7 +15325,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.AutoSortScope), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.PivotFieldExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueSetConstraint(":axis", false, new string[] { "axisValues" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("x:axis", false, new string[] { "axisValues" }));
         }
 
         /// <summary>
@@ -15580,9 +15580,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 .AddAttribute("x", a => a.Index)
 .AddAttribute("d", a => a.Expanded)
 .AddAttribute("e", a => a.DrillAcrossAttributes);
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":n", true, "x:pivotField"));
-            builder.AddConstraint(new AttributeValueSetConstraint(":t", false, new string[] { "blank", "grand" }));
-            builder.AddConstraint(new AttributeRequiredConditionToValue(":x", ":t", "data") { Application = ApplicationType.Excel });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:n", true, "x:pivotField"));
+            builder.AddConstraint(new AttributeValueSetConstraint("x:t", false, new string[] { "blank", "grand" }));
+            builder.AddConstraint(new AttributeRequiredConditionToValue("x:x", "x:t", "data") { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -15768,7 +15768,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.DataFieldExtensionList), 0, 1)
             };
-            builder.AddConstraint(new IndexReferenceConstraint(":fld", ".", null, "x:pivotField", "x:pivotField", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:fld", ".", null, "x:pivotField", "x:pivotField", 0));
         }
 
         /// <summary>
@@ -15896,7 +15896,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.MemberPropertyIndex), 0, 0)
             };
-            builder.AddConstraint(new IndexReferenceConstraint(":i", ".", null, "x:dataField", "x:dataField", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:i", ".", null, "x:dataField", "x:dataField", 0));
         }
 
         /// <inheritdoc/>
@@ -15945,7 +15945,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
   aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":x", true, "x:colFields"));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:x", true, "x:colFields"));
         }
 
         /// <inheritdoc/>
@@ -16046,7 +16046,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.PivotArea), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new IndexReferenceConstraint(":dxfId", "/WorkbookPart/WorkbookStylesPart", null, "x:dxf", "x:dxf", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:dxfId", "/WorkbookPart/WorkbookStylesPart", null, "x:dxf", "x:dxf", 0));
         }
 
         /// <summary>
@@ -16193,7 +16193,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.PivotAreas), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueConditionToAnother(":type", ":scope", new string[] { "none", "all" }, new string[] { "data", "selection" }));
+            builder.AddConstraint(new AttributeValueConditionToAnother("x:type", "x:scope", new string[] { "none", "all" }, new string[] { "data", "selection" }));
         }
 
         /// <summary>
@@ -16689,7 +16689,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Members), 0, 0),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.PivotHierarchyExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":caption", 0, 65535));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:caption", 0, 65535));
         }
 
         /// <summary>
@@ -16982,7 +16982,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
  {
      aBuilder.AddValidator(RequiredValidator.Instance);
  });
-            builder.AddConstraint(new IndexReferenceConstraint(":field", "PivotTableCacheDefinitionPart", null, "x:cacheField", "x:cacheField", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:field", "PivotTableCacheDefinitionPart", null, "x:cacheField", "x:cacheField", 0));
         }
 
         /// <inheritdoc/>
@@ -17136,10 +17136,10 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
 aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":uniqueName", true, null));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":caption", 1, 65535) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 1, 65535) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":uniqueName", 1, 32767) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:uniqueName", true, null));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:caption", 1, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 1, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:uniqueName", 1, 32767) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -17208,8 +17208,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
 aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":caption", 1, 65535) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 1, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:caption", 1, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 1, 65535) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -17540,10 +17540,10 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.AutoFilter), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.PivotFilterExtensionList), 0, 1)
             };
-            builder.AddConstraint(new IndexReferenceConstraint(":fld", ".", null, "x:pivotField", "x:pivotField", 0));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", false, null));
-            builder.AddConstraint(new IndexReferenceConstraint(":iMeasureFld", ".", null, "x:pivotField", "x:pivotField", 0));
-            builder.AddConstraint(new IndexReferenceConstraint(":iMeasureHier", ".", null, "x:pivotHierarchy", "x:pivotHierarchy", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:fld", ".", null, "x:pivotField", "x:pivotField", 0));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:id", false, null));
+            builder.AddConstraint(new IndexReferenceConstraint("x:iMeasureFld", ".", null, "x:pivotField", "x:pivotField", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:iMeasureHier", ".", null, "x:pivotHierarchy", "x:pivotHierarchy", 0));
         }
 
         /// <summary>
@@ -18019,12 +18019,12 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.GroupLevels), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.CacheHierarchyExtensionList), 0, 1)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":allUniqueName", true, null));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":defaultMemberUniqueName", true, null));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":uniqueName", true, null));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":displayFolder", 0, 65535) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":measureGroup", 0, 65535) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":iconSet", true, 0, true, 11, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:allUniqueName", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:defaultMemberUniqueName", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:uniqueName", true, null));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:displayFolder", 0, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:measureGroup", 0, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:iconSet", true, 0, true, 11, true) { Application = ApplicationType.Excel });
         }
 
         /// <summary>
@@ -18228,7 +18228,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 .AddAttribute("startDate", a => a.StartDate)
 .AddAttribute("endDate", a => a.EndDate)
 .AddAttribute("groupInterval", a => a.GroupInterval);
-            builder.AddConstraint(new AttributeValueLessEqualToAnother(":startNum", ":endNum", false));
+            builder.AddConstraint(new AttributeValueLessEqualToAnother("x:startNum", "x:endNum", false));
         }
 
         /// <inheritdoc/>
@@ -18555,8 +18555,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new IndexReferenceConstraint(":fld", "PivotTableCacheDefinitionPart", null, "x:cacheField", "x:cacheField", 0));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", true, null));
+            builder.AddConstraint(new IndexReferenceConstraint("x:fld", "PivotTableCacheDefinitionPart", null, "x:cacheField", "x:cacheField", 0));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:name", true, null));
         }
 
         /// <summary>
@@ -19213,7 +19213,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
 aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 1, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 1, 255) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -19399,12 +19399,12 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", true, null));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", true, null));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 0, 255));
-            builder.AddConstraint(new AttributeValueConditionToAnother(":dataBound", ":clipped", new string[] { "true" }, new string[] { "true" }));
-            builder.AddConstraint(new AttributeValueConditionToAnother(":dataBound", ":fillFormulas", new string[] { "false" }, new string[] { "true" }));
-            builder.AddConstraint(new AttributeValueConditionToAnother(":dataBound", ":rowNumbers", new string[] { "true" }, new string[] { "true" }));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:id", true, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:name", true, null));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 0, 255));
+            builder.AddConstraint(new AttributeValueConditionToAnother("x:dataBound", "x:clipped", new string[] { "true" }, new string[] { "true" }));
+            builder.AddConstraint(new AttributeValueConditionToAnother("x:dataBound", "x:fillFormulas", new string[] { "false" }, new string[] { "true" }));
+            builder.AddConstraint(new AttributeValueConditionToAnother("x:dataBound", "x:rowNumbers", new string[] { "true" }, new string[] { "true" }));
         }
 
         /// <summary>
@@ -19716,7 +19716,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("x:b");
-            builder.AddConstraint(new AttributeValueLengthConstraint(":c", 0, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:c", 0, 65535) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -19744,7 +19744,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("x:i");
-            builder.AddConstraint(new IndexReferenceConstraint(":i", ".", null, "x:dataField", "x:dataField", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:i", ".", null, "x:dataField", "x:dataField", 0));
         }
 
         /// <inheritdoc/>
@@ -20059,7 +20059,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
  {
      aBuilder.AddValidator(RequiredValidator.Instance);
  });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":val", true, 1, true, 409.55, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:val", true, 1, true, 409.55, true));
         }
 
         /// <inheritdoc/>
@@ -20087,9 +20087,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("x:color");
-            builder.AddConstraint(new AttributeValueRangeConstraint(":tint", true, -1, true, 1, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":indexed", true, double.NegativeInfinity, true, 255, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":theme", true, 0, true, 255, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:tint", true, -1, true, 1, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:indexed", true, double.NegativeInfinity, true, 255, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:theme", true, 0, true, 255, true) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -20117,8 +20117,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("x:tabColor");
-            builder.AddConstraint(new AttributeMutualExclusive(":auto", ":indexed", ":rgb", ":theme"));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":tint", true, -1, true, 1, true));
+            builder.AddConstraint(new AttributeMutualExclusive("x:auto", "x:indexed", "x:rgb", "x:theme"));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:tint", true, -1, true, 1, true));
         }
 
         /// <inheritdoc/>
@@ -20146,7 +20146,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("x:fgColor");
-            builder.AddConstraint(new AttributeValueRangeConstraint(":tint", true, -1, true, 1, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:tint", true, -1, true, 1, true));
         }
 
         /// <inheritdoc/>
@@ -20174,7 +20174,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("x:bgColor");
-            builder.AddConstraint(new AttributeValueRangeConstraint(":tint", true, -1, true, 1, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:tint", true, -1, true, 1, true));
         }
 
         /// <inheritdoc/>
@@ -20332,7 +20332,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
   aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":val", 0, 31));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:val", 0, 31));
         }
 
         /// <inheritdoc/>
@@ -20360,7 +20360,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("x:family");
-            builder.AddConstraint(new AttributeValueRangeConstraint(":val", true, 0, true, 5, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:val", true, 0, true, 5, true) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -20388,7 +20388,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("x:charset");
-            builder.AddConstraint(new AttributeValueRangeConstraint(":val", true, 0, true, 255, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:val", true, 0, true, 255, true));
         }
 
         /// <inheritdoc/>
@@ -20776,7 +20776,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Text), 1, 1)
             };
-            builder.AddConstraint(new AttributeValueLessEqualToAnother(":sb", ":eb", false));
+            builder.AddConstraint(new AttributeValueLessEqualToAnother("x:sb", "x:eb", false));
         }
 
         /// <summary>
@@ -20872,7 +20872,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute("type", a => a.Type)
 .AddAttribute("alignment", a => a.Alignment);
-            builder.AddConstraint(new IndexReferenceConstraint(":fontId", "/WorkbookPart/WorkbookStylesPart", null, "x:font", "x:font", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:fontId", "/WorkbookPart/WorkbookStylesPart", null, "x:font", "x:font", 0));
         }
 
         /// <inheritdoc/>
@@ -21080,9 +21080,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ReviewedList), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":maxSheetId", true, double.NegativeInfinity, true, 32767, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":userName", 1, 54) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":minRId", true, double.NegativeInfinity, true, 2147483647, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:maxSheetId", true, double.NegativeInfinity, true, 32767, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:userName", 1, 54) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:minRId", true, double.NegativeInfinity, true, 2147483647, true) { Application = ApplicationType.Excel });
         }
 
         /// <summary>
@@ -21339,7 +21339,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.RevisionCellChange), 0, 0),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.RevisionFormat), 0, 0)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":sId", 0, 32767));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:sId", 0, 32767));
         }
 
         /// <inheritdoc/>
@@ -21540,8 +21540,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.RevisionCellChange), 0, 0),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.RevisionFormat), 0, 0)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":sheetId", true, double.NegativeInfinity, true, 32767, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":sourceSheetId", true, double.NegativeInfinity, true, 32767, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:sheetId", true, double.NegativeInfinity, true, 32767, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:sourceSheetId", true, double.NegativeInfinity, true, 32767, true));
         }
 
         /// <inheritdoc/>
@@ -21788,7 +21788,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":sheetId", 0, 32767));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:sheetId", 0, 32767));
         }
 
         /// <summary>
@@ -21944,8 +21944,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
     aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":sheetId", true, double.NegativeInfinity, true, 32767, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":sheetPosition", true, double.NegativeInfinity, true, 65533, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:sheetId", true, double.NegativeInfinity, true, 32767, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:sheetPosition", true, double.NegativeInfinity, true, 65533, true) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -22265,7 +22265,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.NewDifferentialFormat), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":sId", true, double.NegativeInfinity, true, 32767, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:sId", true, double.NegativeInfinity, true, 32767, true) { Application = ApplicationType.Excel });
         }
 
         /// <summary>
@@ -22505,7 +22505,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.DifferentialFormat), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":sheetId", true, 0, true, 32767, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:sheetId", true, 0, true, 32767, true));
         }
 
         /// <summary>
@@ -22719,8 +22719,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
     aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":autoFormatId", true, 0, true, 16, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":sheetId", true, double.NegativeInfinity, true, 32767, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:autoFormatId", true, 0, true, 16, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:sheetId", true, double.NegativeInfinity, true, 32767, true) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -23204,21 +23204,21 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.OldFormula), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":functionGroupId", true, 1, true, 14, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":localSheetId", true, double.NegativeInfinity, true, 32767, true));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":customMenu", 0, 32767));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":oldCustomMenu", 0, 32767));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":description", 0, 32767));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":oldDescription", 0, 32767));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":help", 0, 32767));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":oldHelp", 0, 32767));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":statusBar", 0, 32767));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":oldStatusBar", 0, 32767));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", true, "x:revisions"));
-            builder.AddConstraint(new AttributeValuePatternConstraint(":name", @"[a-zA-Z_\\][a-zA-Z0-9_.]*"));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":comment", 0, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":oldComment", 0, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":rId", true, double.NegativeInfinity, true, 2147483647, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:functionGroupId", true, 1, true, 14, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:localSheetId", true, double.NegativeInfinity, true, 32767, true));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:customMenu", 0, 32767));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:oldCustomMenu", 0, 32767));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:description", 0, 32767));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:oldDescription", 0, 32767));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:help", 0, 32767));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:oldHelp", 0, 32767));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:statusBar", 0, 32767));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:oldStatusBar", 0, 32767));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:name", true, "x:revisions"));
+            builder.AddConstraint(new AttributeValuePatternConstraint("x:name", @"[a-zA-Z_\\][a-zA-Z0-9_.]*"));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:comment", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:oldComment", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:rId", true, double.NegativeInfinity, true, 2147483647, true) { Application = ApplicationType.Excel });
         }
 
         /// <summary>
@@ -23486,7 +23486,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute("oldLength", a => a.OldLength)
 .AddAttribute("newLength", a => a.NewLength);
-            builder.AddConstraint(new AttributeValueLengthConstraint(":author", 1, 52));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:author", 1, 52));
         }
 
         /// <inheritdoc/>
@@ -23674,7 +23674,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 .AddAttribute("ua", a => a.Ua)
 .AddAttribute("ra", a => a.Ra)
 .AddAttribute("sheetId", a => a.SheetId);
-            builder.AddConstraint(new AttributeValueRangeConstraint(":sheetId", true, 0, true, 32767, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:sheetId", true, 0, true, 32767, true));
         }
 
         /// <inheritdoc/>
@@ -23883,7 +23883,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
 aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":rId", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:rId", true, double.NegativeInfinity, true, 2147483647, true));
         }
 
         /// <inheritdoc/>
@@ -24108,10 +24108,10 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 .AddAttribute("dn", a => a.DefinedName)
 .AddAttribute("r", a => a.CellReference)
 .AddAttribute("sId", a => a.SheetId);
-            builder.AddConstraint(new AttributeValueRangeConstraint(":sId", true, double.NegativeInfinity, true, 32767, true));
-            builder.AddConstraint(new AttributeValueConditionToAnother(":ref3D", ":nf", new string[] { "false" }, new string[] { "true" }));
-            builder.AddConstraint(new AttributeMutualExclusive(":dn", ":r"));
-            builder.AddConstraint(new AttributeMutualExclusive(":dn", ":sId"));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:sId", true, double.NegativeInfinity, true, 32767, true));
+            builder.AddConstraint(new AttributeValueConditionToAnother("x:ref3D", "x:nf", new string[] { "false" }, new string[] { "true" }));
+            builder.AddConstraint(new AttributeMutualExclusive("x:dn", "x:r"));
+            builder.AddConstraint(new AttributeMutualExclusive("x:dn", "x:sId"));
         }
 
         /// <inheritdoc/>
@@ -24179,9 +24179,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.InlineString), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new IndexReferenceConstraint(":cm", "/WorkbookPart/CellMetadataPart", null, "x:cellMetadata", "x:cellMetadata", 0));
-            builder.AddConstraint(new IndexReferenceConstraint(":s", "/WorkbookPart/WorkbookStylesPart", null, "x:cellStyle", "x:cellStyle", 0));
-            builder.AddConstraint(new IndexReferenceConstraint(":vm", "/WorkbookPart/CellMetadataPart", null, "x:valueMetadata", "x:valueMetadata", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:cm", "/WorkbookPart/CellMetadataPart", null, "x:cellMetadata", "x:cellMetadata", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:s", "/WorkbookPart/WorkbookStylesPart", null, "x:cellStyle", "x:cellStyle", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:vm", "/WorkbookPart/CellMetadataPart", null, "x:valueMetadata", "x:valueMetadata", 0));
         }
 
         /// <inheritdoc/>
@@ -24249,15 +24249,15 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.InlineString), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":cm", true, double.NegativeInfinity, true, 2147483647, true));
-            builder.AddConstraint(new IndexReferenceConstraint(":cm", "/WorkbookPart/CellMetadataPart", "x:cellMetadata", "x:bk", "x:bk", 1));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":vm", true, double.NegativeInfinity, true, 2147483648, true));
-            builder.AddConstraint(new IndexReferenceConstraint(":vm", "/WorkbookPart/CellMetadataPart", "x:valueMetadata", "x:bk", "x:bk", 1));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":s", true, 0, true, 65490, true));
-            builder.AddConstraint(new IndexReferenceConstraint(":s", "/WorkbookPart/WorkbookStylesPart", "x:cellXfs", "x:xf", "x:xf", 0));
-            builder.AddConstraint(new AttributeMutualExclusive(":l", ":s"));
-            builder.AddConstraint(new ReferenceExistConstraint(":i", "/WorkbookPart", "x:sheet", "x:sheet", ":sheetId"));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":i", true, 1, true, 65534, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:cm", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new IndexReferenceConstraint("x:cm", "/WorkbookPart/CellMetadataPart", "x:cellMetadata", "x:bk", "x:bk", 1));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:vm", true, double.NegativeInfinity, true, 2147483648, true));
+            builder.AddConstraint(new IndexReferenceConstraint("x:vm", "/WorkbookPart/CellMetadataPart", "x:valueMetadata", "x:bk", "x:bk", 1));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:s", true, 0, true, 65490, true));
+            builder.AddConstraint(new IndexReferenceConstraint("x:s", "/WorkbookPart/WorkbookStylesPart", "x:cellXfs", "x:xf", "x:xf", 0));
+            builder.AddConstraint(new AttributeMutualExclusive("x:l", "x:s"));
+            builder.AddConstraint(new ReferenceExistConstraint("x:i", "/WorkbookPart", "x:sheet", "x:sheet", "x:sheetId"));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:i", true, 1, true, 65534, true) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -24647,9 +24647,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.InlineString), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueSetConstraint(":cm", true, new string[] { "0" }) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueSetConstraint(":vm", true, new string[] { "0" }) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueSetConstraint(":s", true, new string[] { "0" }) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueSetConstraint("x:cm", true, new string[] { "0" }) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueSetConstraint("x:vm", true, new string[] { "0" }) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueSetConstraint("x:s", true, new string[] { "0" }) { Application = ApplicationType.Excel });
         }
 
         /// <summary>
@@ -25123,7 +25123,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
 aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":val", true, double.NegativeInfinity, true, 65535, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:val", true, double.NegativeInfinity, true, 65535, true));
         }
 
         /// <inheritdoc/>
@@ -25389,8 +25389,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
   .AddAttribute("si", a => a.SharedIndex)
   .AddAttribute("bx", a => a.Bx)
   .AddAttribute("xml:space", a => a.Space);
-            builder.AddConstraint(new AttributeValueSetConstraint(":bx", true, new string[] { "false" }));
-            builder.AddConstraint(new AttributeRequiredConditionToValue(":si", ":t", "shared"));
+            builder.AddConstraint(new AttributeValueSetConstraint("x:bx", true, new string[] { "false" }));
+            builder.AddConstraint(new AttributeRequiredConditionToValue("x:si", "x:t", "shared"));
         }
 
         /// <inheritdoc/>
@@ -25841,10 +25841,10 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Cell), 0, 0),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":r", true, 1, true, 1048576, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":outlineLevel", true, 0, true, 7, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":s", true, 0, true, 65490, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":r", true, double.NegativeInfinity, true, 1048576, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:r", true, 1, true, 1048576, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:outlineLevel", true, 0, true, 7, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:s", true, 0, true, 65490, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:r", true, double.NegativeInfinity, true, 1048576, true));
         }
 
         /// <inheritdoc/>
@@ -26049,13 +26049,13 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
 .AddAttribute("phonetic", a => a.Phonetic)
 .AddAttribute("outlineLevel", a => a.OutlineLevel)
 .AddAttribute("collapsed", a => a.Collapsed);
-            builder.AddConstraint(new AttributeValueRangeConstraint(":outlineLevel", true, 0, true, 7, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":min", true, 1, true, 16384, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":max", true, 1, true, 16384, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":width", true, 0, true, 255, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":style", true, 0, true, 65429, true));
-            builder.AddConstraint(new IndexReferenceConstraint(":style", "/WorkbookPart/WorkbookStylesPart", null, "x:xf", "x:xf", 0));
-            builder.AddConstraint(new AttributeValueLessEqualToAnother(":min", ":max", true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:outlineLevel", true, 0, true, 7, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:min", true, 1, true, 16384, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:max", true, 1, true, 16384, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:width", true, 0, true, 255, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:style", true, 0, true, 65429, true));
+            builder.AddConstraint(new IndexReferenceConstraint("x:style", "/WorkbookPart/WorkbookStylesPart", null, "x:xf", "x:xf", 0));
+            builder.AddConstraint(new AttributeValueLessEqualToAnother("x:min", "x:max", true) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -26423,7 +26423,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
 .AddAttribute("activeCell", a => a.ActiveCell)
 .AddAttribute("activeCellId", a => a.ActiveCellId)
 .AddAttribute("sqref", a => a.SequenceOfReferences);
-            builder.AddConstraint(new AttributeValueRangeConstraint(":activeCell", true, double.NegativeInfinity, true, 8191, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:activeCell", true, double.NegativeInfinity, true, 8191, true) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -26782,9 +26782,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.PivotArea), 1, 1)
             };
-            builder.AddConstraint(new AttributeValueSetConstraint(":axis", false, new string[] { "axisValues" }));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":previousCol", true, double.NegativeInfinity, true, 16383, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":previousRow", true, double.NegativeInfinity, true, 1048575, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueSetConstraint("x:axis", false, new string[] { "axisValues" }));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:previousCol", true, double.NegativeInfinity, true, 16383, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:previousRow", true, double.NegativeInfinity, true, 1048575, true) { Application = ApplicationType.Excel });
         }
 
         /// <summary>
@@ -26911,9 +26911,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 .AddAttribute("max", a => a.Max)
 .AddAttribute("man", a => a.ManualPageBreak)
 .AddAttribute("pt", a => a.PivotTablePageBreak);
-            builder.AddConstraint(new AttributeValueRangeConstraint(":min", true, double.NegativeInfinity, true, 1048576, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":id", true, 1, true, 1048576, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":max", true, 1, true, 1048576, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:min", true, double.NegativeInfinity, true, 1048576, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:id", true, 1, true, 1048576, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:max", true, 1, true, 1048576, true) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -27074,8 +27074,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Break), 0, 0)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":count", true, double.NegativeInfinity, true, 1022, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":manualBreakCount", true, double.NegativeInfinity, true, 1022, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:count", true, double.NegativeInfinity, true, 1022, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:manualBreakCount", true, double.NegativeInfinity, true, 1022, true));
         }
 
         /// <inheritdoc/>
@@ -27137,8 +27137,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Break), 0, 0)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":count", true, double.NegativeInfinity, true, 1023, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":manualBreakCount", true, double.NegativeInfinity, true, 1023, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:count", true, double.NegativeInfinity, true, 1023, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:manualBreakCount", true, double.NegativeInfinity, true, 1023, true));
         }
 
         /// <inheritdoc/>
@@ -27373,12 +27373,12 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
 aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":left", true, 0, true, 49, false));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":right", true, 0, true, 49, false));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":top", true, 0, true, 49, false));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":bottom", true, 0, true, 49, false));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":header", true, 0, true, 49, false));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":footer", true, 0, true, 49, false));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:left", true, 0, true, 49, false));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:right", true, 0, true, 49, false));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:top", true, 0, true, 49, false));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:bottom", true, 0, true, 49, false));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:header", true, 0, true, 49, false));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:footer", true, 0, true, 49, false));
         }
 
         /// <inheritdoc/>
@@ -27812,11 +27812,11 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 .AddAttribute("verticalDpi", a => a.VerticalDpi)
 .AddAttribute("copies", a => a.Copies)
 .AddAttribute("r:id", a => a.Id);
-            builder.AddConstraint(new AttributeValueRangeConstraint(":fitToWidth", true, double.NegativeInfinity, true, 32767, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":fitToHeight", true, double.NegativeInfinity, true, 32767, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":copies", true, 1, true, 32767, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":horizontalDpi", true, 1, true, double.PositiveInfinity, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":verticalDpi", true, 1, true, double.PositiveInfinity, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:fitToWidth", true, double.NegativeInfinity, true, 32767, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:fitToHeight", true, double.NegativeInfinity, true, 32767, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:copies", true, 1, true, 32767, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:horizontalDpi", true, 1, true, double.PositiveInfinity, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:verticalDpi", true, 1, true, double.PositiveInfinity, true) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -28429,9 +28429,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.IconSet), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ConditionalFormattingRuleExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeRequiredConditionToValue(":operator", ":type", "cells"));
-            builder.AddConstraint(new AttributeRequiredConditionToValue(":timePeriod", ":type", "timePeriod"));
-            builder.AddConstraint(new IndexReferenceConstraint(":dxfId", "/WorkbookPart/WorkbookStylesPart", null, "x:dxf", "x:dxf", 0));
+            builder.AddConstraint(new AttributeRequiredConditionToValue("x:operator", "x:type", "cells"));
+            builder.AddConstraint(new AttributeRequiredConditionToValue("x:timePeriod", "x:type", "timePeriod"));
+            builder.AddConstraint(new IndexReferenceConstraint("x:dxfId", "/WorkbookPart/WorkbookStylesPart", null, "x:dxf", "x:dxf", 0));
         }
 
         /// <inheritdoc/>
@@ -28551,9 +28551,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 .AddAttribute("location", a => a.Location)
 .AddAttribute("tooltip", a => a.Tooltip)
 .AddAttribute("display", a => a.Display);
-            builder.AddConstraint(new AttributeValueLengthConstraint(":location", 0, 2084));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":display", 0, 2084));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":tooltip", 0, 255));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:location", 0, 2084));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:display", 0, 2084));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:tooltip", 0, 255));
             builder.AddConstraint(new RelationshipExistConstraint("r:id"));
         }
 
@@ -28853,11 +28853,11 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.InputCells), 1, 32)
             };
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", true, "x:worksheet"));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":count", true, 1, true, 32, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 0, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":user", 1, 54) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":comment", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:name", true, "x:worksheet"));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:count", true, 1, true, 32, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:user", 1, 54) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:comment", 0, 255) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -29031,9 +29031,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute("securityDescriptor", a => a.SecurityDescriptor);
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", true, "x:protectedRanges"));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 1, 255) { Application = ApplicationType.Word });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":sqref", true, 1, true, double.PositiveInfinity, true));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:name", true, "x:protectedRanges"));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 1, 255) { Application = ApplicationType.Word });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:sqref", true, 1, true, double.PositiveInfinity, true));
         }
 
         /// <inheritdoc/>
@@ -29082,7 +29082,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
 aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":r", true, "x:cellWatches"));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:r", true, "x:cellWatches"));
         }
 
         /// <inheritdoc/>
@@ -29301,11 +29301,11 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 .AddAttribute("verticalDpi", a => a.VerticalDpi)
 .AddAttribute("copies", a => a.Copies)
 .AddAttribute("r:id", a => a.Id);
-            builder.AddConstraint(new AttributeValueRangeConstraint(":fitToWidth", true, double.NegativeInfinity, true, 32767, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":fitToHeight", true, double.NegativeInfinity, true, 32767, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":copies", true, 1, true, 32767, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":horizontalDpi", true, 1, true, double.PositiveInfinity, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":verticalDpi", true, 1, true, double.PositiveInfinity, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:fitToWidth", true, double.NegativeInfinity, true, 32767, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:fitToHeight", true, double.NegativeInfinity, true, 32767, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:copies", true, 1, true, 32767, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:horizontalDpi", true, 1, true, double.PositiveInfinity, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:verticalDpi", true, 1, true, double.PositiveInfinity, true) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -29377,7 +29377,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
 aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", false, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:name", false, null));
         }
 
         /// <inheritdoc/>
@@ -29554,13 +29554,13 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute("title", a => a.Title)
 .AddAttribute("autoRepublish", a => a.AutoRepublish);
-            builder.AddConstraint(new AttributeValueLengthConstraint(":title", 0, 255));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":destinationFile", 1, 255));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":divId", 1, 255));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":id", true, 1, true, 2147483647, true));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", true, null));
-            builder.AddConstraint(new AttributeRequiredConditionToValue(":sourceRef", ":sourceType", "range"));
-            builder.AddConstraint(new AttributeAbsentConditionToNonValue(":sourceRef", ":sourceType", "range"));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:title", 0, 255));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:destinationFile", 1, 255));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:divId", 1, 255));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:id", true, 1, true, 2147483647, true));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:id", true, null));
+            builder.AddConstraint(new AttributeRequiredConditionToValue("x:sourceRef", "x:sourceType", "range"));
+            builder.AddConstraint(new AttributeAbsentConditionToNonValue("x:sourceRef", "x:sourceType", "range"));
         }
 
         /// <inheritdoc/>
@@ -29746,12 +29746,12 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":colorId", true, double.NegativeInfinity, true, 64, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":zoomScale", true, 10, true, 400, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":zoomScaleNormal", true, 10, true, 400, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":zoomScalePageLayoutView", true, 10, true, 400, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":zoomScaleSheetLayoutView", true, 10, true, 400, true));
-            builder.AddConstraint(new IndexReferenceConstraint(":workbookViewId", "/WorkbookPart", null, "x:workbookView", "x:workbookView", 0));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:colorId", true, double.NegativeInfinity, true, 64, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:zoomScale", true, 10, true, 400, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:zoomScaleNormal", true, 10, true, 400, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:zoomScalePageLayoutView", true, 10, true, 400, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:zoomScaleSheetLayoutView", true, 10, true, 400, true));
+            builder.AddConstraint(new IndexReferenceConstraint("x:workbookViewId", "/WorkbookPart", null, "x:workbookView", "x:workbookView", 0));
         }
 
         /// <summary>
@@ -29906,9 +29906,9 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ChartSheetPageSetup), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.HeaderFooter), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":scale", true, 10, true, 400, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":colorId", true, double.NegativeInfinity, true, 64, true));
-            builder.AddConstraint(new AttributeValueSetConstraint(":guid", false, new string[] { "00000000-0000-0000-0000-000000000000" }));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:scale", true, 10, true, 400, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:colorId", true, double.NegativeInfinity, true, 64, true));
+            builder.AddConstraint(new AttributeValueSetConstraint("x:guid", false, new string[] { "00000000-0000-0000-0000-000000000000" }));
         }
 
         /// <summary>
@@ -30067,7 +30067,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute("numFmtId", a => a.NumberFormatId);
-            builder.AddConstraint(new AttributeValueLengthConstraint(":val", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:val", 0, 255) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -30191,9 +30191,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ControlProperties), 0, 1, version: FileFormatVersions.Office2010)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":shapeId", true, 1, true, 67098623, true));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", true, null) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 0, 32) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:shapeId", true, 1, true, 67098623, true));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:name", true, null) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 0, 32) { Application = ApplicationType.Excel });
         }
 
         /// <summary>
@@ -30408,7 +30408,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 .AddAttribute("emptyCellReference", a => a.EmptyCellReference)
 .AddAttribute("listDataValidation", a => a.ListDataValidation)
 .AddAttribute("calculatedColumn", a => a.CalculatedColumn);
-            builder.AddConstraint(new AttributeValueRangeConstraint(":sqref", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:sqref", true, double.NegativeInfinity, true, 2147483647, true));
         }
 
         /// <inheritdoc/>
@@ -30750,9 +30750,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Formula1), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Formula2), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":sqref", true, 1, true, 32767, true));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":errorTitle", 0, 32));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":promptTitle", 0, 32));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:sqref", true, 1, true, 32767, true));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:errorTitle", 0, 32));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:promptTitle", 0, 32));
         }
 
         /// <summary>
@@ -31190,12 +31190,12 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.PivotSelection), 0, 4),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":colorId", true, double.NegativeInfinity, true, 64, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":zoomScale", true, 10, true, 400, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":zoomScaleNormal", true, 10, true, 400, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":zoomScalePageLayoutView", true, 10, true, 400, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":zoomScaleSheetLayoutView", true, 10, true, 400, true));
-            builder.AddConstraint(new IndexReferenceConstraint(":workbookViewId", "/WorkbookPart", null, "x:workbookView", "x:workbookView", 0));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:colorId", true, double.NegativeInfinity, true, 64, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:zoomScale", true, 10, true, 400, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:zoomScaleNormal", true, 10, true, 400, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:zoomScalePageLayoutView", true, 10, true, 400, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:zoomScaleSheetLayoutView", true, 10, true, 400, true));
+            builder.AddConstraint(new IndexReferenceConstraint("x:workbookViewId", "/WorkbookPart", null, "x:workbookView", "x:workbookView", 0));
         }
 
         /// <summary>
@@ -31643,9 +31643,9 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.AutoFilter), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":scale", true, 10, true, 400, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":colorId", true, double.NegativeInfinity, true, 64, true));
-            builder.AddConstraint(new AttributeValueSetConstraint(":guid", false, new string[] { "00000000-0000-0000-0000-000000000000" }));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:scale", true, 10, true, 400, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:colorId", true, double.NegativeInfinity, true, 64, true));
+            builder.AddConstraint(new AttributeValueSetConstraint("x:guid", false, new string[] { "00000000-0000-0000-0000-000000000000" }));
         }
 
         /// <summary>
@@ -31964,9 +31964,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.EmbeddedObjectProperties), 0, 1, version: FileFormatVersions.Office2010)
             };
-            builder.AddConstraint(new AttributeValuePatternConstraint(":progId", @"[^\d].*"));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":progId", 0, 39));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":shapeId", true, 1, true, 67098623, true));
+            builder.AddConstraint(new AttributeValuePatternConstraint("x:progId", @"[^\d].*"));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:progId", 0, 39));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:shapeId", true, 1, true, 67098623, true));
         }
 
         /// <summary>
@@ -32060,7 +32060,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.MetadataType), 1, 0)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":count", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:count", true, double.NegativeInfinity, true, 2147483647, true));
         }
 
         /// <inheritdoc/>
@@ -32141,7 +32141,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.CharacterValue), 1, 0)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":count", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:count", true, double.NegativeInfinity, true, 2147483647, true));
         }
 
         /// <inheritdoc/>
@@ -32222,7 +32222,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Mdx), 1, 0)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":count", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:count", true, double.NegativeInfinity, true, 2147483647, true));
         }
 
         /// <inheritdoc/>
@@ -32326,10 +32326,10 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.FutureMetadataBlock), 0, 0),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":count", true, double.NegativeInfinity, true, 2147483647, true));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", true, "x:metadata"));
-            builder.AddConstraint(new AttributeValueSetConstraint(":name", false, new string[] { "XLMDX" }));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 1, 65535));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:count", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:name", true, "x:metadata"));
+            builder.AddConstraint(new AttributeValueSetConstraint("x:name", false, new string[] { "XLMDX" }));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 1, 65535));
         }
 
         /// <inheritdoc/>
@@ -32391,7 +32391,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.MetadataBlock), 1, 0)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":count", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:count", true, double.NegativeInfinity, true, 2147483647, true));
         }
 
         /// <inheritdoc/>
@@ -32453,7 +32453,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.MetadataBlock), 1, 0)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":count", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:count", true, double.NegativeInfinity, true, 2147483647, true));
         }
 
         /// <inheritdoc/>
@@ -33033,8 +33033,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 .AddAttribute("coerce", a => a.Coerce)
 .AddAttribute("adjust", a => a.Adjust)
 .AddAttribute("cellMeta", a => a.CellMeta);
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", true, "x:metadataTypes"));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 1, 65535));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:name", true, "x:metadataTypes"));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 1, 65535));
         }
 
         /// <inheritdoc/>
@@ -33165,8 +33165,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
  {
      aBuilder.AddValidator(RequiredValidator.Instance);
  });
-            builder.AddConstraint(new IndexReferenceConstraint(":t", ".", null, "x:metadataType", "x:metadataType", 1));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":t", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new IndexReferenceConstraint("x:t", ".", null, "x:metadataType", "x:metadataType", 1));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:t", true, double.NegativeInfinity, true, 2147483647, true));
         }
 
         /// <inheritdoc/>
@@ -33354,8 +33354,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.MdxMemberProp), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.MdxKpi), 1, 1)
             };
-            builder.AddConstraint(new IndexReferenceConstraint(":n", "/WorkbookPart/CellMetadataPart", "x:metadataStrings", "x:s", "x:s", 0));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":n", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new IndexReferenceConstraint("x:n", "/WorkbookPart/CellMetadataPart", "x:metadataStrings", "x:s", "x:s", 0));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:n", true, double.NegativeInfinity, true, 2147483647, true));
         }
 
         /// <summary>
@@ -33647,10 +33647,10 @@ aBuilder.AddValidator(new StringValidator() { Length = (4L) });
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.NameIndex), 0, 0)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":si", true, double.NegativeInfinity, true, 2147483647, true));
-            builder.AddConstraint(new IndexReferenceConstraint(":si", "/WorkbookPart/CellMetadataPart", "x:metadataStrings", "x:s", "x:s", 0));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":c", true, double.NegativeInfinity, true, 2147483647, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":fi", true, double.NegativeInfinity, true, 58, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:si", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new IndexReferenceConstraint("x:si", "/WorkbookPart/CellMetadataPart", "x:metadataStrings", "x:s", "x:s", 0));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:c", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:fi", true, double.NegativeInfinity, true, 58, true));
         }
 
         /// <inheritdoc/>
@@ -33768,9 +33768,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.NameIndex), 0, 0)
             };
-            builder.AddConstraint(new IndexReferenceConstraint(":ns", "/WorkbookPart/CellMetadataPart", "x:metadataStrings", "x:s", "x:s", 0));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":ns", true, 0, true, 2147483647, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":c", true, 0, true, 2147483647, true));
+            builder.AddConstraint(new IndexReferenceConstraint("x:ns", "/WorkbookPart/CellMetadataPart", "x:metadataStrings", "x:s", "x:s", 0));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:ns", true, 0, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:c", true, 0, true, 2147483647, true));
         }
 
         /// <inheritdoc/>
@@ -33839,10 +33839,10 @@ aBuilder.AddValidator(RequiredValidator.Instance);
   {
       aBuilder.AddValidator(RequiredValidator.Instance);
   });
-            builder.AddConstraint(new IndexReferenceConstraint(":n", "/WorkbookPart/CellMetadataPart", "x:metadataStrings", "x:s", "x:s", 0));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":n", true, double.NegativeInfinity, true, 2147483647, true));
-            builder.AddConstraint(new IndexReferenceConstraint(":np", "/WorkbookPart/CellMetadataPart", "x:metadataStrings", "x:s", "x:s", 0));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":np", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new IndexReferenceConstraint("x:n", "/WorkbookPart/CellMetadataPart", "x:metadataStrings", "x:s", "x:s", 0));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:n", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new IndexReferenceConstraint("x:np", "/WorkbookPart/CellMetadataPart", "x:metadataStrings", "x:s", "x:s", 0));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:np", true, double.NegativeInfinity, true, 2147483647, true));
         }
 
         /// <inheritdoc/>
@@ -33931,10 +33931,10 @@ aBuilder.AddValidator(RequiredValidator.Instance);
   {
       aBuilder.AddValidator(RequiredValidator.Instance);
   });
-            builder.AddConstraint(new IndexReferenceConstraint(":n", ".", "x:metadataStrings", "x:s", "x:s", 0));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":n", true, double.NegativeInfinity, true, 2147483647, true));
-            builder.AddConstraint(new IndexReferenceConstraint(":np", "/WorkbookPart/CellMetadataPart", "x:metadataStrings", "x:s", "x:s", 0));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":np", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new IndexReferenceConstraint("x:n", ".", "x:metadataStrings", "x:s", "x:s", 0));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:n", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new IndexReferenceConstraint("x:np", "/WorkbookPart/CellMetadataPart", "x:metadataStrings", "x:s", "x:s", 0));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:np", true, double.NegativeInfinity, true, 2147483647, true));
         }
 
         /// <inheritdoc/>
@@ -34000,11 +34000,11 @@ aBuilder.AddValidator(RequiredValidator.Instance);
       aBuilder.AddValidator(RequiredValidator.Instance);
   })
   .AddAttribute("s", a => a.IsASet);
-            builder.AddConstraint(new AttributeValueRangeConstraint(":x", true, 0, true, double.PositiveInfinity, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":x", true, double.NegativeInfinity, true, 2147483647, true));
-            builder.AddConstraint(new IndexReferenceConstraint(":in", ".", null, "x:serverFormat", "x:serverFormat", 0));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":c", 0, 65535) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueSetConstraint(":v", false, new string[] { "INF", "-INF", "NaN" }) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:x", true, 0, true, double.PositiveInfinity, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:x", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new IndexReferenceConstraint("x:in", ".", null, "x:serverFormat", "x:serverFormat", 0));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:c", 0, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueSetConstraint("x:v", false, new string[] { "INF", "-INF", "NaN" }) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -34131,9 +34131,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.XmlCellProperties), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":id", true, 1, true, 4294967294, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":connectionId", true, double.NegativeInfinity, true, 2147483647, true));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", true, null));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:id", true, 1, true, 4294967294, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:connectionId", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:id", true, null));
         }
 
         /// <summary>
@@ -34266,9 +34266,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.XmlProperties), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueSetConstraint(":id", true, new string[] { "1" }));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":uniqueName", true, null));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":uniqueName", 1, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueSetConstraint("x:id", true, new string[] { "1" }));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:uniqueName", true, null));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:uniqueName", 1, 255) { Application = ApplicationType.Excel });
         }
 
         /// <summary>
@@ -34418,8 +34418,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":xpath", 0, 32000));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":mapId", true, 1, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:xpath", 0, 32000));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:mapId", true, 1, true, 2147483647, true));
         }
 
         /// <summary>
@@ -34707,11 +34707,11 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.GradientStop), 0, 0)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":top", true, 0, true, 1, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":bottom", true, 0, true, 1, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":left", true, 0, true, 1, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":right", true, 0, true, 1, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":degree", true, -1.7E+308, true, 1.7E+308, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:top", true, 0, true, 1, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:bottom", true, 0, true, 1, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:left", true, 0, true, 1, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:right", true, 0, true, 1, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:degree", true, -1.7E+308, true, 1.7E+308, true));
         }
 
         /// <inheritdoc/>
@@ -34795,7 +34795,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Color), 1, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":position", true, 0, true, 1, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:position", true, 0, true, 1, true));
         }
 
         /// <summary>
@@ -34877,7 +34877,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
  aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":formatCode", 0, 255));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:formatCode", 0, 255));
         }
 
         /// <inheritdoc/>
@@ -35076,9 +35076,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 .AddAttribute("shrinkToFit", a => a.ShrinkToFit)
 .AddAttribute("readingOrder", a => a.ReadingOrder)
 .AddAttribute("mergeCell", a => a.MergeCell);
-            builder.AddConstraint(new AttributeValueRangeConstraint(":readingOrder", true, 0, true, 2, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":indent", true, double.NegativeInfinity, true, 255, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueSetConstraint(":readingOrder", true, new string[] { "0", "1", "2" }) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:readingOrder", true, 0, true, 2, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:indent", true, double.NegativeInfinity, true, 255, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueSetConstraint("x:readingOrder", true, new string[] { "0", "1", "2" }) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -36044,7 +36044,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.TableStyleElement), 0, 28)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 1, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 1, 255) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -36261,11 +36261,11 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 0, 255));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":builtinId", true, 0, true, 53, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":iLevel", true, 0, true, 7, true));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":xfId", true, "x:cellStyles"));
-            builder.AddConstraint(new IndexReferenceConstraint(":xfId", "/WorkbookPart/WorkbookStylesPart", null, "x:xf", "x:xf", 0));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 0, 255));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:builtinId", true, 0, true, 53, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:iLevel", true, 0, true, 7, true));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:xfId", true, "x:cellStyles"));
+            builder.AddConstraint(new IndexReferenceConstraint("x:xfId", "/WorkbookPart/WorkbookStylesPart", null, "x:xf", "x:xf", 0));
         }
 
         /// <summary>
@@ -36569,11 +36569,11 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Protection), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new IndexReferenceConstraint(":borderId", "/WorkbookPart/WorkbookStylesPart", null, "x:border", "x:border", 0));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":borderId", true, 0, true, double.PositiveInfinity, true));
-            builder.AddConstraint(new IndexReferenceConstraint(":fillId", "/WorkbookPart/WorkbookStylesPart", null, "x:fill", "x:fill", 0));
-            builder.AddConstraint(new IndexReferenceConstraint(":fontId", "/WorkbookPart/WorkbookStylesPart", null, "x:font", "x:font", 0));
-            builder.AddConstraint(new IndexReferenceConstraint(":xfId", "/WorkbookPart/WorkbookStylesPart", "x:cellStyleXfs", "x:xf", "x:xf", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:borderId", "/WorkbookPart/WorkbookStylesPart", null, "x:border", "x:border", 0));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:borderId", true, 0, true, double.PositiveInfinity, true));
+            builder.AddConstraint(new IndexReferenceConstraint("x:fillId", "/WorkbookPart/WorkbookStylesPart", null, "x:fill", "x:fill", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:fontId", "/WorkbookPart/WorkbookStylesPart", null, "x:font", "x:font", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:xfId", "/WorkbookPart/WorkbookStylesPart", "x:cellStyleXfs", "x:xf", "x:xf", 0));
         }
 
         /// <summary>
@@ -36662,7 +36662,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(RequiredValidator.Instance);
    aBuilder.AddValidator(new StringValidator() { MinLength = (1L) });
 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":val", 1, 31) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:val", 1, 31) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -36712,7 +36712,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
  aBuilder.AddValidator(RequiredValidator.Instance);
  aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (5L) });
 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":val", true, 0, true, 5, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:val", true, 0, true, 5, true) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -36762,7 +36762,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(RequiredValidator.Instance);
 aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive = (255L) });
 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":val", true, 0, true, 255, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:val", true, 0, true, 255, true));
         }
 
         /// <inheritdoc/>
@@ -36845,8 +36845,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute("size", a => a.Size)
 .AddAttribute("dxfId", a => a.FormatId);
-            builder.AddConstraint(new AttributeValueRangeConstraint(":size", true, 1, true, 9, true));
-            builder.AddConstraint(new IndexReferenceConstraint(":dxfId", "/WorkbookPart/WorkbookStylesPart", null, "x:dxf", "x:dxf", 0));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:size", true, 1, true, 9, true));
+            builder.AddConstraint(new IndexReferenceConstraint("x:dxfId", "/WorkbookPart/WorkbookStylesPart", null, "x:dxf", "x:dxf", 0));
         }
 
         /// <inheritdoc/>
@@ -37115,10 +37115,10 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute("refersTo", a => a.RefersTo)
 .AddAttribute("sheetId", a => a.SheetId);
-            builder.AddConstraint(new AttributeValueRangeConstraint(":sheetId", true, 0, true, 65533, true));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":comment", 0, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 1, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":localSheetId", true, double.NegativeInfinity, true, 32766, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:sheetId", true, 0, true, 65533, true));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:comment", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 1, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:localSheetId", true, double.NegativeInfinity, true, 32766, true) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -37219,7 +37219,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExternalRow), 0, 0)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":sheetId", true, 0, true, 65533, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:sheetId", true, 0, true, 65533, true));
         }
 
         /// <inheritdoc/>
@@ -37303,10 +37303,10 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExternalCell), 0, 0)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":r", true, 1, true, 1048576, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":outlineLevel", true, 0, true, 7, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":s", true, 0, true, 65490, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":r", true, double.NegativeInfinity, true, 1048576, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:r", true, 1, true, 1048576, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:outlineLevel", true, 0, true, 7, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:s", true, 0, true, 65490, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:r", true, double.NegativeInfinity, true, 1048576, true));
         }
 
         /// <inheritdoc/>
@@ -37424,8 +37424,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Xstring), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueSetConstraint(":t", false, new string[] { "s" }));
-            builder.AddConstraint(new IndexReferenceConstraint(":vm", "/WorkbookPart/CellMetadataPart", null, "x:valueMetadata", "x:valueMetadata", 0));
+            builder.AddConstraint(new AttributeValueSetConstraint("x:t", false, new string[] { "s" }));
+            builder.AddConstraint(new IndexReferenceConstraint("x:vm", "/WorkbookPart/CellMetadataPart", null, "x:valueMetadata", "x:valueMetadata", 0));
         }
 
         /// <summary>
@@ -37632,8 +37632,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Values), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 0, 255));
-            builder.AddConstraint(new AttributeValueConditionToAnother(":name", ":ole", new string[] { "StdDocumentName" }, new string[] { "true" }));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 0, 255));
+            builder.AddConstraint(new AttributeValueConditionToAnother("x:name", "x:ole", new string[] { "StdDocumentName" }, new string[] { "true" }));
         }
 
         /// <summary>
@@ -37744,8 +37744,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Value), 1, 0)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":cols", true, 1, true, 16384, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":rows", true, 1, true, 1048576, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:cols", true, 1, true, 16384, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:rows", true, 1, true, 1048576, true) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -38138,8 +38138,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.DdeItems), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":ddeService", 1, 255));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":ddeTopic", 0, 255));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:ddeService", 1, 255));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:ddeTopic", 0, 255));
         }
 
         /// <summary>
@@ -38259,7 +38259,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.OleItems), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":progId", 1, 255));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:progId", 1, 255));
         }
 
         /// <summary>
@@ -38318,7 +38318,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             builder.SetSchema("x:sheetName");
             builder.AddElement<SheetName>()
 .AddAttribute("val", a => a.Val);
-            builder.AddConstraint(new AttributeValueLengthConstraint(":val", 0, 31));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:val", 0, 31));
         }
 
         /// <inheritdoc/>
@@ -38641,20 +38641,20 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.XmlColumnProperties), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 0, 255));
-            builder.AddConstraint(new AttributeAbsentConditionToValue(":totalsRowLabel", ":totalsRowFunction", "custom"));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":headerRowCellStyle", 1, 255));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":totalsRowCellStyle", 1, 255));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":queryTableFieldId", true, 1, true, double.PositiveInfinity, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":id", true, 1, true, double.PositiveInfinity, true));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":totalsRowLabel", 0, 32767));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":dataCellStyle", 1, 255));
-            builder.AddConstraint(new IndexReferenceConstraint(":dataDxfId", "/WorkbookPart/WorkbookStylesPart", "x:dxfs", "x:dxf", "x:dxf", 0));
-            builder.AddConstraint(new IndexReferenceConstraint(":headerRowDxfId", "/WorkbookPart/WorkbookStylesPart", null, "x:dxf", "x:dxf", 0));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", true, "x:table"));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", true, "x:table"));
-            builder.AddConstraint(new IndexReferenceConstraint(":totalsRowDxfId", "/WorkbookPart/WorkbookStylesPart", null, "x:dxf", "x:dxf", 0));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":uniqueName", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 0, 255));
+            builder.AddConstraint(new AttributeAbsentConditionToValue("x:totalsRowLabel", "x:totalsRowFunction", "custom"));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:headerRowCellStyle", 1, 255));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:totalsRowCellStyle", 1, 255));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:queryTableFieldId", true, 1, true, double.PositiveInfinity, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:id", true, 1, true, double.PositiveInfinity, true));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:totalsRowLabel", 0, 32767));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:dataCellStyle", 1, 255));
+            builder.AddConstraint(new IndexReferenceConstraint("x:dataDxfId", "/WorkbookPart/WorkbookStylesPart", "x:dxfs", "x:dxf", "x:dxf", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:headerRowDxfId", "/WorkbookPart/WorkbookStylesPart", null, "x:dxf", "x:dxf", 0));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:id", true, "x:table"));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:name", true, "x:table"));
+            builder.AddConstraint(new IndexReferenceConstraint("x:totalsRowDxfId", "/WorkbookPart/WorkbookStylesPart", null, "x:dxf", "x:dxf", 0));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:uniqueName", 0, 255) { Application = ApplicationType.Excel });
         }
 
         /// <summary>
@@ -38998,9 +38998,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":xpath", 0, 32000));
-            builder.AddConstraint(new ReferenceExistConstraint(":mapId", "CustomXmlMappingsPart", "x:Map", "x:Map", ":ID"));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":mapId", true, 1, true, 21474836477, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:xpath", 0, 32000));
+            builder.AddConstraint(new ReferenceExistConstraint("x:mapId", "CustomXmlMappingsPart", "x:Map", "x:Map", "x:ID"));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:mapId", true, 1, true, 21474836477, true) { Application = ApplicationType.Excel });
         }
 
         /// <summary>
@@ -39180,7 +39180,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Topic), 1, 0)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":first", 1, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:first", 1, 255) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -39348,7 +39348,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
  {
      aBuilder.AddValidator(RequiredValidator.Instance);
  });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":s", true, 1, true, 65534, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:s", true, 1, true, 65534, true) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -39420,7 +39420,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
 aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":cacheId", true, "x:pivotCaches"));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:cacheId", true, "x:pivotCaches"));
             builder.AddConstraint(new RelationshipExistConstraint("r:id"));
         }
 
@@ -39561,11 +39561,11 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute("title", a => a.Title)
 .AddAttribute("autoRepublish", a => a.AutoRepublish);
-            builder.AddConstraint(new AttributeValueLengthConstraint(":title", 0, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":sourceObject", 0, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":destinationFile", 1, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":divId", 1, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":id", true, 1, true, 2147483647, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:title", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:sourceObject", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:destinationFile", 1, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:divId", 1, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:id", true, 1, true, 2147483647, true) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -40098,11 +40098,11 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":windowWidth", true, double.NegativeInfinity, true, 2147483647, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":tabRatio", true, double.NegativeInfinity, true, 1000, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":activeSheetId", true, 1, true, 65534, true));
-            builder.AddConstraint(new AttributeValueSetConstraint(":guid", false, new string[] { "00000000-0000-0000-0000-000000000000" }) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":windowHeight", true, double.NegativeInfinity, true, 2147483647, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:windowWidth", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:tabRatio", true, double.NegativeInfinity, true, 1000, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:activeSheetId", true, 1, true, 65534, true));
+            builder.AddConstraint(new AttributeValueSetConstraint("x:guid", false, new string[] { "00000000-0000-0000-0000-000000000000" }) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:windowHeight", true, double.NegativeInfinity, true, 2147483647, true) { Application = ApplicationType.Excel });
         }
 
         /// <summary>
@@ -40224,12 +40224,12 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
   aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new AttributeValuePatternConstraint(":name", @"[^'*\[\]/\\:?]{1}[^*\[\]/\\:?]*"));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 1, 31));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":name", false, null));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":sheetId", true, null));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":sheetId", true, 1, true, 65534, true));
-            builder.AddConstraint(new AttributeValueLengthConstraint("r:id", 0, 255));
+            builder.AddConstraint(new AttributeValuePatternConstraint("x:name", @"[^'*\[\]/\\:?]{1}[^*\[\]/\\:?]*"));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 1, 31));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:name", false, null));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:sheetId", true, null));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:sheetId", true, 1, true, 65534, true));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:id", 0, 255));
             builder.AddConstraint(new RelationshipExistConstraint("r:id"));
         }
 
@@ -40515,10 +40515,10 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":windowWidth", true, double.NegativeInfinity, true, 2147483647, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":windowHeight", true, double.NegativeInfinity, true, 2147483647, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":tabRatio", true, double.NegativeInfinity, true, 1000, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":activeTab", true, 0, true, 32766, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:windowWidth", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:windowHeight", true, double.NegativeInfinity, true, 2147483647, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:tabRatio", true, double.NegativeInfinity, true, 1000, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:activeTab", true, 0, true, 32766, true));
         }
 
         /// <summary>
@@ -40831,10 +40831,10 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 .AddAttribute("shortcutKey", a => a.ShortcutKey)
 .AddAttribute("publishToServer", a => a.PublishToServer)
 .AddAttribute("workbookParameter", a => a.WorkbookParameter);
-            builder.AddConstraint(new AttributeValueRangeConstraint(":sheetId", true, 0, true, 65533, true));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":comment", 0, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 1, 255) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":localSheetId", true, double.NegativeInfinity, true, 32766, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:sheetId", true, 0, true, 65533, true));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:comment", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 1, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:localSheetId", true, double.NegativeInfinity, true, 32766, true) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -40883,7 +40883,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
 aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 0, 32) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 0, 32) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -41891,7 +41891,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 .AddAttribute("showLastColumn", a => a.ShowLastColumn)
 .AddAttribute("showRowStripes", a => a.ShowRowStripes)
 .AddAttribute("showColumnStripes", a => a.ShowColumnStripes);
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 1, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 1, 255) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -42053,8 +42053,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 .AddAttribute("icon", a => a.Icon)
 .AddAttribute("advise", a => a.Advise)
 .AddAttribute("preferPic", a => a.PreferPicture);
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 0, 255));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 1, int.MaxValue));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 0, 255));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 1, int.MaxValue));
         }
 
         /// <inheritdoc/>
@@ -43404,8 +43404,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.TabColor), 0, 1)
             };
-            builder.AddConstraint(new AttributeValuePatternConstraint(":codeName", @"[\p{L}\P{IsBasicLatin}][_\d\p{L}\P{IsBasicLatin}]*"));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":codeName", 0, 32));
+            builder.AddConstraint(new AttributeValuePatternConstraint("x:codeName", @"[\p{L}\P{IsBasicLatin}][_\d\p{L}\P{IsBasicLatin}]*"));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:codeName", 0, 32));
         }
 
         /// <summary>
@@ -44517,8 +44517,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ConditionalFormatValueObject), 2, 2),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Color), 1, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":maxLength", true, double.NegativeInfinity, true, 100, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":minLength", true, double.NegativeInfinity, true, 100, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:maxLength", true, double.NegativeInfinity, true, 100, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:minLength", true, double.NegativeInfinity, true, 100, true) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -45014,8 +45014,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.OutlineProperties), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.PageSetupProperties), 0, 1)
             };
-            builder.AddConstraint(new AttributeValuePatternConstraint(":codeName", @"[\p{L}\P{IsBasicLatin}][_\d\p{L}\P{IsBasicLatin}]*"));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":codeName", 0, 32));
+            builder.AddConstraint(new AttributeValuePatternConstraint("x:codeName", @"[\p{L}\P{IsBasicLatin}][_\d\p{L}\P{IsBasicLatin}]*"));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:codeName", 0, 32));
         }
 
         /// <summary>
@@ -45327,10 +45327,10 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
 aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010));
 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":outlineLevelCol", true, 0, true, 7, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":outlineLevelRow", true, 0, true, 7, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":baseColWidth", true, double.NegativeInfinity, true, 255, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":defaultColWidth", true, 0, true, 65535, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:outlineLevelCol", true, 0, true, 7, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:outlineLevelRow", true, 0, true, 7, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:baseColWidth", true, double.NegativeInfinity, true, 255, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:defaultColWidth", true, 0, true, 65535, true));
         }
 
         /// <inheritdoc/>
@@ -45953,10 +45953,10 @@ aBuilder.AddValidator(new StringValidator() { Length = (2L) });
 {
 aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":uniqueName", true, null));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":caption", 1, 65535) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 1, 65535) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":uniqueName", 1, 32767) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:uniqueName", true, null));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:caption", 1, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 1, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:uniqueName", 1, 32767) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -46081,7 +46081,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Row), 0, 0)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":sheetId", true, 0, true, 65533, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:sheetId", true, 0, true, 65533, true));
         }
 
         /// <inheritdoc/>
@@ -46346,7 +46346,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ConditionalFormattingRule), 1, 0),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":sqref", 1, int.MaxValue));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:sqref", 1, int.MaxValue));
         }
 
         /// <inheritdoc/>
@@ -46964,8 +46964,8 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
 .AddAttribute("name", a => a.Name)
 .AddAttribute("sheet", a => a.Sheet)
 .AddAttribute("r:id", a => a.Id);
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 1, 255));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":sheet", 0, 31));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 1, 255));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:sheet", 0, 31));
             builder.AddConstraint(new RelationshipExistConstraint("r:id"));
         }
 
@@ -47668,10 +47668,10 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
  aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new IndexReferenceConstraint(":fld", ".", null, "x:pivotField", "x:pivotField", 0));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":id", false, null));
-            builder.AddConstraint(new IndexReferenceConstraint(":iMeasureFld", ".", null, "x:pivotField", "x:pivotField", 0));
-            builder.AddConstraint(new IndexReferenceConstraint(":iMeasureHier", ".", null, "x:pivotHierarchy", "x:pivotHierarchy", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:fld", ".", null, "x:pivotField", "x:pivotField", 0));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:id", false, null));
+            builder.AddConstraint(new IndexReferenceConstraint("x:iMeasureFld", ".", null, "x:pivotField", "x:pivotField", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:iMeasureHier", ".", null, "x:pivotHierarchy", "x:pivotHierarchy", 0));
         }
 
         /// <inheritdoc/>
@@ -47825,12 +47825,12 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 {
 aBuilder.AddValidator(RequiredValidator.Instance);
 });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":day", true, 1, true, 31, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":hour", true, 0, true, 23, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":minute", true, 0, true, 59, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":month", true, 1, true, 12, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":second", true, 0, true, 59, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":year", true, 1000, true, 9999, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:day", true, 1, true, 31, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:hour", true, 0, true, 23, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:minute", true, 0, true, 59, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:month", true, 1, true, 12, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:second", true, 0, true, 59, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:year", true, 1000, true, 9999, true));
         }
 
         /// <inheritdoc/>
@@ -48300,7 +48300,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
 aBuilder.AddValidator(RequiredValidator.Instance);
 })
 .AddAttribute("cellColor", a => a.CellColor);
-            builder.AddConstraint(new IndexReferenceConstraint(":dxfId", "/WorkbookPart/WorkbookStylesPart", null, "x:dxf", "x:dxf", 0));
+            builder.AddConstraint(new IndexReferenceConstraint("x:dxfId", "/WorkbookPart/WorkbookStylesPart", null, "x:dxf", "x:dxf", 0));
         }
 
         /// <inheritdoc/>
@@ -48729,8 +48729,8 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 .AddAttribute("command", a => a.Command)
 .AddAttribute("serverCommand", a => a.ServerCommand)
 .AddAttribute("commandType", a => a.CommandType);
-            builder.AddConstraint(new AttributeValueRangeConstraint(":commandType", true, 1, true, 5, true));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":connection", 0, 65535) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:commandType", true, 1, true, 5, true));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:connection", 0, 65535) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -48912,7 +48912,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 .AddAttribute("serverNumberFormat", a => a.ServerNumberFormat)
 .AddAttribute("serverFont", a => a.ServerFont)
 .AddAttribute("serverFontColor", a => a.ServerFontColor);
-            builder.AddConstraint(new AttributeValueRangeConstraint(":rowDrillCount", true, 1, true, 1048576, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:rowDrillCount", true, 1, true, 1048576, true));
         }
 
         /// <inheritdoc/>
@@ -49197,7 +49197,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Tables), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":url", 1, int.MaxValue));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:url", 1, int.MaxValue));
         }
 
         /// <summary>
@@ -49546,11 +49546,11 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.TextFields), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":decimal", 1, 255));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":thousands", 1, 255));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":firstRow", true, double.NegativeInfinity, true, 2147483647, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":sourceFile", 1, 218) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeRequiredConditionToValue(":sourceFile", ":prompt", "false") { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:decimal", 1, 255));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:thousands", 1, 255));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:firstRow", true, double.NegativeInfinity, true, 2147483647, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:sourceFile", 1, 218) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeRequiredConditionToValue("x:sourceFile", "x:prompt", "false") { Application = ApplicationType.Excel });
         }
 
         /// <summary>
@@ -49980,8 +49980,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Consolidation), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.CacheSourceExtensionList), 0, 1)
             };
-            builder.AddConstraint(new ReferenceExistConstraint(":connectionId", "/WorkbookPart/ConnectionsPart", "x:connection", "x:connection", ":id"));
-            builder.AddConstraint(new UniqueAttributeValueConstraint(":connectionId", true, null));
+            builder.AddConstraint(new ReferenceExistConstraint("x:connectionId", "/WorkbookPart/ConnectionsPart", "x:connection", "x:connection", "x:id"));
+            builder.AddConstraint(new UniqueAttributeValueConstraint("x:connectionId", true, null));
         }
 
         /// <summary>
@@ -51272,9 +51272,9 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.StringItem), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.DateTimeItem), 1, 1)
             };
-            builder.AddConstraint(new AttributeValueSetConstraint(":maxValue", false, new string[] { "NaN", "INF", "-INF" }));
-            builder.AddConstraint(new AttributeValueSetConstraint(":minValue", false, new string[] { "NaN", "INF", "-INF" }));
-            builder.AddConstraint(new AttributeValueLessEqualToAnother(":minValue", ":maxValue", true));
+            builder.AddConstraint(new AttributeValueSetConstraint("x:maxValue", false, new string[] { "NaN", "INF", "-INF" }));
+            builder.AddConstraint(new AttributeValueSetConstraint("x:minValue", false, new string[] { "NaN", "INF", "-INF" }));
+            builder.AddConstraint(new AttributeValueLessEqualToAnother("x:minValue", "x:maxValue", true));
         }
 
         /// <inheritdoc/>
@@ -53143,7 +53143,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 .AddAttribute("showRowStripes", a => a.ShowRowStripes)
 .AddAttribute("showColStripes", a => a.ShowColumnStripes)
 .AddAttribute("showLastColumn", a => a.ShowLastColumn);
-            builder.AddConstraint(new AttributeValueLengthConstraint(":name", 0, 255) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:name", 0, 255) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -53940,10 +53940,10 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.SortState), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.ExtensionList), 0, 1)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":unboundColumnsLeft", true, double.NegativeInfinity, true, 16383, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":unboundColumnsRight", true, double.NegativeInfinity, true, 16383, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":nextId", true, double.NegativeInfinity, true, 65535, true));
-            builder.AddConstraint(new AttributeValueRangeConstraint(":minimumVersion", true, 0, true, 31, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:unboundColumnsLeft", true, double.NegativeInfinity, true, 16383, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:unboundColumnsRight", true, double.NegativeInfinity, true, 16383, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:nextId", true, double.NegativeInfinity, true, 65535, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:minimumVersion", true, 0, true, 31, true));
         }
 
         /// <summary>
@@ -54490,9 +54490,9 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.DataValidation), 1, 65534)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":xWindow", true, double.NegativeInfinity, true, 65535, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":yWindow", true, double.NegativeInfinity, true, 65535, true) { Application = ApplicationType.Excel });
-            builder.AddConstraint(new AttributeValueRangeConstraint(":count", true, double.NegativeInfinity, true, 65535, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:xWindow", true, double.NegativeInfinity, true, 65535, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:yWindow", true, double.NegativeInfinity, true, 65535, true) { Application = ApplicationType.Excel });
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:count", true, double.NegativeInfinity, true, 65535, true) { Application = ApplicationType.Excel });
         }
 
         /// <inheritdoc/>
@@ -55707,7 +55707,7 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.TableStyle), 0, 0)
             };
-            builder.AddConstraint(new AttributeValueLengthConstraint(":defaultTableStyle", 1, 255));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:defaultTableStyle", 1, 255));
         }
 
         /// <inheritdoc/>
@@ -56071,10 +56071,10 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 {
 aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\\}") });
 });
-            builder.AddConstraint(new AttributeValueLengthConstraint(":appName", 0, 65535));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":lastEdited", 0, 65535));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":lowestEdited", 0, 65535));
-            builder.AddConstraint(new AttributeValueLengthConstraint(":rupBuild", 0, 65535));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:appName", 0, 65535));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:lastEdited", 0, 65535));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:lowestEdited", 0, 65535));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:rupBuild", 0, 65535));
         }
 
         /// <inheritdoc/>
@@ -56225,7 +56225,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (2L) });
 .AddAttribute("hashValue", a => a.HashValue)
 .AddAttribute("saltValue", a => a.SaltValue)
 .AddAttribute("spinCount", a => a.SpinCount);
-            builder.AddConstraint(new AttributeValueLengthConstraint(":userName", 1, 54));
+            builder.AddConstraint(new AttributeValueLengthConstraint("x:userName", 1, 54));
         }
 
         /// <inheritdoc/>
@@ -57039,7 +57039,7 @@ aBuilder.AddValidator(new StringValidator() { Length = (2L) });
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.FunctionGroup), 0, 255)
             };
-            builder.AddConstraint(new AttributeValueRangeConstraint(":builtInGroupCount", true, double.NegativeInfinity, true, 255, true));
+            builder.AddConstraint(new AttributeValueRangeConstraint("x:builtInGroupCount", true, double.NegativeInfinity, true, 255, true));
         }
 
         /// <inheritdoc/>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_wordprocessingml_2006_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_wordprocessingml_2006_main.g.cs
@@ -12882,8 +12882,8 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("w:bottom");
-            builder.AddConstraint(new AttributeCannotOmitConstraint("w:type") { Application = ApplicationType.Word });
-            builder.AddConstraint(new AttributeCannotOmitConstraint("w:w") { Application = ApplicationType.Word });
+            builder.AddConstraint(new AttributeCannotOmitConstraint("@w:type") { Application = ApplicationType.Word });
+            builder.AddConstraint(new AttributeCannotOmitConstraint("@w:w") { Application = ApplicationType.Word });
         }
 
         /// <inheritdoc/>
@@ -23159,7 +23159,7 @@ aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("w:subDoc");
-            builder.AddConstraint(new RelationshipTypeConstraint("r:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/subDocument"));
+            builder.AddConstraint(new RelationshipTypeConstraint("w:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/subDocument"));
         }
 
         /// <inheritdoc/>
@@ -23187,7 +23187,7 @@ aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("w:printerSettings");
-            builder.AddConstraint(new RelationshipTypeConstraint("r:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/printerSettings"));
+            builder.AddConstraint(new RelationshipTypeConstraint("w:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/printerSettings"));
         }
 
         /// <inheritdoc/>
@@ -23243,7 +23243,7 @@ aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("w:recipientData");
-            builder.AddConstraint(new RelationshipTypeConstraint("r:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/recipientData"));
+            builder.AddConstraint(new RelationshipTypeConstraint("w:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/recipientData"));
         }
 
         /// <inheritdoc/>
@@ -23271,7 +23271,7 @@ aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("w:dataSource");
-            builder.AddConstraint(new RelationshipTypeConstraint("r:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/mailMergeSource"));
+            builder.AddConstraint(new RelationshipTypeConstraint("w:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/mailMergeSource"));
         }
 
         /// <inheritdoc/>
@@ -23326,7 +23326,7 @@ aBuilder.AddValidator(new StringValidator() { MaxLength = (255L) });
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("w:sourceFileName");
-            builder.AddConstraint(new RelationshipTypeConstraint("r:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/frame"));
+            builder.AddConstraint(new RelationshipTypeConstraint("w:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/frame"));
         }
 
         /// <inheritdoc/>
@@ -23974,8 +23974,8 @@ aBuilder.AddValidator(new OfficeVersionValidator(FileFormatVersions.Office2010))
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("w:bottom");
-            builder.AddConstraint(new AttributeCannotOmitConstraint("w:type") { Application = ApplicationType.Word });
-            builder.AddConstraint(new AttributeCannotOmitConstraint("w:w") { Application = ApplicationType.Word });
+            builder.AddConstraint(new AttributeCannotOmitConstraint("@w:type") { Application = ApplicationType.Word });
+            builder.AddConstraint(new AttributeCannotOmitConstraint("@w:w") { Application = ApplicationType.Word });
         }
 
         /// <inheritdoc/>
@@ -26425,7 +26425,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Wordprocessing.AltChunkProperties), 0, 1)
             };
-            builder.AddConstraint(new RelationshipTypeConstraint("r:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/aFChunk"));
+            builder.AddConstraint(new RelationshipTypeConstraint("w:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/aFChunk"));
             builder.AddConstraint(new RelationshipExistConstraint("r:id"));
         }
 
@@ -40515,7 +40515,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Wordprocessing.ColumnIndex), 1, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Wordprocessing.UniqueTag), 1, 1)
             };
-            builder.AddConstraint(new RelationshipTypeConstraint("r:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/recipientData"));
+            builder.AddConstraint(new RelationshipTypeConstraint("w:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/recipientData"));
         }
 
         /// <summary>
@@ -54100,7 +54100,7 @@ union.AddValidator<Int32Value>(new NumberValidator() { MaxInclusive = (-2L) });
 aBuilder.AddValidator(new StringValidator() { MaxLength = (254L) });
 })
 .AddAttribute("r:id", a => a.Id);
-            builder.AddConstraint(new RelationshipTypeConstraint("r:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/control"));
+            builder.AddConstraint(new RelationshipTypeConstraint("w:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/control"));
             builder.AddConstraint(new UniqueAttributeValueConstraint("w:name", true, null));
         }
 
@@ -57968,7 +57968,7 @@ aBuilder.AddValidator(new StringValidator() { MaxLength = (100L) });
             builder.AddElement<SaveThroughXslt>()
 .AddAttribute("r:id", a => a.Id)
 .AddAttribute("w:solutionID", a => a.SolutionId);
-            builder.AddConstraint(new RelationshipTypeConstraint("r:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/transform"));
+            builder.AddConstraint(new RelationshipTypeConstraint(":id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/transform"));
         }
 
         /// <inheritdoc/>
@@ -60696,7 +60696,7 @@ aBuilder.AddValidator(new StringValidator() { Pattern = ("[0-9a-fA-F]*"), MinLen
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("w:embedRegular");
-            builder.AddConstraint(new RelationshipTypeConstraint("r:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/font"));
+            builder.AddConstraint(new RelationshipTypeConstraint("w:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/font"));
             builder.AddConstraint(new RelationshipExistConstraint("r:id"));
         }
 
@@ -60725,7 +60725,7 @@ aBuilder.AddValidator(new StringValidator() { Pattern = ("[0-9a-fA-F]*"), MinLen
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("w:embedBold");
-            builder.AddConstraint(new RelationshipTypeConstraint("r:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/font"));
+            builder.AddConstraint(new RelationshipTypeConstraint("w:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/font"));
         }
 
         /// <inheritdoc/>
@@ -60753,7 +60753,7 @@ aBuilder.AddValidator(new StringValidator() { Pattern = ("[0-9a-fA-F]*"), MinLen
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("w:embedItalic");
-            builder.AddConstraint(new RelationshipTypeConstraint("r:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/font"));
+            builder.AddConstraint(new RelationshipTypeConstraint("w:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/font"));
         }
 
         /// <inheritdoc/>
@@ -60781,7 +60781,7 @@ aBuilder.AddValidator(new StringValidator() { Pattern = ("[0-9a-fA-F]*"), MinLen
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("w:embedBoldItalic");
-            builder.AddConstraint(new RelationshipTypeConstraint("r:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/font"));
+            builder.AddConstraint(new RelationshipTypeConstraint("w:id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/font"));
         }
 
         /// <inheritdoc/>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/www_w3_org_2003_04_emma.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/www_w3_org_2003_04_emma.g.cs
@@ -944,7 +944,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
                     new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.Ink.ContextNode), 0, 1)
                 }
             };
-            builder.AddConstraint(new AttributeValuePatternConstraint(":id", @"[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}") { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValuePatternConstraint("emma:id", @"[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}") { Version = FileFormatVersions.Office2010 });
             builder.AddConstraint(new AttributeValueSetConstraint("emma:mode", true, new string[] { "ink" }) { Version = FileFormatVersions.Office2010 });
         }
 
@@ -1531,7 +1531,7 @@ aBuilder.AddValidator(new NumberValidator() { MinInclusive = (0L), MaxInclusive 
                     new ElementParticle(typeof(DocumentFormat.OpenXml.EMMA.Sequence), 1, 1)
                 }
             };
-            builder.AddConstraint(new AttributeValueSetConstraint(":disjunction-type", true, new string[] { "recognition" }) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueSetConstraint("emma:disjunction-type", true, new string[] { "recognition" }) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/www_w3_org_2003_InkML.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/www_w3_org_2003_InkML.g.cs
@@ -753,7 +753,7 @@ union.AddValidator(StringValidator.Instance);
             {
                 new ElementParticle(typeof(DocumentFormat.OpenXml.InkML.Mapping), 0, 0)
             };
-            builder.AddConstraint(new AttributeValueSetConstraint(":units", true, new string[] { "dev", "in", "cm", "deg", "rad", "s", "lb", "g" }) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueSetConstraint("inkml:units", true, new string[] { "dev", "in", "cm", "deg", "rad", "s", "lb", "g" }) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -947,7 +947,7 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerOtherUnitsV
 union.AddValidator(StringValidator.Instance);
 });
 });
-            builder.AddConstraint(new AttributeValueSetConstraint(":units", true, new string[] { "dev", "in", "cm", "deg", "rad", "s", "lb", "g" }) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueSetConstraint("inkml:units", true, new string[] { "dev", "in", "cm", "deg", "rad", "s", "lb", "g" }) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -1259,7 +1259,7 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerOtherUnitsV
 union.AddValidator(StringValidator.Instance);
 });
 });
-            builder.AddConstraint(new AttributeValueSetConstraint(":units", true, new string[] { "dev", "in", "cm", "deg", "rad", "s", "lb", "g" }) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueSetConstraint("inkml:units", true, new string[] { "dev", "in", "cm", "deg", "rad", "s", "lb", "g" }) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -1361,7 +1361,7 @@ union.AddValidator<EnumValue<DocumentFormat.OpenXml.InkML.StandardPerOtherUnitsV
 union.AddValidator(StringValidator.Instance);
 });
 });
-            builder.AddConstraint(new AttributeValueSetConstraint(":units", true, new string[] { "dev", "in", "cm", "deg", "rad", "s", "lb", "g" }) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueSetConstraint("inkml:units", true, new string[] { "dev", "in", "cm", "deg", "rad", "s", "lb", "g" }) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>
@@ -1781,7 +1781,7 @@ union.AddValidator(StringValidator.Instance);
                 new ElementParticle(typeof(DocumentFormat.OpenXml.InkML.Annotation), 0, 0),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.InkML.AnnotationXml), 0, 0)
             };
-            builder.AddConstraint(new AttributeValueSetConstraint(":units", true, new string[] { "dev", "in", "cm", "deg", "rad", "s", "lb", "g" }) { Version = FileFormatVersions.Office2010 });
+            builder.AddConstraint(new AttributeValueSetConstraint("inkml:units", true, new string[] { "dev", "in", "cm", "deg", "rad", "s", "lb", "g" }) { Version = FileFormatVersions.Office2010 });
         }
 
         /// <inheritdoc/>

--- a/src/DocumentFormat.OpenXml/Validation/Semantic/ReferenceExistConstraint.cs
+++ b/src/DocumentFormat.OpenXml/Validation/Semantic/ReferenceExistConstraint.cs
@@ -93,10 +93,8 @@ namespace DocumentFormat.OpenXml.Validation.Semantic
                 {
                     if (element.QName.Equals(key.constraint._element))
                     {
-                        var attribute = element.ParsedState.Attributes[key.constraint._attribute];
-
                         // Attributes whose value is empty string or null don't need to be cached.
-                        if (attribute.Value is not null && !attribute.Value.InnerText.IsNullOrEmpty())
+                        if (TryFindAttribute(element, key.constraint._attribute, out var attribute) && attribute.Value is not null && !attribute.Value.InnerText.IsNullOrEmpty())
                         {
                             referencedAttributes.Add(attribute.Value.InnerText);
                         }


### PR DESCRIPTION
This may lead to some prefixes that are not correct, but it matches the
actual schematron items we use. This had been cleaned up on the backend,
but required loading the SDK file itself in order to do so. By breaking
that dependency, we must now do the same logic. This is being done in
the TryFindAttribute method and does the following:

- Check if there is an exact match. Returns that if found
- Find a match by name only as a back up
