### PR TITLE
Enhance Linq feature

### DIFF
--- a/src/DocumentFormat.OpenXml.Linq/Feature/IPartRootXElementFeature.cs
+++ b/src/DocumentFormat.OpenXml.Linq/Feature/IPartRootXElementFeature.cs
@@ -12,6 +12,11 @@ namespace DocumentFormat.OpenXml.Packaging
     public interface IPartRootXElementFeature
     {
         /// <summary>
+        /// Gets or sets the associated <see cref="XDocument" />. Setting will save the underlying <see cref="OpenXmlPart"/>.
+        /// </summary>
+        XDocument Document { get; set; }
+
+        /// <summary>
         /// Gets or sets the associated <see cref="XElement"/>. Setting will save the underlying <see cref="OpenXmlPart"/>.
         /// </summary>
         [DisallowNull]

--- a/src/DocumentFormat.OpenXml.Linq/Feature/OpenXmlLinqExtensions.cs
+++ b/src/DocumentFormat.OpenXml.Linq/Feature/OpenXmlLinqExtensions.cs
@@ -7,7 +7,7 @@ using System.Xml.Linq;
 namespace DocumentFormat.OpenXml.Packaging
 {
     /// <summary>
-    /// Extensions to access an <see cref="XElement"/> instance for parts.
+    /// Extensions to access an <see cref="XElement"/> or <see cref="XDocument"/> instance for parts.
     /// </summary>
     public static class OpenXmlLinqExtensions
     {
@@ -36,34 +36,103 @@ namespace DocumentFormat.OpenXml.Packaging
         }
 
         /// <summary>
+        /// Gets an <see cref="XDocument"/> representation of the <paramref name="part"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This method always returns the same <see cref="XDocument"/> instance, unless that
+        /// instance is changed via <see cref="SetXDocument"/>. Calling this method has the same
+        /// effect as calling <c>part.GetXElement().Document</c>.
+        /// </para>
+        /// <para>
+        /// When called with a given <see cref="OpenXmlPart"/> for the first time after having
+        /// opened the containing <see cref="OpenXmlPackage"/> or saved the strongly-typed
+        /// <see cref="OpenXmlPartRootElement"/> to the OpenXmlPart, deserializes, caches, and
+        /// returns the outer XML of an already loaded OpenXmlPartRootElement or the content
+        /// of the OpenXmlPart as an <see cref="XDocument"/>. In the following calls, directly
+        /// returns the cached XDocument.
+        /// </para>
+        /// </remarks>
+        /// <param name="part">The part to get the contents of.</param>
+        /// <returns>An <see cref="XDocument"/>.</returns>
+        /// <seealso cref="GetXElement"/>
+        /// <seealso cref="SetXDocument"/>
+        /// <seealso cref="SaveXDocument"/>
+        public static XDocument GetXDocument(this OpenXmlPart part)
+            => part.GetPartRootXElementFeature().Document;
+
+        /// <summary>
         /// Gets an <see cref="XElement"/> representation of the <paramref name="part"/>.
         /// </summary>
         /// <remarks>
+        /// <para>
+        /// Calling this method has same effect as calling <c>part.GetXDocument().Root</c>.
+        /// </para>
+        /// <para>
         /// When called with a given <see cref="OpenXmlPart"/> for the first time after having
         /// opened the containing <see cref="OpenXmlPackage"/> or saved the strongly-typed
         /// <see cref="OpenXmlPartRootElement"/> to the OpenXmlPart, deserializes, caches, and
         /// returns the outer XML of an already loaded OpenXmlPartRootElement or the content
         /// of the OpenXmlPart as an <see cref="XElement"/>. In the following calls, directly
         /// returns the cached XElement.
+        /// </para>
         /// </remarks>
         /// <param name="part">The part to get the contents of.</param>
         /// <returns>An <see cref="XElement"/>.</returns>
+        /// <seealso cref="GetXDocument"/>
+        /// <seealso cref="SetXElement"/>
+        /// <seealso cref="SaveXElement"/>
         public static XElement? GetXElement(this OpenXmlPart part)
             => part.GetPartRootXElementFeature().Root;
+
+        /// <summary>
+        /// Sets the <see cref="OpenXmlPart"/>'s <see cref="XDocument"/> to the given XDocument,
+        /// serializes and writes the XDocument to the OpenXmlPart, and reloads the OpenXmlPart's
+        /// <see cref="OpenXmlPartRootElement"/> if it was previously loaded.
+        /// </summary>
+        /// <param name="part">The <see cref="OpenXmlPart"/>.</param>
+        /// <param name="document">The <see cref="XDocument"/>.</param>
+        /// <seealso cref="GetXDocument"/>
+        /// <seealso cref="SaveXDocument"/>
+        public static void SetXDocument(this OpenXmlPart part, XDocument document)
+            => part.GetPartRootXElementFeature().Document = document;
 
         /// <summary>
         /// Sets the <see cref="OpenXmlPart"/>'s root <see cref="XElement"/> to the given XElement,
         /// serializes and writes the XElement to the OpenXmlPart, and reloads the OpenXmlPart's
         /// <see cref="OpenXmlPartRootElement"/> if it was previously loaded.
         /// </summary>
+        /// <remarks>
+        /// Effectively sets the <see cref="XDocument.Root"/> property of the <see cref="XDocument"/>
+        /// returned by <see cref="GetXDocument"/>.
+        /// </remarks>
         /// <param name="part">The <see cref="OpenXmlPart"/>.</param>
         /// <param name="element">The <see cref="XElement"/>.</param>
+        /// <seealso cref="GetXElement"/>
+        /// <seealso cref="SaveXElement"/>
         public static void SetXElement(this OpenXmlPart part, XElement element)
             => part.GetPartRootXElementFeature().Root = element;
 
         /// <summary>
-        /// Saves the current <see cref="XElement"/> to the part.
+        /// Saves the current <see cref="XDocument"/> to the part.
         /// </summary>
+        /// <remarks>
+        /// Calling this method has the same effect as calling <seealso cref="SaveXElement"/>.
+        /// This method is provided for naming consistency with <see cref="GetXDocument"/> and
+        /// <see cref="SetXDocument"/>.
+        /// </remarks>
+        /// <param name="part">The part to save to.</param>
+        public static void SaveXDocument(this OpenXmlPart part)
+            => part.GetPartRootXElementFeature().Save();
+
+        /// <summary>
+        /// Saves the current root <see cref="XElement"/> to the part.
+        /// </summary>
+        /// <remarks>
+        /// Calling this method has the same effect as calling <see cref="SaveXDocument"/>.
+        /// This method is provided for naming consistency with <see cref="GetXElement"/> and
+        /// <see cref="SetXElement"/>.
+        /// </remarks>
         /// <param name="part">The part to save to.</param>
         public static void SaveXElement(this OpenXmlPart part)
             => part.GetPartRootXElementFeature().Save();

--- a/src/DocumentFormat.OpenXml.Linq/PublicAPI.Unshipped.txt
+++ b/src/DocumentFormat.OpenXml.Linq/PublicAPI.Unshipped.txt
@@ -74,13 +74,18 @@ DocumentFormat.OpenXml.Linq.XML
 DocumentFormat.OpenXml.Linq.XNE
 DocumentFormat.OpenXml.Linq.XVML
 DocumentFormat.OpenXml.Packaging.IPartRootXElementFeature
+DocumentFormat.OpenXml.Packaging.IPartRootXElementFeature.Document.get -> System.Xml.Linq.XDocument!
+DocumentFormat.OpenXml.Packaging.IPartRootXElementFeature.Document.set -> void
 DocumentFormat.OpenXml.Packaging.IPartRootXElementFeature.Root.get -> System.Xml.Linq.XElement?
 DocumentFormat.OpenXml.Packaging.IPartRootXElementFeature.Root.set -> void
 DocumentFormat.OpenXml.Packaging.IPartRootXElementFeature.Save() -> void
 DocumentFormat.OpenXml.Packaging.OpenXmlLinqExtensions
 static DocumentFormat.OpenXml.Packaging.OpenXmlLinqExtensions.GetPartRootXElementFeature(this DocumentFormat.OpenXml.Packaging.OpenXmlPart! part) -> DocumentFormat.OpenXml.Packaging.IPartRootXElementFeature!
+static DocumentFormat.OpenXml.Packaging.OpenXmlLinqExtensions.GetXDocument(this DocumentFormat.OpenXml.Packaging.OpenXmlPart! part) -> System.Xml.Linq.XDocument!
 static DocumentFormat.OpenXml.Packaging.OpenXmlLinqExtensions.GetXElement(this DocumentFormat.OpenXml.Packaging.OpenXmlPart! part) -> System.Xml.Linq.XElement?
+static DocumentFormat.OpenXml.Packaging.OpenXmlLinqExtensions.SaveXDocument(this DocumentFormat.OpenXml.Packaging.OpenXmlPart! part) -> void
 static DocumentFormat.OpenXml.Packaging.OpenXmlLinqExtensions.SaveXElement(this DocumentFormat.OpenXml.Packaging.OpenXmlPart! part) -> void
+static DocumentFormat.OpenXml.Packaging.OpenXmlLinqExtensions.SetXDocument(this DocumentFormat.OpenXml.Packaging.OpenXmlPart! part, System.Xml.Linq.XDocument! document) -> void
 static DocumentFormat.OpenXml.Packaging.OpenXmlLinqExtensions.SetXElement(this DocumentFormat.OpenXml.Packaging.OpenXmlPart! part, System.Xml.Linq.XElement! element) -> void
 static readonly DocumentFormat.OpenXml.Linq.MC.AlternateContent -> System.Xml.Linq.XName!
 static readonly DocumentFormat.OpenXml.Linq.MC.Choice -> System.Xml.Linq.XName!


### PR DESCRIPTION
This PR enhances the `RootXElementFeature`, `IPartRootXElementFeature`, and `OpenXmlLinqExtensions` by adding the capability to work with both `XElement` and `XDocument` representations. It adds the following properties and extension methods to the public API:

```csharp
public interface IPartRootXElementFeature
{
    XDocument Document { get; set; }
}

public static class OpenXmlLinqExtensions
{
    XDocument GetXDocument(this OpenXmlPart part);
    void SetXDocument(this OpenXmlPart part, XDocument document);
    void SaveXDocument(this OpenXmlPart part);
}
```

The `SaveXDocument` extension method is only added for naming consistency with the `GetXDocument` and `SetXDocument` methods. It has the exact same effect as calling `part.SaveXElement()`.

Calling `part.GetXElement()` has the same effect as `part.GetXDocument().Root`. Calling `part.SetXElement(element)` either adds or replaces the `XDocument` instance's root element. In other words, we can freely use either subset of Get, Set, and Save methods or mix and match as desired.

Depending on the use case, the `GetXDocument` method has the benefit of always returning the same instance (unless you change it via `SetXDocument`). For example, you can get the instance from an initially empty part and change the root `XElement` via `SetXElement`. Further, changing and saving the strongly typed `OpenXmlPartRootElement` will only remove the `XDocument` instance's root element but not replace the instance. Thus, you could hold on to that instance in your code if desired.

`XDocument` representations are extensively used by the [Open XML PowerTools](https://github.com/EricWhiteDev/Open-Xml-PowerTools). To leverage the Linq feature in the Open XML PowerTools without lots of breaking changes, we need the ability to get, set, and save `XDocument` representations as well.