### PR TITLE
fixes a couple historical namespace issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - DocumentFormat.OpenXml.Office.Drawing.ShapeTree is now available only in Office 2010 and above, not 2007.
-- DocumentFormat.OpenXml.Office2010.ExcelAc changed to DocumentFormat.OpenXml.Office2013.ExcelAc, affecting the List class.
 
 ## [2.14.0] - 2021-10-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added virtual method for content type checking in `OpenXmlPart` and fix issue for `model/gltf.binary` (#1069)
 
+### Fixed
+- DocumentFormat.OpenXml.Office.Drawing.ShapeTree is now available only in Office 2010 and above, not 2007.
+- DocumentFormat.OpenXml.Office2010.ExcelAc changed to DocumentFormat.OpenXml.Office2013.ExcelAc, affecting the List class.
+
 ## [2.14.0] - 2021-10-28
 
 ### Added

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2008_diagram.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2008_diagram.g.cs
@@ -18,7 +18,7 @@ namespace DocumentFormat.OpenXml.Office.Drawing
 {
     /// <summary>
     /// <para>Defines the Drawing Class.</para>
-    /// <para>This class is available in Office 2007 and above.</para>
+    /// <para>This class is available in Office 2010 and above.</para>
     /// <para>When the object is serialized out as xml, it's qualified name is dsp:drawing.</para>
     /// </summary>
     /// <remark>
@@ -67,10 +67,11 @@ namespace DocumentFormat.OpenXml.Office.Drawing
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("dsp:drawing");
+            builder.Availability = FileFormatVersions.Office2010;
             builder.AddChild<DocumentFormat.OpenXml.Office.Drawing.ShapeTree>();
             builder.Particle = new CompositeParticle.Builder(ParticleType.Sequence, 1, 1)
             {
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.ShapeTree), 1, 1)
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.ShapeTree), 1, 1, version: FileFormatVersions.Office2010)
             };
         }
 
@@ -124,7 +125,7 @@ namespace DocumentFormat.OpenXml.Office.Drawing
 
     /// <summary>
     /// <para>Defines the DataModelExtensionBlock Class.</para>
-    /// <para>This class is available in Office 2007 and above.</para>
+    /// <para>This class is available in Office 2010 and above.</para>
     /// <para>When the object is serialized out as xml, it's qualified name is dsp:dataModelExt.</para>
     /// </summary>
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -140,7 +141,7 @@ namespace DocumentFormat.OpenXml.Office.Drawing
         }
 
         /// <summary>
-        /// <para>relId</para>
+        /// <para>relId, this property is only available in Office 2010 and later.</para>
         /// <para>Represents the following attribute in the schema: relId</para>
         /// </summary>
 
@@ -156,7 +157,7 @@ namespace DocumentFormat.OpenXml.Office.Drawing
         }
 
         /// <summary>
-        /// <para>minVer</para>
+        /// <para>minVer, this property is only available in Office 2010 and later.</para>
         /// <para>Represents the following attribute in the schema: minVer</para>
         /// </summary>
 
@@ -175,6 +176,7 @@ namespace DocumentFormat.OpenXml.Office.Drawing
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("dsp:dataModelExt");
+            builder.Availability = FileFormatVersions.Office2010;
             builder.AddElement<DataModelExtensionBlock>()
 .AddAttribute("relId", a => a.RelId)
 .AddAttribute("minVer", a => a.MinVer, aBuilder =>
@@ -189,7 +191,7 @@ aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
 
     /// <summary>
     /// <para>Defines the NonVisualDrawingProperties Class.</para>
-    /// <para>This class is available in Office 2007 and above.</para>
+    /// <para>This class is available in Office 2010 and above.</para>
     /// <para>When the object is serialized out as xml, it's qualified name is dsp:cNvPr.</para>
     /// </summary>
     /// <remark>
@@ -320,6 +322,7 @@ aBuilder.AddValidator(new StringValidator() { IsUri = (true) });
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("dsp:cNvPr");
+            builder.Availability = FileFormatVersions.Office2010;
             builder.AddChild<DocumentFormat.OpenXml.Drawing.HyperlinkOnClick>();
             builder.AddChild<DocumentFormat.OpenXml.Drawing.HyperlinkOnHover>();
             builder.AddChild<DocumentFormat.OpenXml.Drawing.NonVisualDrawingPropertiesExtensionList>();
@@ -388,7 +391,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 
     /// <summary>
     /// <para>Defines the NonVisualDrawingShapeProperties Class.</para>
-    /// <para>This class is available in Office 2007 and above.</para>
+    /// <para>This class is available in Office 2010 and above.</para>
     /// <para>When the object is serialized out as xml, it's qualified name is dsp:cNvSpPr.</para>
     /// </summary>
     /// <remark>
@@ -454,6 +457,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("dsp:cNvSpPr");
+            builder.Availability = FileFormatVersions.Office2010;
             builder.AddChild<DocumentFormat.OpenXml.Drawing.ExtensionList>();
             builder.AddChild<DocumentFormat.OpenXml.Drawing.ShapeLocks>();
             builder.AddElement<NonVisualDrawingShapeProperties>()
@@ -497,7 +501,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 
     /// <summary>
     /// <para>Defines the ShapeNonVisualProperties Class.</para>
-    /// <para>This class is available in Office 2007 and above.</para>
+    /// <para>This class is available in Office 2010 and above.</para>
     /// <para>When the object is serialized out as xml, it's qualified name is dsp:nvSpPr.</para>
     /// </summary>
     /// <remark>
@@ -547,12 +551,13 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("dsp:nvSpPr");
+            builder.Availability = FileFormatVersions.Office2010;
             builder.AddChild<DocumentFormat.OpenXml.Office.Drawing.NonVisualDrawingProperties>();
             builder.AddChild<DocumentFormat.OpenXml.Office.Drawing.NonVisualDrawingShapeProperties>();
             builder.Particle = new CompositeParticle.Builder(ParticleType.Sequence, 1, 1)
             {
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.NonVisualDrawingProperties), 1, 1),
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.NonVisualDrawingShapeProperties), 1, 1)
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.NonVisualDrawingProperties), 1, 1, version: FileFormatVersions.Office2010),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.NonVisualDrawingShapeProperties), 1, 1, version: FileFormatVersions.Office2010)
             };
         }
 
@@ -588,7 +593,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 
     /// <summary>
     /// <para>Defines the ShapeProperties Class.</para>
-    /// <para>This class is available in Office 2007 and above.</para>
+    /// <para>This class is available in Office 2010 and above.</para>
     /// <para>When the object is serialized out as xml, it's qualified name is dsp:spPr.</para>
     /// </summary>
     /// <remark>
@@ -667,6 +672,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("dsp:spPr");
+            builder.Availability = FileFormatVersions.Office2010;
             builder.AddChild<DocumentFormat.OpenXml.Drawing.BlipFill>();
             builder.AddChild<DocumentFormat.OpenXml.Drawing.CustomGeometry>();
             builder.AddChild<DocumentFormat.OpenXml.Drawing.EffectDag>();
@@ -744,7 +750,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 
     /// <summary>
     /// <para>Defines the ShapeStyle Class.</para>
-    /// <para>This class is available in Office 2007 and above.</para>
+    /// <para>This class is available in Office 2010 and above.</para>
     /// <para>When the object is serialized out as xml, it's qualified name is dsp:style.</para>
     /// </summary>
     /// <remark>
@@ -796,6 +802,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("dsp:style");
+            builder.Availability = FileFormatVersions.Office2010;
             builder.AddChild<DocumentFormat.OpenXml.Drawing.FontReference>();
             builder.AddChild<DocumentFormat.OpenXml.Drawing.LineReference>();
             builder.AddChild<DocumentFormat.OpenXml.Drawing.FillReference>();
@@ -867,7 +874,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 
     /// <summary>
     /// <para>Defines the TextBody Class.</para>
-    /// <para>This class is available in Office 2007 and above.</para>
+    /// <para>This class is available in Office 2010 and above.</para>
     /// <para>When the object is serialized out as xml, it's qualified name is dsp:txBody.</para>
     /// </summary>
     /// <remark>
@@ -918,6 +925,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("dsp:txBody");
+            builder.Availability = FileFormatVersions.Office2010;
             builder.AddChild<DocumentFormat.OpenXml.Drawing.BodyProperties>();
             builder.AddChild<DocumentFormat.OpenXml.Drawing.ListStyle>();
             builder.AddChild<DocumentFormat.OpenXml.Drawing.Paragraph>();
@@ -961,7 +969,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 
     /// <summary>
     /// <para>Defines the Transform2D Class.</para>
-    /// <para>This class is available in Office 2007 and above.</para>
+    /// <para>This class is available in Office 2010 and above.</para>
     /// <para>When the object is serialized out as xml, it's qualified name is dsp:txXfrm.</para>
     /// </summary>
     /// <remark>
@@ -1059,6 +1067,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("dsp:txXfrm");
+            builder.Availability = FileFormatVersions.Office2010;
             builder.AddChild<DocumentFormat.OpenXml.Drawing.Offset>();
             builder.AddChild<DocumentFormat.OpenXml.Drawing.Extents>();
             builder.AddElement<Transform2D>()
@@ -1104,7 +1113,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 
     /// <summary>
     /// <para>Defines the OfficeArtExtensionList Class.</para>
-    /// <para>This class is available in Office 2007 and above.</para>
+    /// <para>This class is available in Office 2010 and above.</para>
     /// <para>When the object is serialized out as xml, it's qualified name is dsp:extLst.</para>
     /// </summary>
     /// <remark>
@@ -1153,6 +1162,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("dsp:extLst");
+            builder.Availability = FileFormatVersions.Office2010;
             builder.AddChild<DocumentFormat.OpenXml.Drawing.Extension>();
             builder.Particle = new CompositeParticle.Builder(ParticleType.Sequence, 1, 1)
             {
@@ -1172,7 +1182,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 
     /// <summary>
     /// <para>Defines the NonVisualGroupDrawingShapeProperties Class.</para>
-    /// <para>This class is available in Office 2007 and above.</para>
+    /// <para>This class is available in Office 2010 and above.</para>
     /// <para>When the object is serialized out as xml, it's qualified name is dsp:cNvGrpSpPr.</para>
     /// </summary>
     /// <remark>
@@ -1222,6 +1232,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("dsp:cNvGrpSpPr");
+            builder.Availability = FileFormatVersions.Office2010;
             builder.AddChild<DocumentFormat.OpenXml.Drawing.GroupShapeLocks>();
             builder.AddChild<DocumentFormat.OpenXml.Drawing.NonVisualGroupDrawingShapePropsExtensionList>();
             builder.Particle = new CompositeParticle.Builder(ParticleType.Sequence, 1, 1)
@@ -1263,7 +1274,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 
     /// <summary>
     /// <para>Defines the GroupShapeNonVisualProperties Class.</para>
-    /// <para>This class is available in Office 2007 and above.</para>
+    /// <para>This class is available in Office 2010 and above.</para>
     /// <para>When the object is serialized out as xml, it's qualified name is dsp:nvGrpSpPr.</para>
     /// </summary>
     /// <remark>
@@ -1313,12 +1324,13 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("dsp:nvGrpSpPr");
+            builder.Availability = FileFormatVersions.Office2010;
             builder.AddChild<DocumentFormat.OpenXml.Office.Drawing.NonVisualDrawingProperties>();
             builder.AddChild<DocumentFormat.OpenXml.Office.Drawing.NonVisualGroupDrawingShapeProperties>();
             builder.Particle = new CompositeParticle.Builder(ParticleType.Sequence, 1, 1)
             {
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.NonVisualDrawingProperties), 1, 1),
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.NonVisualGroupDrawingShapeProperties), 1, 1)
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.NonVisualDrawingProperties), 1, 1, version: FileFormatVersions.Office2010),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.NonVisualGroupDrawingShapeProperties), 1, 1, version: FileFormatVersions.Office2010)
             };
         }
 
@@ -1354,7 +1366,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 
     /// <summary>
     /// <para>Defines the GroupShapeProperties Class.</para>
-    /// <para>This class is available in Office 2007 and above.</para>
+    /// <para>This class is available in Office 2010 and above.</para>
     /// <para>When the object is serialized out as xml, it's qualified name is dsp:grpSpPr.</para>
     /// </summary>
     /// <remark>
@@ -1429,6 +1441,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("dsp:grpSpPr");
+            builder.Availability = FileFormatVersions.Office2010;
             builder.AddChild<DocumentFormat.OpenXml.Drawing.BlipFill>();
             builder.AddChild<DocumentFormat.OpenXml.Drawing.EffectDag>();
             builder.AddChild<DocumentFormat.OpenXml.Drawing.EffectList>();
@@ -1492,7 +1505,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
 
     /// <summary>
     /// <para>Defines the Shape Class.</para>
-    /// <para>This class is available in Office 2007 and above.</para>
+    /// <para>This class is available in Office 2010 and above.</para>
     /// <para>When the object is serialized out as xml, it's qualified name is dsp:sp.</para>
     /// </summary>
     /// <remark>
@@ -1543,7 +1556,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
         }
 
         /// <summary>
-        /// <para>modelId</para>
+        /// <para>modelId, this property is only available in Office 2010 and later.</para>
         /// <para>Represents the following attribute in the schema: modelId</para>
         /// </summary>
 
@@ -1562,6 +1575,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("dsp:sp");
+            builder.Availability = FileFormatVersions.Office2010;
             builder.AddChild<DocumentFormat.OpenXml.Office.Drawing.OfficeArtExtensionList>();
             builder.AddChild<DocumentFormat.OpenXml.Office.Drawing.ShapeProperties>();
             builder.AddChild<DocumentFormat.OpenXml.Office.Drawing.ShapeStyle>();
@@ -1580,12 +1594,12 @@ union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4
 });
             builder.Particle = new CompositeParticle.Builder(ParticleType.Sequence, 1, 1)
             {
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.ShapeNonVisualProperties), 1, 1),
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.ShapeProperties), 1, 1),
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.ShapeStyle), 0, 1),
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.TextBody), 0, 1),
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.Transform2D), 0, 1),
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.OfficeArtExtensionList), 0, 1)
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.ShapeNonVisualProperties), 1, 1, version: FileFormatVersions.Office2010),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.ShapeProperties), 1, 1, version: FileFormatVersions.Office2010),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.ShapeStyle), 0, 1, version: FileFormatVersions.Office2010),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.TextBody), 0, 1, version: FileFormatVersions.Office2010),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.Transform2D), 0, 1, version: FileFormatVersions.Office2010),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.OfficeArtExtensionList), 0, 1, version: FileFormatVersions.Office2010)
             };
         }
 
@@ -1673,7 +1687,7 @@ union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4
 
     /// <summary>
     /// <para>Defines the GroupShape Class.</para>
-    /// <para>This class is available in Office 2007 and above.</para>
+    /// <para>This class is available in Office 2010 and above.</para>
     /// <para>When the object is serialized out as xml, it's qualified name is dsp:grpSp.</para>
     /// </summary>
     /// <remark>
@@ -1726,16 +1740,17 @@ union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("dsp:grpSp");
+            builder.Availability = FileFormatVersions.Office2010;
             builder.Particle = new CompositeParticle.Builder(ParticleType.Sequence, 1, 1)
             {
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.GroupShapeNonVisualProperties), 1, 1),
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.GroupShapeProperties), 1, 1),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.GroupShapeNonVisualProperties), 1, 1, version: FileFormatVersions.Office2010),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.GroupShapeProperties), 1, 1, version: FileFormatVersions.Office2010),
                 new CompositeParticle.Builder(ParticleType.Choice, 0, 0)
                 {
-                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.Shape), 1, 1),
-                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.GroupShape), 1, 1)
+                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.Shape), 1, 1, version: FileFormatVersions.Office2010),
+                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.GroupShape), 1, 1, version: FileFormatVersions.Office2010)
                 },
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.OfficeArtExtensionList), 0, 1)
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.OfficeArtExtensionList), 0, 1, version: FileFormatVersions.Office2010)
             };
         }
 
@@ -1745,7 +1760,7 @@ union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4
 
     /// <summary>
     /// <para>Defines the ShapeTree Class.</para>
-    /// <para>This class is available in Office 2007 and above.</para>
+    /// <para>This class is available in Office 2010 and above.</para>
     /// <para>When the object is serialized out as xml, it's qualified name is dsp:spTree.</para>
     /// </summary>
     /// <remark>
@@ -1798,16 +1813,17 @@ union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("dsp:spTree");
+            builder.Availability = FileFormatVersions.Office2010;
             builder.Particle = new CompositeParticle.Builder(ParticleType.Sequence, 1, 1)
             {
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.GroupShapeNonVisualProperties), 1, 1),
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.GroupShapeProperties), 1, 1),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.GroupShapeNonVisualProperties), 1, 1, version: FileFormatVersions.Office2010),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.GroupShapeProperties), 1, 1, version: FileFormatVersions.Office2010),
                 new CompositeParticle.Builder(ParticleType.Choice, 0, 0)
                 {
-                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.Shape), 1, 1),
-                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.GroupShape), 1, 1)
+                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.Shape), 1, 1, version: FileFormatVersions.Office2010),
+                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.GroupShape), 1, 1, version: FileFormatVersions.Office2010)
                 },
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.OfficeArtExtensionList), 0, 1)
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.OfficeArtExtensionList), 0, 1, version: FileFormatVersions.Office2010)
             };
         }
 
@@ -1817,7 +1833,7 @@ union.AddValidator(new StringValidator() { Pattern = ("\\{[0-9A-F]{8}-[0-9A-F]{4
 
     /// <summary>
     /// <para>Defines the GroupShapeType Class.</para>
-    /// <para>This class is available in Office 2007 and above.</para>
+    /// <para>This class is available in Office 2010 and above.</para>
     /// <para>When the object is serialized out as xml, it's qualified name is :.</para>
     /// </summary>
     /// <remark>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2011_1_ac.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2011_1_ac.g.cs
@@ -13,11 +13,11 @@ using System;
 using System.Collections.Generic;
 using System.IO.Packaging;
 
-namespace DocumentFormat.OpenXml.Office2013.ExcelAc
+namespace DocumentFormat.OpenXml.Office2010.ExcelAc
 {
     /// <summary>
     /// <para>Defines the List Class.</para>
-    /// <para>This class is available in Office 2013 and above.</para>
+    /// <para>This class is available in Office 2010 and above.</para>
     /// <para>When the object is serialized out as xml, it's qualified name is x12ac:list.</para>
     /// </summary>
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -49,7 +49,7 @@ namespace DocumentFormat.OpenXml.Office2013.ExcelAc
         {
             base.ConfigureMetadata(builder);
             builder.SetSchema("x12ac:list");
-            builder.Availability = FileFormatVersions.Office2013;
+            builder.Availability = FileFormatVersions.Office2010;
         }
 
         /// <inheritdoc/>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2011_1_ac.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2011_1_ac.g.cs
@@ -13,7 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.IO.Packaging;
 
-namespace DocumentFormat.OpenXml.Office2010.ExcelAc
+namespace DocumentFormat.OpenXml.Office2013.ExcelAc
 {
     /// <summary>
     /// <para>Defines the List Class.</para>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2014_revision.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2014_revision.g.cs
@@ -9,7 +9,7 @@ using DocumentFormat.OpenXml.Drawing.Spreadsheet;
 using DocumentFormat.OpenXml.Framework;
 using DocumentFormat.OpenXml.Framework.Metadata;
 using DocumentFormat.OpenXml.Office2010.Excel;
-using DocumentFormat.OpenXml.Office2013.ExcelAc;
+using DocumentFormat.OpenXml.Office2010.ExcelAc;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using DocumentFormat.OpenXml.Validation.Schema;
@@ -6054,7 +6054,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
     /// <list type="bullet">
     ///   <item><description><see cref="DocumentFormat.OpenXml.Spreadsheet.Formula1" /> <c>&lt;x:formula1></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Spreadsheet.Formula2" /> <c>&lt;x:formula2></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office2013.ExcelAc.List" /> <c>&lt;x12ac:list></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office2010.ExcelAc.List" /> <c>&lt;x12ac:list></c></description></item>
     /// </list>
     /// </remark>
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -6308,7 +6308,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             builder.Availability = FileFormatVersions.Office2016;
             builder.AddChild<DocumentFormat.OpenXml.Spreadsheet.Formula1>();
             builder.AddChild<DocumentFormat.OpenXml.Spreadsheet.Formula2>();
-            builder.AddChild<DocumentFormat.OpenXml.Office2013.ExcelAc.List>();
+            builder.AddChild<DocumentFormat.OpenXml.Office2010.ExcelAc.List>();
             builder.AddElement<DataValidation>()
 .AddAttribute("type", a => a.Type)
 .AddAttribute("errorStyle", a => a.ErrorStyle)
@@ -6328,7 +6328,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 });
             builder.Particle = new CompositeParticle.Builder(ParticleType.Sequence, 1, 1)
             {
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office2013.ExcelAc.List), 0, 1, version: FileFormatVersions.Office2013),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.ExcelAc.List), 0, 1, version: FileFormatVersions.Office2010),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Formula1), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Formula2), 0, 1)
             };
@@ -6341,9 +6341,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         /// <remark>
         /// xmlns:x12ac = http://schemas.microsoft.com/office/spreadsheetml/2011/1/ac
         /// </remark>
-        public DocumentFormat.OpenXml.Office2013.ExcelAc.List? List
+        public DocumentFormat.OpenXml.Office2010.ExcelAc.List? List
         {
-            get => GetElement<DocumentFormat.OpenXml.Office2013.ExcelAc.List>();
+            get => GetElement<DocumentFormat.OpenXml.Office2010.ExcelAc.List>();
             set => SetElement(value);
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2014_revision.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_spreadsheetml_2014_revision.g.cs
@@ -9,7 +9,7 @@ using DocumentFormat.OpenXml.Drawing.Spreadsheet;
 using DocumentFormat.OpenXml.Framework;
 using DocumentFormat.OpenXml.Framework.Metadata;
 using DocumentFormat.OpenXml.Office2010.Excel;
-using DocumentFormat.OpenXml.Office2010.ExcelAc;
+using DocumentFormat.OpenXml.Office2013.ExcelAc;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using DocumentFormat.OpenXml.Validation.Schema;
@@ -6054,7 +6054,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
     /// <list type="bullet">
     ///   <item><description><see cref="DocumentFormat.OpenXml.Spreadsheet.Formula1" /> <c>&lt;x:formula1></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Spreadsheet.Formula2" /> <c>&lt;x:formula2></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office2010.ExcelAc.List" /> <c>&lt;x12ac:list></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office2013.ExcelAc.List" /> <c>&lt;x12ac:list></c></description></item>
     /// </list>
     /// </remark>
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -6308,7 +6308,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             builder.Availability = FileFormatVersions.Office2016;
             builder.AddChild<DocumentFormat.OpenXml.Spreadsheet.Formula1>();
             builder.AddChild<DocumentFormat.OpenXml.Spreadsheet.Formula2>();
-            builder.AddChild<DocumentFormat.OpenXml.Office2010.ExcelAc.List>();
+            builder.AddChild<DocumentFormat.OpenXml.Office2013.ExcelAc.List>();
             builder.AddElement<DataValidation>()
 .AddAttribute("type", a => a.Type)
 .AddAttribute("errorStyle", a => a.ErrorStyle)
@@ -6328,7 +6328,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 });
             builder.Particle = new CompositeParticle.Builder(ParticleType.Sequence, 1, 1)
             {
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.ExcelAc.List), 0, 1, version: FileFormatVersions.Office2013),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office2013.ExcelAc.List), 0, 1, version: FileFormatVersions.Office2013),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Formula1), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Formula2), 0, 1)
             };
@@ -6341,9 +6341,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         /// <remark>
         /// xmlns:x12ac = http://schemas.microsoft.com/office/spreadsheetml/2011/1/ac
         /// </remark>
-        public DocumentFormat.OpenXml.Office2010.ExcelAc.List? List
+        public DocumentFormat.OpenXml.Office2013.ExcelAc.List? List
         {
-            get => GetElement<DocumentFormat.OpenXml.Office2010.ExcelAc.List>();
+            get => GetElement<DocumentFormat.OpenXml.Office2013.ExcelAc.List>();
             set => SetElement(value);
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_spreadsheetml_2006_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_spreadsheetml_2006_main.g.cs
@@ -8,6 +8,7 @@ using DocumentFormat.OpenXml.Drawing.Spreadsheet;
 using DocumentFormat.OpenXml.Framework;
 using DocumentFormat.OpenXml.Framework.Metadata;
 using DocumentFormat.OpenXml.Office2010.Excel;
+using DocumentFormat.OpenXml.Office2010.ExcelAc;
 using DocumentFormat.OpenXml.Office2013.Excel;
 using DocumentFormat.OpenXml.Office2013.ExcelAc;
 using DocumentFormat.OpenXml.Packaging;
@@ -30472,7 +30473,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
     /// <list type="bullet">
     ///   <item><description><see cref="DocumentFormat.OpenXml.Spreadsheet.Formula1" /> <c>&lt;x:formula1></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Spreadsheet.Formula2" /> <c>&lt;x:formula2></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office2013.ExcelAc.List" /> <c>&lt;x12ac:list></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office2010.ExcelAc.List" /> <c>&lt;x12ac:list></c></description></item>
     /// </list>
     /// </remark>
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -30725,7 +30726,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             builder.SetSchema("x:dataValidation");
             builder.AddChild<DocumentFormat.OpenXml.Spreadsheet.Formula1>();
             builder.AddChild<DocumentFormat.OpenXml.Spreadsheet.Formula2>();
-            builder.AddChild<DocumentFormat.OpenXml.Office2013.ExcelAc.List>();
+            builder.AddChild<DocumentFormat.OpenXml.Office2010.ExcelAc.List>();
             builder.AddElement<DataValidation>()
 .AddAttribute("type", a => a.Type)
 .AddAttribute("errorStyle", a => a.ErrorStyle)
@@ -30745,7 +30746,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 });
             builder.Particle = new CompositeParticle.Builder(ParticleType.Sequence, 1, 1)
             {
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office2013.ExcelAc.List), 0, 1, version: FileFormatVersions.Office2013),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.ExcelAc.List), 0, 1, version: FileFormatVersions.Office2010),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Formula1), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Formula2), 0, 1)
             };
@@ -30755,15 +30756,15 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         }
 
         /// <summary>
-        /// <para>List, this property is only available in Office 2013 and later..</para>
+        /// <para>List, this property is only available in Office 2010 and later..</para>
         /// <para>Represents the following element tag in the schema: x12ac:list.</para>
         /// </summary>
         /// <remark>
         /// xmlns:x12ac = http://schemas.microsoft.com/office/spreadsheetml/2011/1/ac
         /// </remark>
-        public DocumentFormat.OpenXml.Office2013.ExcelAc.List? List
+        public DocumentFormat.OpenXml.Office2010.ExcelAc.List? List
         {
-            get => GetElement<DocumentFormat.OpenXml.Office2013.ExcelAc.List>();
+            get => GetElement<DocumentFormat.OpenXml.Office2010.ExcelAc.List>();
             set => SetElement(value);
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_spreadsheetml_2006_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_spreadsheetml_2006_main.g.cs
@@ -8,7 +8,6 @@ using DocumentFormat.OpenXml.Drawing.Spreadsheet;
 using DocumentFormat.OpenXml.Framework;
 using DocumentFormat.OpenXml.Framework.Metadata;
 using DocumentFormat.OpenXml.Office2010.Excel;
-using DocumentFormat.OpenXml.Office2010.ExcelAc;
 using DocumentFormat.OpenXml.Office2013.Excel;
 using DocumentFormat.OpenXml.Office2013.ExcelAc;
 using DocumentFormat.OpenXml.Packaging;
@@ -30473,7 +30472,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
     /// <list type="bullet">
     ///   <item><description><see cref="DocumentFormat.OpenXml.Spreadsheet.Formula1" /> <c>&lt;x:formula1></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Spreadsheet.Formula2" /> <c>&lt;x:formula2></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office2010.ExcelAc.List" /> <c>&lt;x12ac:list></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office2013.ExcelAc.List" /> <c>&lt;x12ac:list></c></description></item>
     /// </list>
     /// </remark>
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -30726,7 +30725,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             builder.SetSchema("x:dataValidation");
             builder.AddChild<DocumentFormat.OpenXml.Spreadsheet.Formula1>();
             builder.AddChild<DocumentFormat.OpenXml.Spreadsheet.Formula2>();
-            builder.AddChild<DocumentFormat.OpenXml.Office2010.ExcelAc.List>();
+            builder.AddChild<DocumentFormat.OpenXml.Office2013.ExcelAc.List>();
             builder.AddElement<DataValidation>()
 .AddAttribute("type", a => a.Type)
 .AddAttribute("errorStyle", a => a.ErrorStyle)
@@ -30746,7 +30745,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 });
             builder.Particle = new CompositeParticle.Builder(ParticleType.Sequence, 1, 1)
             {
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office2010.ExcelAc.List), 0, 1, version: FileFormatVersions.Office2013),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office2013.ExcelAc.List), 0, 1, version: FileFormatVersions.Office2013),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Formula1), 0, 1),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Spreadsheet.Formula2), 0, 1)
             };
@@ -30762,9 +30761,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         /// <remark>
         /// xmlns:x12ac = http://schemas.microsoft.com/office/spreadsheetml/2011/1/ac
         /// </remark>
-        public DocumentFormat.OpenXml.Office2010.ExcelAc.List? List
+        public DocumentFormat.OpenXml.Office2013.ExcelAc.List? List
         {
-            get => GetElement<DocumentFormat.OpenXml.Office2010.ExcelAc.List>();
+            get => GetElement<DocumentFormat.OpenXml.Office2013.ExcelAc.List>();
             set => SetElement(value);
         }
 

--- a/test/DocumentFormat.OpenXml.Framework.Tests/ElementChildren.json
+++ b/test/DocumentFormat.OpenXml.Framework.Tests/ElementChildren.json
@@ -25197,6 +25197,10 @@
     "Children": []
   },
   {
+    "Element": "DocumentFormat.OpenXml.Office2010.ExcelAc.List",
+    "Children": []
+  },
+  {
     "Element": "DocumentFormat.OpenXml.Office2010.Ink.ContextNode",
     "Children": [
       {
@@ -30905,10 +30909,6 @@
   },
   {
     "Element": "DocumentFormat.OpenXml.Office2013.ExcelAc.AbsolutePath",
-    "Children": []
-  },
-  {
-    "Element": "DocumentFormat.OpenXml.Office2013.ExcelAc.List",
     "Children": []
   },
   {

--- a/test/DocumentFormat.OpenXml.Framework.Tests/ElementChildren.json
+++ b/test/DocumentFormat.OpenXml.Framework.Tests/ElementChildren.json
@@ -25197,10 +25197,6 @@
     "Children": []
   },
   {
-    "Element": "DocumentFormat.OpenXml.Office2010.ExcelAc.List",
-    "Children": []
-  },
-  {
     "Element": "DocumentFormat.OpenXml.Office2010.Ink.ContextNode",
     "Children": [
       {
@@ -30909,6 +30905,10 @@
   },
   {
     "Element": "DocumentFormat.OpenXml.Office2013.ExcelAc.AbsolutePath",
+    "Children": []
+  },
+  {
+    "Element": "DocumentFormat.OpenXml.Office2013.ExcelAc.List",
     "Children": []
   },
   {

--- a/test/DocumentFormat.OpenXml.Packaging.Tests/data/Particles.json
+++ b/test/DocumentFormat.OpenXml.Packaging.Tests/data/Particles.json
@@ -48766,7 +48766,7 @@
     "Value": {
      "ChildrenParticles": [
       {
-       "ElementType": "DocumentFormat.OpenXml.Office2013.ExcelAc.List",
+       "ElementType": "DocumentFormat.OpenXml.Office2010.ExcelAc.List",
        "MinOccurs": 0
       },
       {
@@ -60198,11 +60198,11 @@
   "Key": "DocumentFormat.OpenXml.Spreadsheet.DataValidation",
   "Value": [
    {
-    "Key": "Office2013, Office2016, Office2019, Office2021",
+    "Key": "Office2010, Office2013, Office2016, Office2019, Office2021",
     "Value": {
      "ChildrenParticles": [
       {
-       "ElementType": "DocumentFormat.OpenXml.Office2013.ExcelAc.List",
+       "ElementType": "DocumentFormat.OpenXml.Office2010.ExcelAc.List",
        "MinOccurs": 0
       },
       {
@@ -60218,7 +60218,7 @@
     }
    },
    {
-    "Key": "Office2007, Office2010",
+    "Key": "Office2007",
     "Value": {
      "ChildrenParticles": [
       {

--- a/test/DocumentFormat.OpenXml.Packaging.Tests/data/Particles.json
+++ b/test/DocumentFormat.OpenXml.Packaging.Tests/data/Particles.json
@@ -32350,7 +32350,7 @@
   "Key": "DocumentFormat.OpenXml.Office.Drawing.Drawing",
   "Value": [
    {
-    "Key": "Office2007, Office2010, Office2013, Office2016, Office2019, Office2021",
+    "Key": "Office2010, Office2013, Office2016, Office2019, Office2021",
     "Value": {
      "ChildrenParticles": [
       {
@@ -32366,7 +32366,7 @@
   "Key": "DocumentFormat.OpenXml.Office.Drawing.GroupShape",
   "Value": [
    {
-    "Key": "Office2007, Office2010, Office2013, Office2016, Office2019, Office2021",
+    "Key": "Office2010, Office2013, Office2016, Office2019, Office2021",
     "Value": {
      "ChildrenParticles": [
       {
@@ -32402,7 +32402,7 @@
   "Key": "DocumentFormat.OpenXml.Office.Drawing.GroupShapeNonVisualProperties",
   "Value": [
    {
-    "Key": "Office2007, Office2010, Office2013, Office2016, Office2019, Office2021",
+    "Key": "Office2010, Office2013, Office2016, Office2019, Office2021",
     "Value": {
      "ChildrenParticles": [
       {
@@ -32421,7 +32421,7 @@
   "Key": "DocumentFormat.OpenXml.Office.Drawing.GroupShapeProperties",
   "Value": [
    {
-    "Key": "Office2007, Office2010, Office2013, Office2016, Office2019, Office2021",
+    "Key": "Office2010, Office2013, Office2016, Office2019, Office2021",
     "Value": {
      "ChildrenParticles": [
       {
@@ -32492,7 +32492,7 @@
   "Key": "DocumentFormat.OpenXml.Office.Drawing.NonVisualDrawingProperties",
   "Value": [
    {
-    "Key": "Office2007, Office2010, Office2013, Office2016, Office2019, Office2021",
+    "Key": "Office2010, Office2013, Office2016, Office2019, Office2021",
     "Value": {
      "ChildrenParticles": [
       {
@@ -32517,7 +32517,7 @@
   "Key": "DocumentFormat.OpenXml.Office.Drawing.NonVisualDrawingShapeProperties",
   "Value": [
    {
-    "Key": "Office2007, Office2010, Office2013, Office2016, Office2019, Office2021",
+    "Key": "Office2010, Office2013, Office2016, Office2019, Office2021",
     "Value": {
      "ChildrenParticles": [
       {
@@ -32538,7 +32538,7 @@
   "Key": "DocumentFormat.OpenXml.Office.Drawing.NonVisualGroupDrawingShapeProperties",
   "Value": [
    {
-    "Key": "Office2007, Office2010, Office2013, Office2016, Office2019, Office2021",
+    "Key": "Office2010, Office2013, Office2016, Office2019, Office2021",
     "Value": {
      "ChildrenParticles": [
       {
@@ -32559,7 +32559,7 @@
   "Key": "DocumentFormat.OpenXml.Office.Drawing.OfficeArtExtensionList",
   "Value": [
    {
-    "Key": "Office2007, Office2010, Office2013, Office2016, Office2019, Office2021",
+    "Key": "Office2010, Office2013, Office2016, Office2019, Office2021",
     "Value": {
      "ChildrenParticles": [
       {
@@ -32587,7 +32587,7 @@
   "Key": "DocumentFormat.OpenXml.Office.Drawing.Shape",
   "Value": [
    {
-    "Key": "Office2007, Office2010, Office2013, Office2016, Office2019, Office2021",
+    "Key": "Office2010, Office2013, Office2016, Office2019, Office2021",
     "Value": {
      "ChildrenParticles": [
       {
@@ -32622,7 +32622,7 @@
   "Key": "DocumentFormat.OpenXml.Office.Drawing.ShapeNonVisualProperties",
   "Value": [
    {
-    "Key": "Office2007, Office2010, Office2013, Office2016, Office2019, Office2021",
+    "Key": "Office2010, Office2013, Office2016, Office2019, Office2021",
     "Value": {
      "ChildrenParticles": [
       {
@@ -32641,7 +32641,7 @@
   "Key": "DocumentFormat.OpenXml.Office.Drawing.ShapeProperties",
   "Value": [
    {
-    "Key": "Office2007, Office2010, Office2013, Office2016, Office2019, Office2021",
+    "Key": "Office2010, Office2013, Office2016, Office2019, Office2021",
     "Value": {
      "ChildrenParticles": [
       {
@@ -32737,7 +32737,7 @@
   "Key": "DocumentFormat.OpenXml.Office.Drawing.ShapeStyle",
   "Value": [
    {
-    "Key": "Office2007, Office2010, Office2013, Office2016, Office2019, Office2021",
+    "Key": "Office2010, Office2013, Office2016, Office2019, Office2021",
     "Value": {
      "ChildrenParticles": [
       {
@@ -32762,7 +32762,7 @@
   "Key": "DocumentFormat.OpenXml.Office.Drawing.ShapeTree",
   "Value": [
    {
-    "Key": "Office2007, Office2010, Office2013, Office2016, Office2019, Office2021",
+    "Key": "Office2010, Office2013, Office2016, Office2019, Office2021",
     "Value": {
      "ChildrenParticles": [
       {
@@ -32798,7 +32798,7 @@
   "Key": "DocumentFormat.OpenXml.Office.Drawing.TextBody",
   "Value": [
    {
-    "Key": "Office2007, Office2010, Office2013, Office2016, Office2019, Office2021",
+    "Key": "Office2010, Office2013, Office2016, Office2019, Office2021",
     "Value": {
      "ChildrenParticles": [
       {
@@ -32822,7 +32822,7 @@
   "Key": "DocumentFormat.OpenXml.Office.Drawing.Transform2D",
   "Value": [
    {
-    "Key": "Office2007, Office2010, Office2013, Office2016, Office2019, Office2021",
+    "Key": "Office2010, Office2013, Office2016, Office2019, Office2021",
     "Value": {
      "ChildrenParticles": [
       {
@@ -48766,7 +48766,7 @@
     "Value": {
      "ChildrenParticles": [
       {
-       "ElementType": "DocumentFormat.OpenXml.Office2010.ExcelAc.List",
+       "ElementType": "DocumentFormat.OpenXml.Office2013.ExcelAc.List",
        "MinOccurs": 0
       },
       {
@@ -60202,7 +60202,7 @@
     "Value": {
      "ChildrenParticles": [
       {
-       "ElementType": "DocumentFormat.OpenXml.Office2010.ExcelAc.List",
+       "ElementType": "DocumentFormat.OpenXml.Office2013.ExcelAc.List",
        "MinOccurs": 0
       },
       {

--- a/test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlValidatorTest.cs
+++ b/test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlValidatorTest.cs
@@ -3230,7 +3230,7 @@ namespace DocumentFormat.OpenXml.Tests
                                                 new DocumentFormat.OpenXml.Office.Drawing.GroupShapeProperties());
 
             // ***** good case ******
-            var actual = O12Validator.Validate(element);
+            var actual = O14Validator.Validate(element);
             Assert.Empty(actual);
         }
 


### PR DESCRIPTION
DocumentFormat.OpenXml.Office.Drawing.ShapeTree is available in Office 2010 and above, not 2007.
DocumentFormat.OpenXml.Office2010.ExcelAc changed to DocumentFormat.OpenXml.Office2013.ExcelAc