### PR TITLE
Store shared context in a lazy

### DIFF
--- a/gen/DocumentFormat.OpenXml.Generator/OpenXmlGeneratorContext.cs
+++ b/gen/DocumentFormat.OpenXml.Generator/OpenXmlGeneratorContext.cs
@@ -13,6 +13,8 @@ namespace DocumentFormat.OpenXml.Generator;
 
 public record OpenXmlGeneratorContext
 {
+    private static readonly Lazy<OpenXmlGeneratorContext> _context = new(Load);
+
     private static readonly JsonSerializer _serializer = JsonSerializer.Create(new()
     {
         Converters = new[]
@@ -21,15 +23,14 @@ public record OpenXmlGeneratorContext
         },
     });
 
-    public static OpenXmlGeneratorContext Shared { get; } = Load();
+    public static OpenXmlGeneratorContext Shared => _context.Value;
 
     public IEnumerable<NamespaceInfo> Namespaces { get; init; } = Enumerable.Empty<NamespaceInfo>();
 
-    public static OpenXmlGeneratorContext Load()
-        => new()
-        {
-            Namespaces = Load<NamespaceInfo[]>("namespaces.json"),
-        };
+    public static OpenXmlGeneratorContext Load() => new()
+    {
+        Namespaces = Load<NamespaceInfo[]>("namespaces.json"),
+    };
 
     private static T Load<T>(string name)
     {


### PR DESCRIPTION
This will allow the exception to be thrown from within a generator if it occurs. By so doing, it will be surfaced better in VS and other tools rather than a TypeLoadException
