### PR TITLE
refactor C# namespace to map xmlns URIs

### DIFF
--- a/gen/DocumentFormat.OpenXml.Generator.Linq/Properties/launchSettings.json
+++ b/gen/DocumentFormat.OpenXml.Generator.Linq/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "DocumentFormat.OpenXml.Generator.Linq": {
+      "commandName": "Project",
+      "commandLineArgs": "D:\\source\\forks\\Open-XML-SDK\\src\\DocumentFormat.OpenXml.Linq\\GeneratedCode"
+    }
+  }
+}

--- a/gen/DocumentFormat.OpenXml.Generator.Linq/Properties/launchSettings.json
+++ b/gen/DocumentFormat.OpenXml.Generator.Linq/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "DocumentFormat.OpenXml.Generator.Linq": {
-      "commandName": "Project",
-      "commandLineArgs": "D:\\source\\forks\\Open-XML-SDK\\src\\DocumentFormat.OpenXml.Linq\\GeneratedCode"
-    }
-  }
-}

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2021_oembed.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2021_oembed.g.cs
@@ -13,7 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.IO.Packaging;
 
-namespace DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed
+namespace DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed
 {
     /// <summary>
     /// <para>Defines the OEmbedShared Class.</para>
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed
     /// <remark>
     /// <para>The following table lists the possible child types:</para>
     /// <list type="bullet">
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OfficeArtExtensionList" /> <c>&lt;aoe:extLst></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OfficeArtExtensionList" /> <c>&lt;aoe:extLst></c></description></item>
     /// </list>
     /// </remark>
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -99,7 +99,7 @@ namespace DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed
             base.ConfigureMetadata(builder);
             builder.SetSchema("aoe:oembedShared");
             builder.Availability = FileFormatVersions.Microsoft365;
-            builder.AddChild<DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OfficeArtExtensionList>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OfficeArtExtensionList>();
             builder.AddElement<OEmbedShared>()
 .AddAttribute("srcUrl", a => a.SrcUrl, aBuilder =>
 {
@@ -111,7 +111,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 });
             builder.Particle = new CompositeParticle.Builder(ParticleType.Sequence, 1, 1)
             {
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OfficeArtExtensionList), 0, 1, version: FileFormatVersions.Microsoft365)
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OfficeArtExtensionList), 0, 1, version: FileFormatVersions.Microsoft365)
             };
         }
 
@@ -122,9 +122,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         /// <remark>
         /// xmlns:aoe = http://schemas.microsoft.com/office/drawing/2021/oembed
         /// </remark>
-        public DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OfficeArtExtensionList? OfficeArtExtensionList
+        public DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OfficeArtExtensionList? OfficeArtExtensionList
         {
-            get => GetElement<DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OfficeArtExtensionList>();
+            get => GetElement<DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OfficeArtExtensionList>();
             set => SetElement(value);
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2021_oembed.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2021_oembed.g.cs
@@ -13,7 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.IO.Packaging;
 
-namespace DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed
+namespace DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed
 {
     /// <summary>
     /// <para>Defines the OEmbedShared Class.</para>
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed
     /// <remark>
     /// <para>The following table lists the possible child types:</para>
     /// <list type="bullet">
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OfficeArtExtensionList" /> <c>&lt;aoe:extLst></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OfficeArtExtensionList" /> <c>&lt;aoe:extLst></c></description></item>
     /// </list>
     /// </remark>
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -99,7 +99,7 @@ namespace DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed
             base.ConfigureMetadata(builder);
             builder.SetSchema("aoe:oembedShared");
             builder.Availability = FileFormatVersions.Microsoft365;
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OfficeArtExtensionList>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OfficeArtExtensionList>();
             builder.AddElement<OEmbedShared>()
 .AddAttribute("srcUrl", a => a.SrcUrl, aBuilder =>
 {
@@ -111,7 +111,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
 });
             builder.Particle = new CompositeParticle.Builder(ParticleType.Sequence, 1, 1)
             {
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OfficeArtExtensionList), 0, 1, version: FileFormatVersions.Microsoft365)
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OfficeArtExtensionList), 0, 1, version: FileFormatVersions.Microsoft365)
             };
         }
 
@@ -122,9 +122,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
         /// <remark>
         /// xmlns:aoe = http://schemas.microsoft.com/office/drawing/2021/oembed
         /// </remark>
-        public DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OfficeArtExtensionList? OfficeArtExtensionList
+        public DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OfficeArtExtensionList? OfficeArtExtensionList
         {
-            get => GetElement<DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OfficeArtExtensionList>();
+            get => GetElement<DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OfficeArtExtensionList>();
             set => SetElement(value);
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2021_scriptlink.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2021_scriptlink.g.cs
@@ -13,7 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.IO.Packaging;
 
-namespace DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink
+namespace DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink
 {
     /// <summary>
     /// <para>Defines the ScriptLink Class.</para>
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink
     /// <remark>
     /// <para>The following table lists the possible child types:</para>
     /// <list type="bullet">
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.OfficeArtExtensionList" /> <c>&lt;asl:extLst></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.OfficeArtExtensionList" /> <c>&lt;asl:extLst></c></description></item>
     /// </list>
     /// </remark>
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -83,12 +83,12 @@ namespace DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink
             base.ConfigureMetadata(builder);
             builder.SetSchema("asl:scriptLink");
             builder.Availability = FileFormatVersions.Microsoft365;
-            builder.AddChild<DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.OfficeArtExtensionList>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.OfficeArtExtensionList>();
             builder.AddElement<ScriptLink>()
 .AddAttribute("val", a => a.Val);
             builder.Particle = new CompositeParticle.Builder(ParticleType.Sequence, 1, 1)
             {
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.OfficeArtExtensionList), 0, 1, version: FileFormatVersions.Microsoft365)
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.OfficeArtExtensionList), 0, 1, version: FileFormatVersions.Microsoft365)
             };
         }
 
@@ -99,9 +99,9 @@ namespace DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink
         /// <remark>
         /// xmlns:asl = http://schemas.microsoft.com/office/drawing/2021/scriptlink
         /// </remark>
-        public DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.OfficeArtExtensionList? OfficeArtExtensionList
+        public DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.OfficeArtExtensionList? OfficeArtExtensionList
         {
-            get => GetElement<DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.OfficeArtExtensionList>();
+            get => GetElement<DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.OfficeArtExtensionList>();
             set => SetElement(value);
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2021_scriptlink.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_drawing_2021_scriptlink.g.cs
@@ -13,7 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.IO.Packaging;
 
-namespace DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink
+namespace DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink
 {
     /// <summary>
     /// <para>Defines the ScriptLink Class.</para>
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink
     /// <remark>
     /// <para>The following table lists the possible child types:</para>
     /// <list type="bullet">
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.OfficeArtExtensionList" /> <c>&lt;asl:extLst></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.OfficeArtExtensionList" /> <c>&lt;asl:extLst></c></description></item>
     /// </list>
     /// </remark>
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -83,12 +83,12 @@ namespace DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink
             base.ConfigureMetadata(builder);
             builder.SetSchema("asl:scriptLink");
             builder.Availability = FileFormatVersions.Microsoft365;
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.OfficeArtExtensionList>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.OfficeArtExtensionList>();
             builder.AddElement<ScriptLink>()
 .AddAttribute("val", a => a.Val);
             builder.Particle = new CompositeParticle.Builder(ParticleType.Sequence, 1, 1)
             {
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.OfficeArtExtensionList), 0, 1, version: FileFormatVersions.Microsoft365)
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.OfficeArtExtensionList), 0, 1, version: FileFormatVersions.Microsoft365)
             };
         }
 
@@ -99,9 +99,9 @@ namespace DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink
         /// <remark>
         /// xmlns:asl = http://schemas.microsoft.com/office/drawing/2021/scriptlink
         /// </remark>
-        public DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.OfficeArtExtensionList? OfficeArtExtensionList
+        public DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.OfficeArtExtensionList? OfficeArtExtensionList
         {
-            get => GetElement<DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.OfficeArtExtensionList>();
+            get => GetElement<DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.OfficeArtExtensionList>();
             set => SetElement(value);
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_powerpoint_2021_06_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_powerpoint_2021_06_main.g.cs
@@ -15,7 +15,7 @@ using System;
 using System.Collections.Generic;
 using System.IO.Packaging;
 
-namespace DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main
+namespace DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main
 {
     /// <summary>
     /// <para>Defines the TaskHistoryDetails Class.</para>
@@ -25,8 +25,8 @@ namespace DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main
     /// <remark>
     /// <para>The following table lists the possible child types:</para>
     /// <list type="bullet">
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList" /> <c>&lt;p216:extLst></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistory" /> <c>&lt;p216:history></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList" /> <c>&lt;p216:extLst></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistory" /> <c>&lt;p216:history></c></description></item>
     /// </list>
     /// </remark>
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -86,8 +86,8 @@ namespace DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main
             base.ConfigureMetadata(builder);
             builder.SetSchema("p216:taskHistoryDetails");
             builder.Availability = FileFormatVersions.Microsoft365;
-            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList>();
-            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistory>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistory>();
             builder.AddElement<TaskHistoryDetails>()
 .AddAttribute("id", a => a.Id, aBuilder =>
 {
@@ -96,8 +96,8 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
 });
             builder.Particle = new CompositeParticle.Builder(ParticleType.Sequence, 1, 1)
             {
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistory), 1, 1, version: FileFormatVersions.Microsoft365),
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList), 0, 1, version: FileFormatVersions.Microsoft365)
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistory), 1, 1, version: FileFormatVersions.Microsoft365),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList), 0, 1, version: FileFormatVersions.Microsoft365)
             };
         }
 
@@ -108,9 +108,9 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
         /// <remark>
         /// xmlns:p216 = http://schemas.microsoft.com/office/powerpoint/2021/06/main
         /// </remark>
-        public DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistory? TaskHistory
+        public DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistory? TaskHistory
         {
-            get => GetElement<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistory>();
+            get => GetElement<DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistory>();
             set => SetElement(value);
         }
 
@@ -121,9 +121,9 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
         /// <remark>
         /// xmlns:p216 = http://schemas.microsoft.com/office/powerpoint/2021/06/main
         /// </remark>
-        public DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList? ExtensionList
+        public DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList? ExtensionList
         {
-            get => GetElement<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList>();
+            get => GetElement<DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList>();
             set => SetElement(value);
         }
 
@@ -384,8 +384,8 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
     /// <remark>
     /// <para>The following table lists the possible child types:</para>
     /// <list type="bullet">
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList" /> <c>&lt;p216:extLst></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.CommentAnchor" /> <c>&lt;p216:comment></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList" /> <c>&lt;p216:extLst></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.CommentAnchor" /> <c>&lt;p216:comment></c></description></item>
     /// </list>
     /// </remark>
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -429,12 +429,12 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             base.ConfigureMetadata(builder);
             builder.SetSchema("p216:anchr");
             builder.Availability = FileFormatVersions.Microsoft365;
-            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList>();
-            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.CommentAnchor>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.CommentAnchor>();
             builder.Particle = new CompositeParticle.Builder(ParticleType.Sequence, 1, 1)
             {
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.CommentAnchor), 1, 1, version: FileFormatVersions.Microsoft365),
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList), 0, 1, version: FileFormatVersions.Microsoft365)
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.CommentAnchor), 1, 1, version: FileFormatVersions.Microsoft365),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList), 0, 1, version: FileFormatVersions.Microsoft365)
             };
         }
 
@@ -445,9 +445,9 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
         /// <remark>
         /// xmlns:p216 = http://schemas.microsoft.com/office/powerpoint/2021/06/main
         /// </remark>
-        public DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.CommentAnchor? CommentAnchor
+        public DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.CommentAnchor? CommentAnchor
         {
-            get => GetElement<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.CommentAnchor>();
+            get => GetElement<DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.CommentAnchor>();
             set => SetElement(value);
         }
 
@@ -458,9 +458,9 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
         /// <remark>
         /// xmlns:p216 = http://schemas.microsoft.com/office/powerpoint/2021/06/main
         /// </remark>
-        public DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList? ExtensionList
+        public DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList? ExtensionList
         {
-            get => GetElement<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList>();
+            get => GetElement<DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList>();
             set => SetElement(value);
         }
 
@@ -842,19 +842,19 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
     /// <remark>
     /// <para>The following table lists the possible child types:</para>
     /// <list type="bullet">
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AddEmpty" /> <c>&lt;p216:add></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.UnasgnAllEmpty" /> <c>&lt;p216:unasgnAll></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList" /> <c>&lt;p216:extLst></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskAnchor" /> <c>&lt;p216:anchr></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AtrbtnTaskAssignUnassignUser" /> <c>&lt;p216:atrbtn></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AsgnTaskAssignUnassignUser" /> <c>&lt;p216:asgn></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.UnAsgnTaskAssignUnassignUser" /> <c>&lt;p216:unAsgn></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskPriorityRecord" /> <c>&lt;p216:pri></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskProgressEventInfo" /> <c>&lt;p216:pcntCmplt></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskScheduleEventInfo" /> <c>&lt;p216:date></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskTitleEventInfo" /> <c>&lt;p216:title></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskUndo" /> <c>&lt;p216:undo></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskUnknownRecord" /> <c>&lt;p216:unknown></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AddEmpty" /> <c>&lt;p216:add></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.UnasgnAllEmpty" /> <c>&lt;p216:unasgnAll></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList" /> <c>&lt;p216:extLst></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskAnchor" /> <c>&lt;p216:anchr></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AtrbtnTaskAssignUnassignUser" /> <c>&lt;p216:atrbtn></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AsgnTaskAssignUnassignUser" /> <c>&lt;p216:asgn></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.UnAsgnTaskAssignUnassignUser" /> <c>&lt;p216:unAsgn></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskPriorityRecord" /> <c>&lt;p216:pri></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskProgressEventInfo" /> <c>&lt;p216:pcntCmplt></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskScheduleEventInfo" /> <c>&lt;p216:date></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskTitleEventInfo" /> <c>&lt;p216:title></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskUndo" /> <c>&lt;p216:undo></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskUnknownRecord" /> <c>&lt;p216:unknown></c></description></item>
     /// </list>
     /// </remark>
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -930,19 +930,19 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             base.ConfigureMetadata(builder);
             builder.SetSchema("p216:event");
             builder.Availability = FileFormatVersions.Microsoft365;
-            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AddEmpty>();
-            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.UnasgnAllEmpty>();
-            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList>();
-            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskAnchor>();
-            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AtrbtnTaskAssignUnassignUser>();
-            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AsgnTaskAssignUnassignUser>();
-            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.UnAsgnTaskAssignUnassignUser>();
-            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskPriorityRecord>();
-            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskProgressEventInfo>();
-            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskScheduleEventInfo>();
-            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskTitleEventInfo>();
-            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskUndo>();
-            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskUnknownRecord>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AddEmpty>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.UnasgnAllEmpty>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskAnchor>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AtrbtnTaskAssignUnassignUser>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AsgnTaskAssignUnassignUser>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.UnAsgnTaskAssignUnassignUser>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskPriorityRecord>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskProgressEventInfo>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskScheduleEventInfo>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskTitleEventInfo>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskUndo>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskUnknownRecord>();
             builder.AddElement<TaskHistoryEvent>()
 .AddAttribute("time", a => a.Time, aBuilder =>
 {
@@ -955,22 +955,22 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
 });
             builder.Particle = new CompositeParticle.Builder(ParticleType.Sequence, 1, 1)
             {
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AtrbtnTaskAssignUnassignUser), 1, 1, version: FileFormatVersions.Microsoft365),
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskAnchor), 0, 1, version: FileFormatVersions.Microsoft365),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AtrbtnTaskAssignUnassignUser), 1, 1, version: FileFormatVersions.Microsoft365),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskAnchor), 0, 1, version: FileFormatVersions.Microsoft365),
                 new CompositeParticle.Builder(ParticleType.Choice, 0, 1)
                 {
-                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AsgnTaskAssignUnassignUser), 1, 1, version: FileFormatVersions.Microsoft365),
-                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.UnAsgnTaskAssignUnassignUser), 1, 1, version: FileFormatVersions.Microsoft365),
-                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AddEmpty), 0, 1, version: FileFormatVersions.Microsoft365),
-                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskTitleEventInfo), 1, 1, version: FileFormatVersions.Microsoft365),
-                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskScheduleEventInfo), 1, 1, version: FileFormatVersions.Microsoft365),
-                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskProgressEventInfo), 1, 1, version: FileFormatVersions.Microsoft365),
-                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskPriorityRecord), 1, 1, version: FileFormatVersions.Microsoft365),
-                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.UnasgnAllEmpty), 0, 1, version: FileFormatVersions.Microsoft365),
-                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskUndo), 1, 1, version: FileFormatVersions.Microsoft365),
-                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskUnknownRecord), 1, 1, version: FileFormatVersions.Microsoft365)
+                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AsgnTaskAssignUnassignUser), 1, 1, version: FileFormatVersions.Microsoft365),
+                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.UnAsgnTaskAssignUnassignUser), 1, 1, version: FileFormatVersions.Microsoft365),
+                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AddEmpty), 0, 1, version: FileFormatVersions.Microsoft365),
+                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskTitleEventInfo), 1, 1, version: FileFormatVersions.Microsoft365),
+                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskScheduleEventInfo), 1, 1, version: FileFormatVersions.Microsoft365),
+                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskProgressEventInfo), 1, 1, version: FileFormatVersions.Microsoft365),
+                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskPriorityRecord), 1, 1, version: FileFormatVersions.Microsoft365),
+                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.UnasgnAllEmpty), 0, 1, version: FileFormatVersions.Microsoft365),
+                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskUndo), 1, 1, version: FileFormatVersions.Microsoft365),
+                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskUnknownRecord), 1, 1, version: FileFormatVersions.Microsoft365)
                 },
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList), 0, 1, version: FileFormatVersions.Microsoft365)
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList), 0, 1, version: FileFormatVersions.Microsoft365)
             };
         }
 
@@ -981,9 +981,9 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
         /// <remark>
         /// xmlns:p216 = http://schemas.microsoft.com/office/powerpoint/2021/06/main
         /// </remark>
-        public DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AtrbtnTaskAssignUnassignUser? AtrbtnTaskAssignUnassignUser
+        public DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AtrbtnTaskAssignUnassignUser? AtrbtnTaskAssignUnassignUser
         {
-            get => GetElement<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AtrbtnTaskAssignUnassignUser>();
+            get => GetElement<DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AtrbtnTaskAssignUnassignUser>();
             set => SetElement(value);
         }
 
@@ -994,9 +994,9 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
         /// <remark>
         /// xmlns:p216 = http://schemas.microsoft.com/office/powerpoint/2021/06/main
         /// </remark>
-        public DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskAnchor? TaskAnchor
+        public DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskAnchor? TaskAnchor
         {
-            get => GetElement<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskAnchor>();
+            get => GetElement<DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskAnchor>();
             set => SetElement(value);
         }
 
@@ -1012,7 +1012,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
     /// <remark>
     /// <para>The following table lists the possible child types:</para>
     /// <list type="bullet">
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistoryEvent" /> <c>&lt;p216:event></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryEvent" /> <c>&lt;p216:event></c></description></item>
     /// </list>
     /// </remark>
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -1056,10 +1056,10 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             base.ConfigureMetadata(builder);
             builder.SetSchema("p216:history");
             builder.Availability = FileFormatVersions.Microsoft365;
-            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistoryEvent>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryEvent>();
             builder.Particle = new CompositeParticle.Builder(ParticleType.Sequence, 1, 1)
             {
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistoryEvent), 0, 0, version: FileFormatVersions.Microsoft365)
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryEvent), 0, 0, version: FileFormatVersions.Microsoft365)
             };
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_powerpoint_2021_06_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_powerpoint_2021_06_main.g.cs
@@ -15,7 +15,7 @@ using System;
 using System.Collections.Generic;
 using System.IO.Packaging;
 
-namespace DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks
+namespace DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main
 {
     /// <summary>
     /// <para>Defines the TaskHistoryDetails Class.</para>
@@ -25,8 +25,8 @@ namespace DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks
     /// <remark>
     /// <para>The following table lists the possible child types:</para>
     /// <list type="bullet">
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList" /> <c>&lt;p216:extLst></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistory" /> <c>&lt;p216:history></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList" /> <c>&lt;p216:extLst></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistory" /> <c>&lt;p216:history></c></description></item>
     /// </list>
     /// </remark>
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -86,8 +86,8 @@ namespace DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks
             base.ConfigureMetadata(builder);
             builder.SetSchema("p216:taskHistoryDetails");
             builder.Availability = FileFormatVersions.Microsoft365;
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList>();
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistory>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistory>();
             builder.AddElement<TaskHistoryDetails>()
 .AddAttribute("id", a => a.Id, aBuilder =>
 {
@@ -96,8 +96,8 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
 });
             builder.Particle = new CompositeParticle.Builder(ParticleType.Sequence, 1, 1)
             {
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistory), 1, 1, version: FileFormatVersions.Microsoft365),
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList), 0, 1, version: FileFormatVersions.Microsoft365)
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistory), 1, 1, version: FileFormatVersions.Microsoft365),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList), 0, 1, version: FileFormatVersions.Microsoft365)
             };
         }
 
@@ -108,9 +108,9 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
         /// <remark>
         /// xmlns:p216 = http://schemas.microsoft.com/office/powerpoint/2021/06/main
         /// </remark>
-        public DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistory? TaskHistory
+        public DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistory? TaskHistory
         {
-            get => GetElement<DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistory>();
+            get => GetElement<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistory>();
             set => SetElement(value);
         }
 
@@ -121,9 +121,9 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
         /// <remark>
         /// xmlns:p216 = http://schemas.microsoft.com/office/powerpoint/2021/06/main
         /// </remark>
-        public DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList? ExtensionList
+        public DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList? ExtensionList
         {
-            get => GetElement<DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList>();
+            get => GetElement<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList>();
             set => SetElement(value);
         }
 
@@ -384,8 +384,8 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
     /// <remark>
     /// <para>The following table lists the possible child types:</para>
     /// <list type="bullet">
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList" /> <c>&lt;p216:extLst></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.CommentAnchor" /> <c>&lt;p216:comment></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList" /> <c>&lt;p216:extLst></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.CommentAnchor" /> <c>&lt;p216:comment></c></description></item>
     /// </list>
     /// </remark>
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -429,12 +429,12 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             base.ConfigureMetadata(builder);
             builder.SetSchema("p216:anchr");
             builder.Availability = FileFormatVersions.Microsoft365;
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList>();
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.CommentAnchor>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.CommentAnchor>();
             builder.Particle = new CompositeParticle.Builder(ParticleType.Sequence, 1, 1)
             {
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.CommentAnchor), 1, 1, version: FileFormatVersions.Microsoft365),
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList), 0, 1, version: FileFormatVersions.Microsoft365)
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.CommentAnchor), 1, 1, version: FileFormatVersions.Microsoft365),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList), 0, 1, version: FileFormatVersions.Microsoft365)
             };
         }
 
@@ -445,9 +445,9 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
         /// <remark>
         /// xmlns:p216 = http://schemas.microsoft.com/office/powerpoint/2021/06/main
         /// </remark>
-        public DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.CommentAnchor? CommentAnchor
+        public DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.CommentAnchor? CommentAnchor
         {
-            get => GetElement<DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.CommentAnchor>();
+            get => GetElement<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.CommentAnchor>();
             set => SetElement(value);
         }
 
@@ -458,9 +458,9 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
         /// <remark>
         /// xmlns:p216 = http://schemas.microsoft.com/office/powerpoint/2021/06/main
         /// </remark>
-        public DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList? ExtensionList
+        public DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList? ExtensionList
         {
-            get => GetElement<DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList>();
+            get => GetElement<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList>();
             set => SetElement(value);
         }
 
@@ -842,19 +842,19 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
     /// <remark>
     /// <para>The following table lists the possible child types:</para>
     /// <list type="bullet">
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AddEmpty" /> <c>&lt;p216:add></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.UnasgnAllEmpty" /> <c>&lt;p216:unasgnAll></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList" /> <c>&lt;p216:extLst></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskAnchor" /> <c>&lt;p216:anchr></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AtrbtnTaskAssignUnassignUser" /> <c>&lt;p216:atrbtn></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AsgnTaskAssignUnassignUser" /> <c>&lt;p216:asgn></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.UnAsgnTaskAssignUnassignUser" /> <c>&lt;p216:unAsgn></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskPriorityRecord" /> <c>&lt;p216:pri></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskProgressEventInfo" /> <c>&lt;p216:pcntCmplt></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskScheduleEventInfo" /> <c>&lt;p216:date></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskTitleEventInfo" /> <c>&lt;p216:title></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskUndo" /> <c>&lt;p216:undo></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskUnknownRecord" /> <c>&lt;p216:unknown></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AddEmpty" /> <c>&lt;p216:add></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.UnasgnAllEmpty" /> <c>&lt;p216:unasgnAll></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList" /> <c>&lt;p216:extLst></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskAnchor" /> <c>&lt;p216:anchr></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AtrbtnTaskAssignUnassignUser" /> <c>&lt;p216:atrbtn></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AsgnTaskAssignUnassignUser" /> <c>&lt;p216:asgn></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.UnAsgnTaskAssignUnassignUser" /> <c>&lt;p216:unAsgn></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskPriorityRecord" /> <c>&lt;p216:pri></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskProgressEventInfo" /> <c>&lt;p216:pcntCmplt></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskScheduleEventInfo" /> <c>&lt;p216:date></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskTitleEventInfo" /> <c>&lt;p216:title></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskUndo" /> <c>&lt;p216:undo></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskUnknownRecord" /> <c>&lt;p216:unknown></c></description></item>
     /// </list>
     /// </remark>
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -930,19 +930,19 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             base.ConfigureMetadata(builder);
             builder.SetSchema("p216:event");
             builder.Availability = FileFormatVersions.Microsoft365;
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AddEmpty>();
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.UnasgnAllEmpty>();
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList>();
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskAnchor>();
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AtrbtnTaskAssignUnassignUser>();
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AsgnTaskAssignUnassignUser>();
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.UnAsgnTaskAssignUnassignUser>();
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskPriorityRecord>();
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskProgressEventInfo>();
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskScheduleEventInfo>();
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskTitleEventInfo>();
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskUndo>();
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskUnknownRecord>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AddEmpty>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.UnasgnAllEmpty>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskAnchor>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AtrbtnTaskAssignUnassignUser>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AsgnTaskAssignUnassignUser>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.UnAsgnTaskAssignUnassignUser>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskPriorityRecord>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskProgressEventInfo>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskScheduleEventInfo>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskTitleEventInfo>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskUndo>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskUnknownRecord>();
             builder.AddElement<TaskHistoryEvent>()
 .AddAttribute("time", a => a.Time, aBuilder =>
 {
@@ -955,22 +955,22 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
 });
             builder.Particle = new CompositeParticle.Builder(ParticleType.Sequence, 1, 1)
             {
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AtrbtnTaskAssignUnassignUser), 1, 1, version: FileFormatVersions.Microsoft365),
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskAnchor), 0, 1, version: FileFormatVersions.Microsoft365),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AtrbtnTaskAssignUnassignUser), 1, 1, version: FileFormatVersions.Microsoft365),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskAnchor), 0, 1, version: FileFormatVersions.Microsoft365),
                 new CompositeParticle.Builder(ParticleType.Choice, 0, 1)
                 {
-                    new ElementParticle(typeof(DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AsgnTaskAssignUnassignUser), 1, 1, version: FileFormatVersions.Microsoft365),
-                    new ElementParticle(typeof(DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.UnAsgnTaskAssignUnassignUser), 1, 1, version: FileFormatVersions.Microsoft365),
-                    new ElementParticle(typeof(DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AddEmpty), 0, 1, version: FileFormatVersions.Microsoft365),
-                    new ElementParticle(typeof(DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskTitleEventInfo), 1, 1, version: FileFormatVersions.Microsoft365),
-                    new ElementParticle(typeof(DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskScheduleEventInfo), 1, 1, version: FileFormatVersions.Microsoft365),
-                    new ElementParticle(typeof(DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskProgressEventInfo), 1, 1, version: FileFormatVersions.Microsoft365),
-                    new ElementParticle(typeof(DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskPriorityRecord), 1, 1, version: FileFormatVersions.Microsoft365),
-                    new ElementParticle(typeof(DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.UnasgnAllEmpty), 0, 1, version: FileFormatVersions.Microsoft365),
-                    new ElementParticle(typeof(DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskUndo), 1, 1, version: FileFormatVersions.Microsoft365),
-                    new ElementParticle(typeof(DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskUnknownRecord), 1, 1, version: FileFormatVersions.Microsoft365)
+                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AsgnTaskAssignUnassignUser), 1, 1, version: FileFormatVersions.Microsoft365),
+                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.UnAsgnTaskAssignUnassignUser), 1, 1, version: FileFormatVersions.Microsoft365),
+                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AddEmpty), 0, 1, version: FileFormatVersions.Microsoft365),
+                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskTitleEventInfo), 1, 1, version: FileFormatVersions.Microsoft365),
+                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskScheduleEventInfo), 1, 1, version: FileFormatVersions.Microsoft365),
+                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskProgressEventInfo), 1, 1, version: FileFormatVersions.Microsoft365),
+                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskPriorityRecord), 1, 1, version: FileFormatVersions.Microsoft365),
+                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.UnasgnAllEmpty), 0, 1, version: FileFormatVersions.Microsoft365),
+                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskUndo), 1, 1, version: FileFormatVersions.Microsoft365),
+                    new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskUnknownRecord), 1, 1, version: FileFormatVersions.Microsoft365)
                 },
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList), 0, 1, version: FileFormatVersions.Microsoft365)
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList), 0, 1, version: FileFormatVersions.Microsoft365)
             };
         }
 
@@ -981,9 +981,9 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
         /// <remark>
         /// xmlns:p216 = http://schemas.microsoft.com/office/powerpoint/2021/06/main
         /// </remark>
-        public DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AtrbtnTaskAssignUnassignUser? AtrbtnTaskAssignUnassignUser
+        public DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AtrbtnTaskAssignUnassignUser? AtrbtnTaskAssignUnassignUser
         {
-            get => GetElement<DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AtrbtnTaskAssignUnassignUser>();
+            get => GetElement<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AtrbtnTaskAssignUnassignUser>();
             set => SetElement(value);
         }
 
@@ -994,9 +994,9 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
         /// <remark>
         /// xmlns:p216 = http://schemas.microsoft.com/office/powerpoint/2021/06/main
         /// </remark>
-        public DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskAnchor? TaskAnchor
+        public DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskAnchor? TaskAnchor
         {
-            get => GetElement<DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskAnchor>();
+            get => GetElement<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskAnchor>();
             set => SetElement(value);
         }
 
@@ -1012,7 +1012,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
     /// <remark>
     /// <para>The following table lists the possible child types:</para>
     /// <list type="bullet">
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryEvent" /> <c>&lt;p216:event></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistoryEvent" /> <c>&lt;p216:event></c></description></item>
     /// </list>
     /// </remark>
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -1056,10 +1056,10 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true), Pattern = ("\\{[
             base.ConfigureMetadata(builder);
             builder.SetSchema("p216:history");
             builder.Availability = FileFormatVersions.Microsoft365;
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryEvent>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistoryEvent>();
             builder.Particle = new CompositeParticle.Builder(ParticleType.Sequence, 1, 1)
             {
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryEvent), 0, 0, version: FileFormatVersions.Microsoft365)
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistoryEvent), 0, 0, version: FileFormatVersions.Microsoft365)
             };
         }
 

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2020_oembed.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2020_oembed.g.cs
@@ -12,7 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.IO.Packaging;
 
-namespace DocumentFormat.OpenXml.Microsoft365.Word.OEmbed
+namespace DocumentFormat.OpenXml.Office.Word._2020.OEmbed
 {
     /// <summary>
     /// <para>Defines the OEmbed Class.</para>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2020_oembed.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_word_2020_oembed.g.cs
@@ -12,7 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.IO.Packaging;
 
-namespace DocumentFormat.OpenXml.Office.Word._2020.OEmbed
+namespace DocumentFormat.OpenXml.Office.Word.Y2020.OEmbed
 {
     /// <summary>
     /// <para>Defines the OEmbed Class.</para>

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_main.g.cs
@@ -7,9 +7,9 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Framework;
 using DocumentFormat.OpenXml.Framework.Metadata;
 using DocumentFormat.OpenXml.Office.Drawing;
-using DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed;
-using DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink;
-using DocumentFormat.OpenXml.Office.Word._2020.OEmbed;
+using DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed;
+using DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink;
+using DocumentFormat.OpenXml.Office.Word.Y2020.OEmbed;
 using DocumentFormat.OpenXml.Office2010.Drawing;
 using DocumentFormat.OpenXml.Office2010.Drawing.Diagram;
 using DocumentFormat.OpenXml.Office2013.Drawing;
@@ -16966,9 +16966,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2019.Drawing.Decorative" /> <c>&lt;adec:decorative></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2019.Drawing.HyperLinkColor.HyperlinkColor" /> <c>&lt;ahyp:hlinkClr></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2021.Drawing.Livefeed.LiveFeedProperties" /> <c>&lt;alf:liveFeedProps></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OEmbedShared" /> <c>&lt;aoe:oembedShared></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OEmbedShared" /> <c>&lt;aoe:oembedShared></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2021.Drawing.SketchyShapes.LineSketchStyleProperties" /> <c>&lt;ask:lineSketchStyleProps></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.ScriptLink" /> <c>&lt;asl:scriptLink></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.ScriptLink" /> <c>&lt;asl:scriptLink></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2019.Drawing.SVG.SVGBlip" /> <c>&lt;asvg:svgBlip></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2013.Drawing.Chart.ExceptionForSave" /> <c>&lt;c15:xForSave></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2013.Drawing.Chart.ShowDataLabelsRange" /> <c>&lt;c15:showDataLabelsRange></c></description></item>
@@ -17171,7 +17171,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2013.Word.SdtRepeatedSection" /> <c>&lt;w15:repeatingSection></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2013.WebExtension.WebExtension" /> <c>&lt;we:webextension></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2013.WebExtension.WebExtensionReference" /> <c>&lt;we:webextensionref></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.Word._2020.OEmbed.OEmbed" /> <c>&lt;woe:oembed></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.Word.Y2020.OEmbed.OEmbed" /> <c>&lt;woe:oembed></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Drawing.Wordprocessing.Anchor" /> <c>&lt;wp:anchor></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Drawing.Wordprocessing.Inline" /> <c>&lt;wp:inline></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2010.Word.Drawing.RelativeWidth" /> <c>&lt;wp14:sizeRelH></c></description></item>
@@ -17287,9 +17287,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             builder.AddChild<DocumentFormat.OpenXml.Office2019.Drawing.Decorative>();
             builder.AddChild<DocumentFormat.OpenXml.Office2019.Drawing.HyperLinkColor.HyperlinkColor>();
             builder.AddChild<DocumentFormat.OpenXml.Office2021.Drawing.Livefeed.LiveFeedProperties>();
-            builder.AddChild<DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OEmbedShared>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OEmbedShared>();
             builder.AddChild<DocumentFormat.OpenXml.Office2021.Drawing.SketchyShapes.LineSketchStyleProperties>();
-            builder.AddChild<DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.ScriptLink>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.ScriptLink>();
             builder.AddChild<DocumentFormat.OpenXml.Office2019.Drawing.SVG.SVGBlip>();
             builder.AddChild<DocumentFormat.OpenXml.Office2013.Drawing.Chart.ExceptionForSave>();
             builder.AddChild<DocumentFormat.OpenXml.Office2013.Drawing.Chart.ShowDataLabelsRange>();
@@ -17492,7 +17492,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             builder.AddChild<DocumentFormat.OpenXml.Office2013.Word.SdtRepeatedSection>();
             builder.AddChild<DocumentFormat.OpenXml.Office2013.WebExtension.WebExtension>();
             builder.AddChild<DocumentFormat.OpenXml.Office2013.WebExtension.WebExtensionReference>();
-            builder.AddChild<DocumentFormat.OpenXml.Office.Word._2020.OEmbed.OEmbed>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.Word.Y2020.OEmbed.OEmbed>();
             builder.AddChild<DocumentFormat.OpenXml.Drawing.Wordprocessing.Anchor>();
             builder.AddChild<DocumentFormat.OpenXml.Drawing.Wordprocessing.Inline>();
             builder.AddChild<DocumentFormat.OpenXml.Office2010.Word.Drawing.RelativeWidth>();
@@ -34485,7 +34485,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2016.Drawing.PredecessorDrawingElementReference" /> <c>&lt;a16:predDERef></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2021.Drawing.DocumentClassification.ClassificationOutcome" /> <c>&lt;aclsh:classification></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2019.Drawing.Decorative" /> <c>&lt;adec:decorative></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.ScriptLink" /> <c>&lt;asl:scriptLink></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.ScriptLink" /> <c>&lt;asl:scriptLink></c></description></item>
     /// </list>
     /// </remark>
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -34550,7 +34550,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddChild<DocumentFormat.OpenXml.Office2016.Drawing.PredecessorDrawingElementReference>();
             builder.AddChild<DocumentFormat.OpenXml.Office2021.Drawing.DocumentClassification.ClassificationOutcome>();
             builder.AddChild<DocumentFormat.OpenXml.Office2019.Drawing.Decorative>();
-            builder.AddChild<DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.ScriptLink>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.ScriptLink>();
             builder.AddElement<NonVisualDrawingPropertiesExtension>()
 .AddAttribute("uri", a => a.Uri, aBuilder =>
 {
@@ -34565,7 +34565,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2016.Drawing.PredecessorDrawingElementReference), 1, 1, version: FileFormatVersions.Office2016),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2019.Drawing.Decorative), 1, 1, version: FileFormatVersions.Office2019),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2021.Drawing.DocumentClassification.ClassificationOutcome), 1, 1, version: FileFormatVersions.Office2021),
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.ScriptLink), 1, 1, version: FileFormatVersions.Microsoft365),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.ScriptLink), 1, 1, version: FileFormatVersions.Microsoft365),
                 new AnyParticle(0, 1)
             };
         }
@@ -35066,9 +35066,9 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2010.Drawing.ImageProperties" /> <c>&lt;a14:imgProps></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2010.Drawing.UseLocalDpi" /> <c>&lt;a14:useLocalDpi></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2019.Drawing.PictureAttributionSourceURL" /> <c>&lt;a1611:picAttrSrcUrl></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OEmbedShared" /> <c>&lt;aoe:oembedShared></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OEmbedShared" /> <c>&lt;aoe:oembedShared></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2019.Drawing.SVG.SVGBlip" /> <c>&lt;asvg:svgBlip></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.Word._2020.OEmbed.OEmbed" /> <c>&lt;woe:oembed></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.Word.Y2020.OEmbed.OEmbed" /> <c>&lt;woe:oembed></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2013.Word.Drawing.WebVideoProperty" /> <c>&lt;wp15:webVideoPr></c></description></item>
     /// </list>
     /// </remark>
@@ -35131,9 +35131,9 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddChild<DocumentFormat.OpenXml.Office2010.Drawing.ImageProperties>();
             builder.AddChild<DocumentFormat.OpenXml.Office2010.Drawing.UseLocalDpi>();
             builder.AddChild<DocumentFormat.OpenXml.Office2019.Drawing.PictureAttributionSourceURL>();
-            builder.AddChild<DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OEmbedShared>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OEmbedShared>();
             builder.AddChild<DocumentFormat.OpenXml.Office2019.Drawing.SVG.SVGBlip>();
-            builder.AddChild<DocumentFormat.OpenXml.Office.Word._2020.OEmbed.OEmbed>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.Word.Y2020.OEmbed.OEmbed>();
             builder.AddChild<DocumentFormat.OpenXml.Office2013.Word.Drawing.WebVideoProperty>();
             builder.AddElement<BlipExtension>()
 .AddAttribute("uri", a => a.Uri, aBuilder =>
@@ -35148,8 +35148,8 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2013.Word.Drawing.WebVideoProperty), 1, 1, version: FileFormatVersions.Office2010),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2019.Drawing.SVG.SVGBlip), 1, 1, version: FileFormatVersions.Office2019),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2019.Drawing.PictureAttributionSourceURL), 1, 1, version: FileFormatVersions.Office2016),
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Word._2020.OEmbed.OEmbed), 1, 1, version: FileFormatVersions.Microsoft365),
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OEmbedShared), 1, 1, version: FileFormatVersions.Microsoft365),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Word.Y2020.OEmbed.OEmbed), 1, 1, version: FileFormatVersions.Microsoft365),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OEmbedShared), 1, 1, version: FileFormatVersions.Microsoft365),
                 new AnyParticle(0, 1)
             };
         }

--- a/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_main.g.cs
+++ b/src/DocumentFormat.OpenXml/GeneratedCode/schemas_openxmlformats_org_drawingml_2006_main.g.cs
@@ -6,10 +6,10 @@
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Framework;
 using DocumentFormat.OpenXml.Framework.Metadata;
-using DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed;
-using DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink;
-using DocumentFormat.OpenXml.Microsoft365.Word.OEmbed;
 using DocumentFormat.OpenXml.Office.Drawing;
+using DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed;
+using DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink;
+using DocumentFormat.OpenXml.Office.Word._2020.OEmbed;
 using DocumentFormat.OpenXml.Office2010.Drawing;
 using DocumentFormat.OpenXml.Office2010.Drawing.Diagram;
 using DocumentFormat.OpenXml.Office2013.Drawing;
@@ -16966,9 +16966,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2019.Drawing.Decorative" /> <c>&lt;adec:decorative></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2019.Drawing.HyperLinkColor.HyperlinkColor" /> <c>&lt;ahyp:hlinkClr></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2021.Drawing.Livefeed.LiveFeedProperties" /> <c>&lt;alf:liveFeedProps></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OEmbedShared" /> <c>&lt;aoe:oembedShared></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OEmbedShared" /> <c>&lt;aoe:oembedShared></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2021.Drawing.SketchyShapes.LineSketchStyleProperties" /> <c>&lt;ask:lineSketchStyleProps></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.ScriptLink" /> <c>&lt;asl:scriptLink></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.ScriptLink" /> <c>&lt;asl:scriptLink></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2019.Drawing.SVG.SVGBlip" /> <c>&lt;asvg:svgBlip></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2013.Drawing.Chart.ExceptionForSave" /> <c>&lt;c15:xForSave></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2013.Drawing.Chart.ShowDataLabelsRange" /> <c>&lt;c15:showDataLabelsRange></c></description></item>
@@ -17171,7 +17171,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2013.Word.SdtRepeatedSection" /> <c>&lt;w15:repeatingSection></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2013.WebExtension.WebExtension" /> <c>&lt;we:webextension></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2013.WebExtension.WebExtensionReference" /> <c>&lt;we:webextensionref></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.Word.OEmbed.OEmbed" /> <c>&lt;woe:oembed></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.Word._2020.OEmbed.OEmbed" /> <c>&lt;woe:oembed></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Drawing.Wordprocessing.Anchor" /> <c>&lt;wp:anchor></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Drawing.Wordprocessing.Inline" /> <c>&lt;wp:inline></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2010.Word.Drawing.RelativeWidth" /> <c>&lt;wp14:sizeRelH></c></description></item>
@@ -17287,9 +17287,9 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             builder.AddChild<DocumentFormat.OpenXml.Office2019.Drawing.Decorative>();
             builder.AddChild<DocumentFormat.OpenXml.Office2019.Drawing.HyperLinkColor.HyperlinkColor>();
             builder.AddChild<DocumentFormat.OpenXml.Office2021.Drawing.Livefeed.LiveFeedProperties>();
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OEmbedShared>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OEmbedShared>();
             builder.AddChild<DocumentFormat.OpenXml.Office2021.Drawing.SketchyShapes.LineSketchStyleProperties>();
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.ScriptLink>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.ScriptLink>();
             builder.AddChild<DocumentFormat.OpenXml.Office2019.Drawing.SVG.SVGBlip>();
             builder.AddChild<DocumentFormat.OpenXml.Office2013.Drawing.Chart.ExceptionForSave>();
             builder.AddChild<DocumentFormat.OpenXml.Office2013.Drawing.Chart.ShowDataLabelsRange>();
@@ -17492,7 +17492,7 @@ aBuilder.AddValidator(RequiredValidator.Instance);
             builder.AddChild<DocumentFormat.OpenXml.Office2013.Word.SdtRepeatedSection>();
             builder.AddChild<DocumentFormat.OpenXml.Office2013.WebExtension.WebExtension>();
             builder.AddChild<DocumentFormat.OpenXml.Office2013.WebExtension.WebExtensionReference>();
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.Word.OEmbed.OEmbed>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.Word._2020.OEmbed.OEmbed>();
             builder.AddChild<DocumentFormat.OpenXml.Drawing.Wordprocessing.Anchor>();
             builder.AddChild<DocumentFormat.OpenXml.Drawing.Wordprocessing.Inline>();
             builder.AddChild<DocumentFormat.OpenXml.Office2010.Word.Drawing.RelativeWidth>();
@@ -34485,7 +34485,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2016.Drawing.PredecessorDrawingElementReference" /> <c>&lt;a16:predDERef></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2021.Drawing.DocumentClassification.ClassificationOutcome" /> <c>&lt;aclsh:classification></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2019.Drawing.Decorative" /> <c>&lt;adec:decorative></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.ScriptLink" /> <c>&lt;asl:scriptLink></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.ScriptLink" /> <c>&lt;asl:scriptLink></c></description></item>
     /// </list>
     /// </remark>
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -34550,7 +34550,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddChild<DocumentFormat.OpenXml.Office2016.Drawing.PredecessorDrawingElementReference>();
             builder.AddChild<DocumentFormat.OpenXml.Office2021.Drawing.DocumentClassification.ClassificationOutcome>();
             builder.AddChild<DocumentFormat.OpenXml.Office2019.Drawing.Decorative>();
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.ScriptLink>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.ScriptLink>();
             builder.AddElement<NonVisualDrawingPropertiesExtension>()
 .AddAttribute("uri", a => a.Uri, aBuilder =>
 {
@@ -34565,7 +34565,7 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2016.Drawing.PredecessorDrawingElementReference), 1, 1, version: FileFormatVersions.Office2016),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2019.Drawing.Decorative), 1, 1, version: FileFormatVersions.Office2019),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2021.Drawing.DocumentClassification.ClassificationOutcome), 1, 1, version: FileFormatVersions.Office2021),
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.ScriptLink), 1, 1, version: FileFormatVersions.Microsoft365),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.ScriptLink), 1, 1, version: FileFormatVersions.Microsoft365),
                 new AnyParticle(0, 1)
             };
         }
@@ -35066,9 +35066,9 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2010.Drawing.ImageProperties" /> <c>&lt;a14:imgProps></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2010.Drawing.UseLocalDpi" /> <c>&lt;a14:useLocalDpi></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2019.Drawing.PictureAttributionSourceURL" /> <c>&lt;a1611:picAttrSrcUrl></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OEmbedShared" /> <c>&lt;aoe:oembedShared></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OEmbedShared" /> <c>&lt;aoe:oembedShared></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2019.Drawing.SVG.SVGBlip" /> <c>&lt;asvg:svgBlip></c></description></item>
-    ///   <item><description><see cref="DocumentFormat.OpenXml.Microsoft365.Word.OEmbed.OEmbed" /> <c>&lt;woe:oembed></c></description></item>
+    ///   <item><description><see cref="DocumentFormat.OpenXml.Office.Word._2020.OEmbed.OEmbed" /> <c>&lt;woe:oembed></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office2013.Word.Drawing.WebVideoProperty" /> <c>&lt;wp15:webVideoPr></c></description></item>
     /// </list>
     /// </remark>
@@ -35131,9 +35131,9 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
             builder.AddChild<DocumentFormat.OpenXml.Office2010.Drawing.ImageProperties>();
             builder.AddChild<DocumentFormat.OpenXml.Office2010.Drawing.UseLocalDpi>();
             builder.AddChild<DocumentFormat.OpenXml.Office2019.Drawing.PictureAttributionSourceURL>();
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OEmbedShared>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OEmbedShared>();
             builder.AddChild<DocumentFormat.OpenXml.Office2019.Drawing.SVG.SVGBlip>();
-            builder.AddChild<DocumentFormat.OpenXml.Microsoft365.Word.OEmbed.OEmbed>();
+            builder.AddChild<DocumentFormat.OpenXml.Office.Word._2020.OEmbed.OEmbed>();
             builder.AddChild<DocumentFormat.OpenXml.Office2013.Word.Drawing.WebVideoProperty>();
             builder.AddElement<BlipExtension>()
 .AddAttribute("uri", a => a.Uri, aBuilder =>
@@ -35148,8 +35148,8 @@ aBuilder.AddValidator(new StringValidator() { IsToken = (true) });
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2013.Word.Drawing.WebVideoProperty), 1, 1, version: FileFormatVersions.Office2010),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2019.Drawing.SVG.SVGBlip), 1, 1, version: FileFormatVersions.Office2019),
                 new ElementParticle(typeof(DocumentFormat.OpenXml.Office2019.Drawing.PictureAttributionSourceURL), 1, 1, version: FileFormatVersions.Office2016),
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Microsoft365.Word.OEmbed.OEmbed), 1, 1, version: FileFormatVersions.Microsoft365),
-                new ElementParticle(typeof(DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OEmbedShared), 1, 1, version: FileFormatVersions.Microsoft365),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Word._2020.OEmbed.OEmbed), 1, 1, version: FileFormatVersions.Microsoft365),
+                new ElementParticle(typeof(DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OEmbedShared), 1, 1, version: FileFormatVersions.Microsoft365),
                 new AnyParticle(0, 1)
             };
         }

--- a/src/DocumentFormat.OpenXml/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/DocumentFormat.OpenXml/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,130 +1,130 @@
 ﻿#nullable enable
 DocumentFormat.OpenXml.FileFormatVersions.Microsoft365 = 1073741824 -> DocumentFormat.OpenXml.FileFormatVersions
-DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OEmbedShared
-DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OEmbedShared.OEmbedShared() -> void
-DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OEmbedShared.OEmbedShared(params DocumentFormat.OpenXml.OpenXmlElement![]! childElements) -> void
-DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OEmbedShared.OEmbedShared(string! outerXml) -> void
-DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OEmbedShared.OEmbedShared(System.Collections.Generic.IEnumerable<DocumentFormat.OpenXml.OpenXmlElement!>! childElements) -> void
-DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OEmbedShared.OfficeArtExtensionList.get -> DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OfficeArtExtensionList?
-DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OEmbedShared.OfficeArtExtensionList.set -> void
-DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OEmbedShared.SrcUrl.get -> DocumentFormat.OpenXml.StringValue?
-DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OEmbedShared.SrcUrl.set -> void
-DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OEmbedShared.Type.get -> DocumentFormat.OpenXml.StringValue?
-DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OEmbedShared.Type.set -> void
-DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OfficeArtExtensionList
-DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OfficeArtExtensionList.OfficeArtExtensionList() -> void
-DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OfficeArtExtensionList.OfficeArtExtensionList(params DocumentFormat.OpenXml.OpenXmlElement![]! childElements) -> void
-DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OfficeArtExtensionList.OfficeArtExtensionList(string! outerXml) -> void
-DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OfficeArtExtensionList.OfficeArtExtensionList(System.Collections.Generic.IEnumerable<DocumentFormat.OpenXml.OpenXmlElement!>! childElements) -> void
-DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.OfficeArtExtensionList
-DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.OfficeArtExtensionList.OfficeArtExtensionList() -> void
-DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.OfficeArtExtensionList.OfficeArtExtensionList(params DocumentFormat.OpenXml.OpenXmlElement![]! childElements) -> void
-DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.OfficeArtExtensionList.OfficeArtExtensionList(string! outerXml) -> void
-DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.OfficeArtExtensionList.OfficeArtExtensionList(System.Collections.Generic.IEnumerable<DocumentFormat.OpenXml.OpenXmlElement!>! childElements) -> void
-DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.ScriptLink
-DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.ScriptLink.OfficeArtExtensionList.get -> DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.OfficeArtExtensionList?
-DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.ScriptLink.OfficeArtExtensionList.set -> void
-DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.ScriptLink.ScriptLink() -> void
-DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.ScriptLink.ScriptLink(params DocumentFormat.OpenXml.OpenXmlElement![]! childElements) -> void
-DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.ScriptLink.ScriptLink(string! outerXml) -> void
-DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.ScriptLink.ScriptLink(System.Collections.Generic.IEnumerable<DocumentFormat.OpenXml.OpenXmlElement!>! childElements) -> void
-DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.ScriptLink.Val.get -> DocumentFormat.OpenXml.StringValue?
-DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.ScriptLink.Val.set -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AddEmpty
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AddEmpty.AddEmpty() -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AsgnTaskAssignUnassignUser
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AsgnTaskAssignUnassignUser.AsgnTaskAssignUnassignUser() -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AtrbtnTaskAssignUnassignUser
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AtrbtnTaskAssignUnassignUser.AtrbtnTaskAssignUnassignUser() -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.CommentAnchor
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.CommentAnchor.CommentAnchor() -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.CommentAnchor.Id.get -> DocumentFormat.OpenXml.StringValue?
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.CommentAnchor.Id.set -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.EmptyType
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.EmptyType.EmptyType() -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList.ExtensionList() -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList.ExtensionList(params DocumentFormat.OpenXml.OpenXmlElement![]! childElements) -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList.ExtensionList(string! outerXml) -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList.ExtensionList(System.Collections.Generic.IEnumerable<DocumentFormat.OpenXml.OpenXmlElement!>! childElements) -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.OpenXmlTaskAssignUnassignUserElement
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.OpenXmlTaskAssignUnassignUserElement.AuthorId.get -> DocumentFormat.OpenXml.StringValue?
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.OpenXmlTaskAssignUnassignUserElement.AuthorId.set -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.OpenXmlTaskAssignUnassignUserElement.OpenXmlTaskAssignUnassignUserElement() -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskAnchor
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskAnchor.CommentAnchor.get -> DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.CommentAnchor?
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskAnchor.CommentAnchor.set -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskAnchor.ExtensionList.get -> DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList?
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskAnchor.ExtensionList.set -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskAnchor.TaskAnchor() -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskAnchor.TaskAnchor(params DocumentFormat.OpenXml.OpenXmlElement![]! childElements) -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskAnchor.TaskAnchor(string! outerXml) -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskAnchor.TaskAnchor(System.Collections.Generic.IEnumerable<DocumentFormat.OpenXml.OpenXmlElement!>! childElements) -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistory
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistory.TaskHistory() -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistory.TaskHistory(params DocumentFormat.OpenXml.OpenXmlElement![]! childElements) -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistory.TaskHistory(string! outerXml) -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistory.TaskHistory(System.Collections.Generic.IEnumerable<DocumentFormat.OpenXml.OpenXmlElement!>! childElements) -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryDetails
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryDetails.ExtensionList.get -> DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList?
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryDetails.ExtensionList.set -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryDetails.Id.get -> DocumentFormat.OpenXml.StringValue?
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryDetails.Id.set -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryDetails.TaskHistory.get -> DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistory?
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryDetails.TaskHistory.set -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryDetails.TaskHistoryDetails() -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryDetails.TaskHistoryDetails(params DocumentFormat.OpenXml.OpenXmlElement![]! childElements) -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryDetails.TaskHistoryDetails(string! outerXml) -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryDetails.TaskHistoryDetails(System.Collections.Generic.IEnumerable<DocumentFormat.OpenXml.OpenXmlElement!>! childElements) -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryEvent
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryEvent.AtrbtnTaskAssignUnassignUser.get -> DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AtrbtnTaskAssignUnassignUser?
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryEvent.AtrbtnTaskAssignUnassignUser.set -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryEvent.Id.get -> DocumentFormat.OpenXml.StringValue?
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryEvent.Id.set -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryEvent.TaskAnchor.get -> DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskAnchor?
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryEvent.TaskAnchor.set -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryEvent.TaskHistoryEvent() -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryEvent.TaskHistoryEvent(params DocumentFormat.OpenXml.OpenXmlElement![]! childElements) -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryEvent.TaskHistoryEvent(string! outerXml) -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryEvent.TaskHistoryEvent(System.Collections.Generic.IEnumerable<DocumentFormat.OpenXml.OpenXmlElement!>! childElements) -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryEvent.Time.get -> DocumentFormat.OpenXml.DateTimeValue?
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryEvent.Time.set -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskPriorityRecord
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskPriorityRecord.TaskPriorityRecord() -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskPriorityRecord.Val.get -> DocumentFormat.OpenXml.Int32Value?
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskPriorityRecord.Val.set -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskProgressEventInfo
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskProgressEventInfo.TaskProgressEventInfo() -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskProgressEventInfo.Val.get -> DocumentFormat.OpenXml.Int32Value?
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskProgressEventInfo.Val.set -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskScheduleEventInfo
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskScheduleEventInfo.EndDt.get -> DocumentFormat.OpenXml.DateTimeValue?
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskScheduleEventInfo.EndDt.set -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskScheduleEventInfo.StDt.get -> DocumentFormat.OpenXml.DateTimeValue?
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskScheduleEventInfo.StDt.set -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskScheduleEventInfo.TaskScheduleEventInfo() -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskTitleEventInfo
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskTitleEventInfo.TaskTitleEventInfo() -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskTitleEventInfo.Val.get -> DocumentFormat.OpenXml.StringValue?
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskTitleEventInfo.Val.set -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskUndo
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskUndo.Id.get -> DocumentFormat.OpenXml.StringValue?
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskUndo.Id.set -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskUndo.TaskUndo() -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskUnknownRecord
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskUnknownRecord.TaskUnknownRecord() -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.UnasgnAllEmpty
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.UnasgnAllEmpty.UnasgnAllEmpty() -> void
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.UnAsgnTaskAssignUnassignUser
-DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.UnAsgnTaskAssignUnassignUser.UnAsgnTaskAssignUnassignUser() -> void
-DocumentFormat.OpenXml.Microsoft365.Word.OEmbed.OEmbed
-DocumentFormat.OpenXml.Microsoft365.Word.OEmbed.OEmbed.MediaType.get -> DocumentFormat.OpenXml.StringValue?
-DocumentFormat.OpenXml.Microsoft365.Word.OEmbed.OEmbed.MediaType.set -> void
-DocumentFormat.OpenXml.Microsoft365.Word.OEmbed.OEmbed.OEmbed() -> void
-DocumentFormat.OpenXml.Microsoft365.Word.OEmbed.OEmbed.OEmbedUrl.get -> DocumentFormat.OpenXml.StringValue?
-DocumentFormat.OpenXml.Microsoft365.Word.OEmbed.OEmbed.OEmbedUrl.set -> void
-DocumentFormat.OpenXml.Microsoft365.Word.OEmbed.OEmbed.PicLocksAutoForOEmbed.get -> DocumentFormat.OpenXml.BooleanValue?
-DocumentFormat.OpenXml.Microsoft365.Word.OEmbed.OEmbed.PicLocksAutoForOEmbed.set -> void
+DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OEmbedShared
+DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OEmbedShared.OEmbedShared() -> void
+DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OEmbedShared.OEmbedShared(params DocumentFormat.OpenXml.OpenXmlElement![]! childElements) -> void
+DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OEmbedShared.OEmbedShared(string! outerXml) -> void
+DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OEmbedShared.OEmbedShared(System.Collections.Generic.IEnumerable<DocumentFormat.OpenXml.OpenXmlElement!>! childElements) -> void
+DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OEmbedShared.OfficeArtExtensionList.get -> DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OfficeArtExtensionList?
+DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OEmbedShared.OfficeArtExtensionList.set -> void
+DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OEmbedShared.SrcUrl.get -> DocumentFormat.OpenXml.StringValue?
+DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OEmbedShared.SrcUrl.set -> void
+DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OEmbedShared.Type.get -> DocumentFormat.OpenXml.StringValue?
+DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OEmbedShared.Type.set -> void
+DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OfficeArtExtensionList
+DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OfficeArtExtensionList.OfficeArtExtensionList() -> void
+DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OfficeArtExtensionList.OfficeArtExtensionList(params DocumentFormat.OpenXml.OpenXmlElement![]! childElements) -> void
+DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OfficeArtExtensionList.OfficeArtExtensionList(string! outerXml) -> void
+DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OfficeArtExtensionList.OfficeArtExtensionList(System.Collections.Generic.IEnumerable<DocumentFormat.OpenXml.OpenXmlElement!>! childElements) -> void
+DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.OfficeArtExtensionList
+DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.OfficeArtExtensionList.OfficeArtExtensionList() -> void
+DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.OfficeArtExtensionList.OfficeArtExtensionList(params DocumentFormat.OpenXml.OpenXmlElement![]! childElements) -> void
+DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.OfficeArtExtensionList.OfficeArtExtensionList(string! outerXml) -> void
+DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.OfficeArtExtensionList.OfficeArtExtensionList(System.Collections.Generic.IEnumerable<DocumentFormat.OpenXml.OpenXmlElement!>! childElements) -> void
+DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.ScriptLink
+DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.ScriptLink.OfficeArtExtensionList.get -> DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.OfficeArtExtensionList?
+DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.ScriptLink.OfficeArtExtensionList.set -> void
+DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.ScriptLink.ScriptLink() -> void
+DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.ScriptLink.ScriptLink(params DocumentFormat.OpenXml.OpenXmlElement![]! childElements) -> void
+DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.ScriptLink.ScriptLink(string! outerXml) -> void
+DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.ScriptLink.ScriptLink(System.Collections.Generic.IEnumerable<DocumentFormat.OpenXml.OpenXmlElement!>! childElements) -> void
+DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.ScriptLink.Val.get -> DocumentFormat.OpenXml.StringValue?
+DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.ScriptLink.Val.set -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AddEmpty
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AddEmpty.AddEmpty() -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AsgnTaskAssignUnassignUser
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AsgnTaskAssignUnassignUser.AsgnTaskAssignUnassignUser() -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AtrbtnTaskAssignUnassignUser
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AtrbtnTaskAssignUnassignUser.AtrbtnTaskAssignUnassignUser() -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.CommentAnchor
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.CommentAnchor.CommentAnchor() -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.CommentAnchor.Id.get -> DocumentFormat.OpenXml.StringValue?
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.CommentAnchor.Id.set -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.EmptyType
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.EmptyType.EmptyType() -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList.ExtensionList() -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList.ExtensionList(params DocumentFormat.OpenXml.OpenXmlElement![]! childElements) -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList.ExtensionList(string! outerXml) -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList.ExtensionList(System.Collections.Generic.IEnumerable<DocumentFormat.OpenXml.OpenXmlElement!>! childElements) -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.OpenXmlTaskAssignUnassignUserElement
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.OpenXmlTaskAssignUnassignUserElement.AuthorId.get -> DocumentFormat.OpenXml.StringValue?
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.OpenXmlTaskAssignUnassignUserElement.AuthorId.set -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.OpenXmlTaskAssignUnassignUserElement.OpenXmlTaskAssignUnassignUserElement() -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskAnchor
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskAnchor.CommentAnchor.get -> DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.CommentAnchor?
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskAnchor.CommentAnchor.set -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskAnchor.ExtensionList.get -> DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList?
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskAnchor.ExtensionList.set -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskAnchor.TaskAnchor() -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskAnchor.TaskAnchor(params DocumentFormat.OpenXml.OpenXmlElement![]! childElements) -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskAnchor.TaskAnchor(string! outerXml) -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskAnchor.TaskAnchor(System.Collections.Generic.IEnumerable<DocumentFormat.OpenXml.OpenXmlElement!>! childElements) -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistory
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistory.TaskHistory() -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistory.TaskHistory(params DocumentFormat.OpenXml.OpenXmlElement![]! childElements) -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistory.TaskHistory(string! outerXml) -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistory.TaskHistory(System.Collections.Generic.IEnumerable<DocumentFormat.OpenXml.OpenXmlElement!>! childElements) -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryDetails
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryDetails.ExtensionList.get -> DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList?
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryDetails.ExtensionList.set -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryDetails.Id.get -> DocumentFormat.OpenXml.StringValue?
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryDetails.Id.set -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryDetails.TaskHistory.get -> DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistory?
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryDetails.TaskHistory.set -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryDetails.TaskHistoryDetails() -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryDetails.TaskHistoryDetails(params DocumentFormat.OpenXml.OpenXmlElement![]! childElements) -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryDetails.TaskHistoryDetails(string! outerXml) -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryDetails.TaskHistoryDetails(System.Collections.Generic.IEnumerable<DocumentFormat.OpenXml.OpenXmlElement!>! childElements) -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryEvent
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryEvent.AtrbtnTaskAssignUnassignUser.get -> DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AtrbtnTaskAssignUnassignUser?
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryEvent.AtrbtnTaskAssignUnassignUser.set -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryEvent.Id.get -> DocumentFormat.OpenXml.StringValue?
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryEvent.Id.set -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryEvent.TaskAnchor.get -> DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskAnchor?
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryEvent.TaskAnchor.set -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryEvent.TaskHistoryEvent() -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryEvent.TaskHistoryEvent(params DocumentFormat.OpenXml.OpenXmlElement![]! childElements) -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryEvent.TaskHistoryEvent(string! outerXml) -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryEvent.TaskHistoryEvent(System.Collections.Generic.IEnumerable<DocumentFormat.OpenXml.OpenXmlElement!>! childElements) -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryEvent.Time.get -> DocumentFormat.OpenXml.DateTimeValue?
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryEvent.Time.set -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskPriorityRecord
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskPriorityRecord.TaskPriorityRecord() -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskPriorityRecord.Val.get -> DocumentFormat.OpenXml.Int32Value?
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskPriorityRecord.Val.set -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskProgressEventInfo
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskProgressEventInfo.TaskProgressEventInfo() -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskProgressEventInfo.Val.get -> DocumentFormat.OpenXml.Int32Value?
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskProgressEventInfo.Val.set -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskScheduleEventInfo
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskScheduleEventInfo.EndDt.get -> DocumentFormat.OpenXml.DateTimeValue?
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskScheduleEventInfo.EndDt.set -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskScheduleEventInfo.StDt.get -> DocumentFormat.OpenXml.DateTimeValue?
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskScheduleEventInfo.StDt.set -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskScheduleEventInfo.TaskScheduleEventInfo() -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskTitleEventInfo
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskTitleEventInfo.TaskTitleEventInfo() -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskTitleEventInfo.Val.get -> DocumentFormat.OpenXml.StringValue?
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskTitleEventInfo.Val.set -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskUndo
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskUndo.Id.get -> DocumentFormat.OpenXml.StringValue?
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskUndo.Id.set -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskUndo.TaskUndo() -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskUnknownRecord
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskUnknownRecord.TaskUnknownRecord() -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.UnasgnAllEmpty
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.UnasgnAllEmpty.UnasgnAllEmpty() -> void
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.UnAsgnTaskAssignUnassignUser
+DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.UnAsgnTaskAssignUnassignUser.UnAsgnTaskAssignUnassignUser() -> void
+DocumentFormat.OpenXml.Office.Word.Y2020.OEmbed.OEmbed
+DocumentFormat.OpenXml.Office.Word.Y2020.OEmbed.OEmbed.MediaType.get -> DocumentFormat.OpenXml.StringValue?
+DocumentFormat.OpenXml.Office.Word.Y2020.OEmbed.OEmbed.MediaType.set -> void
+DocumentFormat.OpenXml.Office.Word.Y2020.OEmbed.OEmbed.OEmbed() -> void
+DocumentFormat.OpenXml.Office.Word.Y2020.OEmbed.OEmbed.OEmbedUrl.get -> DocumentFormat.OpenXml.StringValue?
+DocumentFormat.OpenXml.Office.Word.Y2020.OEmbed.OEmbed.OEmbedUrl.set -> void
+DocumentFormat.OpenXml.Office.Word.Y2020.OEmbed.OEmbed.PicLocksAutoForOEmbed.get -> DocumentFormat.OpenXml.BooleanValue?
+DocumentFormat.OpenXml.Office.Word.Y2020.OEmbed.OEmbed.PicLocksAutoForOEmbed.set -> void
 DocumentFormat.OpenXml.Office2021.Drawing.Livefeed.BackgroundBlurProperties
 DocumentFormat.OpenXml.Office2021.Drawing.Livefeed.BackgroundBlurProperties.BackgroundBlurProperties() -> void
 DocumentFormat.OpenXml.Office2021.Drawing.Livefeed.BackgroundBlurProperties.BackgroundBlurProperties(params DocumentFormat.OpenXml.OpenXmlElement![]! childElements) -> void
@@ -174,28 +174,28 @@ DocumentFormat.OpenXml.Office2021.Drawing.Livefeed.OfficeArtExtensionList.Office
 DocumentFormat.OpenXml.Office2021.Drawing.Livefeed.OfficeArtExtensionList.OfficeArtExtensionList(System.Collections.Generic.IEnumerable<DocumentFormat.OpenXml.OpenXmlElement!>! childElements) -> void
 DocumentFormat.OpenXml.Packaging.ImagePartExtensions
 DocumentFormat.OpenXml.SchemaAttrAttribute.SchemaAttrAttribute(string! qname) -> void
-override DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OEmbedShared.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
-override DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OfficeArtExtensionList.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
-override DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.OfficeArtExtensionList.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
-override DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.ScriptLink.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
-override DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AddEmpty.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
-override DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AsgnTaskAssignUnassignUser.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
-override DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AtrbtnTaskAssignUnassignUser.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
-override DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.CommentAnchor.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
-override DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
-override DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskAnchor.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
-override DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistory.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
-override DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryDetails.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
-override DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryEvent.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
-override DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskPriorityRecord.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
-override DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskProgressEventInfo.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
-override DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskScheduleEventInfo.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
-override DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskTitleEventInfo.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
-override DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskUndo.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
-override DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskUnknownRecord.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
-override DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.UnasgnAllEmpty.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
-override DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.UnAsgnTaskAssignUnassignUser.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
-override DocumentFormat.OpenXml.Microsoft365.Word.OEmbed.OEmbed.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
+override DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OEmbedShared.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
+override DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OfficeArtExtensionList.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
+override DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.OfficeArtExtensionList.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
+override DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.ScriptLink.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
+override DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AddEmpty.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
+override DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AsgnTaskAssignUnassignUser.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
+override DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AtrbtnTaskAssignUnassignUser.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
+override DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.CommentAnchor.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
+override DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
+override DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskAnchor.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
+override DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistory.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
+override DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryDetails.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
+override DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryEvent.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
+override DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskPriorityRecord.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
+override DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskProgressEventInfo.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
+override DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskScheduleEventInfo.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
+override DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskTitleEventInfo.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
+override DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskUndo.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
+override DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskUnknownRecord.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
+override DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.UnasgnAllEmpty.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
+override DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.UnAsgnTaskAssignUnassignUser.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
+override DocumentFormat.OpenXml.Office.Word.Y2020.OEmbed.OEmbed.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
 override DocumentFormat.OpenXml.Office2021.Drawing.Livefeed.BackgroundBlurProperties.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
 override DocumentFormat.OpenXml.Office2021.Drawing.Livefeed.BackgroundCustomProperties.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!
 override DocumentFormat.OpenXml.Office2021.Drawing.Livefeed.BackgroundNormalProperties.CloneNode(bool deep) -> DocumentFormat.OpenXml.OpenXmlElement!

--- a/test/DocumentFormat.OpenXml.Framework.Tests/ElementChildren.json
+++ b/test/DocumentFormat.OpenXml.Framework.Tests/ElementChildren.json
@@ -21682,7 +21682,7 @@
     ]
   },
   {
-    "Element": "DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OEmbedShared",
+    "Element": "DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OEmbedShared",
     "Children": [
       {
         "Name": "extLst",
@@ -21691,7 +21691,7 @@
     ]
   },
   {
-    "Element": "DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OfficeArtExtensionList",
+    "Element": "DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OfficeArtExtensionList",
     "Children": [
       {
         "Name": "ext",
@@ -21700,7 +21700,7 @@
     ]
   },
   {
-    "Element": "DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.OfficeArtExtensionList",
+    "Element": "DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.OfficeArtExtensionList",
     "Children": [
       {
         "Name": "ext",
@@ -21709,7 +21709,7 @@
     ]
   },
   {
-    "Element": "DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.ScriptLink",
+    "Element": "DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.ScriptLink",
     "Children": [
       {
         "Name": "extLst",
@@ -21895,23 +21895,23 @@
     "Children": []
   },
   {
-    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AddEmpty",
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AddEmpty",
     "Children": []
   },
   {
-    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AsgnTaskAssignUnassignUser",
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AsgnTaskAssignUnassignUser",
     "Children": []
   },
   {
-    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AtrbtnTaskAssignUnassignUser",
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AtrbtnTaskAssignUnassignUser",
     "Children": []
   },
   {
-    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.CommentAnchor",
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.CommentAnchor",
     "Children": []
   },
   {
-    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList",
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList",
     "Children": [
       {
         "Name": "ext",
@@ -21920,7 +21920,7 @@
     ]
   },
   {
-    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskAnchor",
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskAnchor",
     "Children": [
       {
         "Name": "comment",
@@ -21933,7 +21933,7 @@
     ]
   },
   {
-    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistory",
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistory",
     "Children": [
       {
         "Name": "event",
@@ -21942,7 +21942,7 @@
     ]
   },
   {
-    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistoryDetails",
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryDetails",
     "Children": [
       {
         "Name": "extLst",
@@ -21955,7 +21955,7 @@
     ]
   },
   {
-    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistoryEvent",
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryEvent",
     "Children": [
       {
         "Name": "add",
@@ -22012,35 +22012,35 @@
     ]
   },
   {
-    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskPriorityRecord",
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskPriorityRecord",
     "Children": []
   },
   {
-    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskProgressEventInfo",
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskProgressEventInfo",
     "Children": []
   },
   {
-    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskScheduleEventInfo",
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskScheduleEventInfo",
     "Children": []
   },
   {
-    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskTitleEventInfo",
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskTitleEventInfo",
     "Children": []
   },
   {
-    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskUndo",
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskUndo",
     "Children": []
   },
   {
-    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskUnknownRecord",
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskUnknownRecord",
     "Children": []
   },
   {
-    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.UnAsgnTaskAssignUnassignUser",
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.UnAsgnTaskAssignUnassignUser",
     "Children": []
   },
   {
-    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.UnasgnAllEmpty",
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.UnasgnAllEmpty",
     "Children": []
   },
   {
@@ -22336,7 +22336,7 @@
     "Children": []
   },
   {
-    "Element": "DocumentFormat.OpenXml.Office.Word._2020.OEmbed.OEmbed",
+    "Element": "DocumentFormat.OpenXml.Office.Word.Y2020.OEmbed.OEmbed",
     "Children": []
   },
   {

--- a/test/DocumentFormat.OpenXml.Framework.Tests/ElementChildren.json
+++ b/test/DocumentFormat.OpenXml.Framework.Tests/ElementChildren.json
@@ -20498,195 +20498,6 @@
     "Children": []
   },
   {
-    "Element": "DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OEmbedShared",
-    "Children": [
-      {
-        "Name": "extLst",
-        "Namespace": "http://schemas.microsoft.com/office/drawing/2021/oembed"
-      }
-    ]
-  },
-  {
-    "Element": "DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OfficeArtExtensionList",
-    "Children": [
-      {
-        "Name": "ext",
-        "Namespace": "http://schemas.openxmlformats.org/drawingml/2006/main"
-      }
-    ]
-  },
-  {
-    "Element": "DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.OfficeArtExtensionList",
-    "Children": [
-      {
-        "Name": "ext",
-        "Namespace": "http://schemas.openxmlformats.org/drawingml/2006/main"
-      }
-    ]
-  },
-  {
-    "Element": "DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.ScriptLink",
-    "Children": [
-      {
-        "Name": "extLst",
-        "Namespace": "http://schemas.microsoft.com/office/drawing/2021/scriptlink"
-      }
-    ]
-  },
-  {
-    "Element": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AddEmpty",
-    "Children": []
-  },
-  {
-    "Element": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AsgnTaskAssignUnassignUser",
-    "Children": []
-  },
-  {
-    "Element": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AtrbtnTaskAssignUnassignUser",
-    "Children": []
-  },
-  {
-    "Element": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.CommentAnchor",
-    "Children": []
-  },
-  {
-    "Element": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList",
-    "Children": [
-      {
-        "Name": "ext",
-        "Namespace": "http://schemas.openxmlformats.org/presentationml/2006/main"
-      }
-    ]
-  },
-  {
-    "Element": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskAnchor",
-    "Children": [
-      {
-        "Name": "comment",
-        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
-      },
-      {
-        "Name": "extLst",
-        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
-      }
-    ]
-  },
-  {
-    "Element": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistory",
-    "Children": [
-      {
-        "Name": "event",
-        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
-      }
-    ]
-  },
-  {
-    "Element": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryDetails",
-    "Children": [
-      {
-        "Name": "extLst",
-        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
-      },
-      {
-        "Name": "history",
-        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
-      }
-    ]
-  },
-  {
-    "Element": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryEvent",
-    "Children": [
-      {
-        "Name": "add",
-        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
-      },
-      {
-        "Name": "anchr",
-        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
-      },
-      {
-        "Name": "asgn",
-        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
-      },
-      {
-        "Name": "atrbtn",
-        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
-      },
-      {
-        "Name": "date",
-        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
-      },
-      {
-        "Name": "extLst",
-        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
-      },
-      {
-        "Name": "pcntCmplt",
-        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
-      },
-      {
-        "Name": "pri",
-        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
-      },
-      {
-        "Name": "title",
-        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
-      },
-      {
-        "Name": "unAsgn",
-        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
-      },
-      {
-        "Name": "unasgnAll",
-        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
-      },
-      {
-        "Name": "undo",
-        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
-      },
-      {
-        "Name": "unknown",
-        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
-      }
-    ]
-  },
-  {
-    "Element": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskPriorityRecord",
-    "Children": []
-  },
-  {
-    "Element": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskProgressEventInfo",
-    "Children": []
-  },
-  {
-    "Element": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskScheduleEventInfo",
-    "Children": []
-  },
-  {
-    "Element": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskTitleEventInfo",
-    "Children": []
-  },
-  {
-    "Element": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskUndo",
-    "Children": []
-  },
-  {
-    "Element": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskUnknownRecord",
-    "Children": []
-  },
-  {
-    "Element": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.UnAsgnTaskAssignUnassignUser",
-    "Children": []
-  },
-  {
-    "Element": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.UnasgnAllEmpty",
-    "Children": []
-  },
-  {
-    "Element": "DocumentFormat.OpenXml.Microsoft365.Word.OEmbed.OEmbed",
-    "Children": []
-  },
-  {
     "Element": "DocumentFormat.OpenXml.Office.ActiveX.ActiveXControlData",
     "Children": [
       {
@@ -21871,6 +21682,42 @@
     ]
   },
   {
+    "Element": "DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OEmbedShared",
+    "Children": [
+      {
+        "Name": "extLst",
+        "Namespace": "http://schemas.microsoft.com/office/drawing/2021/oembed"
+      }
+    ]
+  },
+  {
+    "Element": "DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OfficeArtExtensionList",
+    "Children": [
+      {
+        "Name": "ext",
+        "Namespace": "http://schemas.openxmlformats.org/drawingml/2006/main"
+      }
+    ]
+  },
+  {
+    "Element": "DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.OfficeArtExtensionList",
+    "Children": [
+      {
+        "Name": "ext",
+        "Namespace": "http://schemas.openxmlformats.org/drawingml/2006/main"
+      }
+    ]
+  },
+  {
+    "Element": "DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.ScriptLink",
+    "Children": [
+      {
+        "Name": "extLst",
+        "Namespace": "http://schemas.microsoft.com/office/drawing/2021/scriptlink"
+      }
+    ]
+  },
+  {
     "Element": "DocumentFormat.OpenXml.Office.Excel.ColumnSortMap",
     "Children": [
       {
@@ -22045,6 +21892,155 @@
   },
   {
     "Element": "DocumentFormat.OpenXml.Office.MetaAttributes.Dummy",
+    "Children": []
+  },
+  {
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AddEmpty",
+    "Children": []
+  },
+  {
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AsgnTaskAssignUnassignUser",
+    "Children": []
+  },
+  {
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AtrbtnTaskAssignUnassignUser",
+    "Children": []
+  },
+  {
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.CommentAnchor",
+    "Children": []
+  },
+  {
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList",
+    "Children": [
+      {
+        "Name": "ext",
+        "Namespace": "http://schemas.openxmlformats.org/presentationml/2006/main"
+      }
+    ]
+  },
+  {
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskAnchor",
+    "Children": [
+      {
+        "Name": "comment",
+        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
+      },
+      {
+        "Name": "extLst",
+        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
+      }
+    ]
+  },
+  {
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistory",
+    "Children": [
+      {
+        "Name": "event",
+        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
+      }
+    ]
+  },
+  {
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistoryDetails",
+    "Children": [
+      {
+        "Name": "extLst",
+        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
+      },
+      {
+        "Name": "history",
+        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
+      }
+    ]
+  },
+  {
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistoryEvent",
+    "Children": [
+      {
+        "Name": "add",
+        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
+      },
+      {
+        "Name": "anchr",
+        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
+      },
+      {
+        "Name": "asgn",
+        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
+      },
+      {
+        "Name": "atrbtn",
+        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
+      },
+      {
+        "Name": "date",
+        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
+      },
+      {
+        "Name": "extLst",
+        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
+      },
+      {
+        "Name": "pcntCmplt",
+        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
+      },
+      {
+        "Name": "pri",
+        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
+      },
+      {
+        "Name": "title",
+        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
+      },
+      {
+        "Name": "unAsgn",
+        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
+      },
+      {
+        "Name": "unasgnAll",
+        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
+      },
+      {
+        "Name": "undo",
+        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
+      },
+      {
+        "Name": "unknown",
+        "Namespace": "http://schemas.microsoft.com/office/powerpoint/2021/06/main"
+      }
+    ]
+  },
+  {
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskPriorityRecord",
+    "Children": []
+  },
+  {
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskProgressEventInfo",
+    "Children": []
+  },
+  {
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskScheduleEventInfo",
+    "Children": []
+  },
+  {
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskTitleEventInfo",
+    "Children": []
+  },
+  {
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskUndo",
+    "Children": []
+  },
+  {
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskUnknownRecord",
+    "Children": []
+  },
+  {
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.UnAsgnTaskAssignUnassignUser",
+    "Children": []
+  },
+  {
+    "Element": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.UnasgnAllEmpty",
     "Children": []
   },
   {
@@ -22337,6 +22333,10 @@
   },
   {
     "Element": "DocumentFormat.OpenXml.Office.Word.WllMacroKeyboardCustomization",
+    "Children": []
+  },
+  {
+    "Element": "DocumentFormat.OpenXml.Office.Word._2020.OEmbed.OEmbed",
     "Children": []
   },
   {

--- a/test/DocumentFormat.OpenXml.Packaging.Tests/data/Particles.json
+++ b/test/DocumentFormat.OpenXml.Packaging.Tests/data/Particles.json
@@ -1513,10 +1513,10 @@
        "ElementType": "DocumentFormat.OpenXml.Office2019.Drawing.PictureAttributionSourceURL"
       },
       {
-       "ElementType": "DocumentFormat.OpenXml.Microsoft365.Word.OEmbed.OEmbed"
+       "ElementType": "DocumentFormat.OpenXml.Office.Word._2020.OEmbed.OEmbed"
       },
       {
-       "ElementType": "DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OEmbedShared"
+       "ElementType": "DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OEmbedShared"
       },
       {
        "MinOccurs": 0,
@@ -15414,7 +15414,7 @@
        "ElementType": "DocumentFormat.OpenXml.Office2021.Drawing.DocumentClassification.ClassificationOutcome"
       },
       {
-       "ElementType": "DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.ScriptLink"
+       "ElementType": "DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.ScriptLink"
       },
       {
        "MinOccurs": 0,
@@ -31282,245 +31282,6 @@
   ]
  },
  {
-  "Key": "DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OEmbedShared",
-  "Value": [
-   {
-    "Key": "Microsoft365",
-    "Value": {
-     "ChildrenParticles": [
-      {
-       "ElementType": "DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OfficeArtExtensionList",
-       "MinOccurs": 0
-      }
-     ],
-     "ParticleType": "Sequence"
-    }
-   }
-  ]
- },
- {
-  "Key": "DocumentFormat.OpenXml.Microsoft365.Drawing.OEmbed.OfficeArtExtensionList",
-  "Value": [
-   {
-    "Key": "Microsoft365",
-    "Value": {
-     "ChildrenParticles": [
-      {
-       "ChildrenParticles": [
-        {
-         "ChildrenParticles": [
-          {
-           "ElementType": "DocumentFormat.OpenXml.Drawing.Extension",
-           "MaxOccurs": 0,
-           "MinOccurs": 0
-          }
-         ],
-         "ParticleType": "Sequence"
-        }
-       ],
-       "ParticleType": "Group"
-      }
-     ],
-     "ParticleType": "Sequence"
-    }
-   }
-  ]
- },
- {
-  "Key": "DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.OfficeArtExtensionList",
-  "Value": [
-   {
-    "Key": "Microsoft365",
-    "Value": {
-     "ChildrenParticles": [
-      {
-       "ChildrenParticles": [
-        {
-         "ChildrenParticles": [
-          {
-           "ElementType": "DocumentFormat.OpenXml.Drawing.Extension",
-           "MaxOccurs": 0,
-           "MinOccurs": 0
-          }
-         ],
-         "ParticleType": "Sequence"
-        }
-       ],
-       "ParticleType": "Group"
-      }
-     ],
-     "ParticleType": "Sequence"
-    }
-   }
-  ]
- },
- {
-  "Key": "DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.ScriptLink",
-  "Value": [
-   {
-    "Key": "Microsoft365",
-    "Value": {
-     "ChildrenParticles": [
-      {
-       "ElementType": "DocumentFormat.OpenXml.Microsoft365.Drawing.ScriptLink.OfficeArtExtensionList",
-       "MinOccurs": 0
-      }
-     ],
-     "ParticleType": "Sequence"
-    }
-   }
-  ]
- },
- {
-  "Key": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList",
-  "Value": [
-   {
-    "Key": "Microsoft365",
-    "Value": {
-     "ChildrenParticles": [
-      {
-       "ChildrenParticles": [
-        {
-         "ChildrenParticles": [
-          {
-           "ElementType": "DocumentFormat.OpenXml.Presentation.Extension",
-           "MaxOccurs": 0,
-           "MinOccurs": 0
-          }
-         ],
-         "ParticleType": "Sequence"
-        }
-       ],
-       "MinOccurs": 0,
-       "ParticleType": "Group"
-      }
-     ],
-     "ParticleType": "Sequence"
-    }
-   }
-  ]
- },
- {
-  "Key": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskAnchor",
-  "Value": [
-   {
-    "Key": "Microsoft365",
-    "Value": {
-     "ChildrenParticles": [
-      {
-       "ElementType": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.CommentAnchor"
-      },
-      {
-       "ElementType": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList",
-       "MinOccurs": 0
-      }
-     ],
-     "ParticleType": "Sequence"
-    }
-   }
-  ]
- },
- {
-  "Key": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistory",
-  "Value": [
-   {
-    "Key": "Microsoft365",
-    "Value": {
-     "ChildrenParticles": [
-      {
-       "ElementType": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryEvent",
-       "MaxOccurs": 0,
-       "MinOccurs": 0
-      }
-     ],
-     "ParticleType": "Sequence"
-    }
-   }
-  ]
- },
- {
-  "Key": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryDetails",
-  "Value": [
-   {
-    "Key": "Microsoft365",
-    "Value": {
-     "ChildrenParticles": [
-      {
-       "ElementType": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistory"
-      },
-      {
-       "ElementType": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList",
-       "MinOccurs": 0
-      }
-     ],
-     "ParticleType": "Sequence"
-    }
-   }
-  ]
- },
- {
-  "Key": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskHistoryEvent",
-  "Value": [
-   {
-    "Key": "Microsoft365",
-    "Value": {
-     "ChildrenParticles": [
-      {
-       "ElementType": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AtrbtnTaskAssignUnassignUser"
-      },
-      {
-       "ElementType": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskAnchor",
-       "MinOccurs": 0
-      },
-      {
-       "ChildrenParticles": [
-        {
-         "ElementType": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AsgnTaskAssignUnassignUser"
-        },
-        {
-         "ElementType": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.UnAsgnTaskAssignUnassignUser"
-        },
-        {
-         "ElementType": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.AddEmpty",
-         "MinOccurs": 0
-        },
-        {
-         "ElementType": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskTitleEventInfo"
-        },
-        {
-         "ElementType": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskScheduleEventInfo"
-        },
-        {
-         "ElementType": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskProgressEventInfo"
-        },
-        {
-         "ElementType": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskPriorityRecord"
-        },
-        {
-         "ElementType": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.UnasgnAllEmpty",
-         "MinOccurs": 0
-        },
-        {
-         "ElementType": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskUndo"
-        },
-        {
-         "ElementType": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.TaskUnknownRecord"
-        }
-       ],
-       "MinOccurs": 0,
-       "ParticleType": "Choice"
-      },
-      {
-       "ElementType": "DocumentFormat.OpenXml.Microsoft365.PowerPoint.Tasks.ExtensionList",
-       "MinOccurs": 0
-      }
-     ],
-     "ParticleType": "Sequence"
-    }
-   }
-  ]
- },
- {
   "Key": "DocumentFormat.OpenXml.Office.ActiveX.ActiveXControlData",
   "Value": [
    {
@@ -33199,6 +32960,96 @@
   ]
  },
  {
+  "Key": "DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OEmbedShared",
+  "Value": [
+   {
+    "Key": "Microsoft365",
+    "Value": {
+     "ChildrenParticles": [
+      {
+       "ElementType": "DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OfficeArtExtensionList",
+       "MinOccurs": 0
+      }
+     ],
+     "ParticleType": "Sequence"
+    }
+   }
+  ]
+ },
+ {
+  "Key": "DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OfficeArtExtensionList",
+  "Value": [
+   {
+    "Key": "Microsoft365",
+    "Value": {
+     "ChildrenParticles": [
+      {
+       "ChildrenParticles": [
+        {
+         "ChildrenParticles": [
+          {
+           "ElementType": "DocumentFormat.OpenXml.Drawing.Extension",
+           "MaxOccurs": 0,
+           "MinOccurs": 0
+          }
+         ],
+         "ParticleType": "Sequence"
+        }
+       ],
+       "ParticleType": "Group"
+      }
+     ],
+     "ParticleType": "Sequence"
+    }
+   }
+  ]
+ },
+ {
+  "Key": "DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.OfficeArtExtensionList",
+  "Value": [
+   {
+    "Key": "Microsoft365",
+    "Value": {
+     "ChildrenParticles": [
+      {
+       "ChildrenParticles": [
+        {
+         "ChildrenParticles": [
+          {
+           "ElementType": "DocumentFormat.OpenXml.Drawing.Extension",
+           "MaxOccurs": 0,
+           "MinOccurs": 0
+          }
+         ],
+         "ParticleType": "Sequence"
+        }
+       ],
+       "ParticleType": "Group"
+      }
+     ],
+     "ParticleType": "Sequence"
+    }
+   }
+  ]
+ },
+ {
+  "Key": "DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.ScriptLink",
+  "Value": [
+   {
+    "Key": "Microsoft365",
+    "Value": {
+     "ChildrenParticles": [
+      {
+       "ElementType": "DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.OfficeArtExtensionList",
+       "MinOccurs": 0
+      }
+     ],
+     "ParticleType": "Sequence"
+    }
+   }
+  ]
+ },
+ {
   "Key": "DocumentFormat.OpenXml.Office.Excel.ColumnSortMap",
   "Value": [
    {
@@ -33498,6 +33349,155 @@
       {
        "ElementType": "DocumentFormat.OpenXml.Office.LongProperties.LongProperty",
        "MaxOccurs": 0,
+       "MinOccurs": 0
+      }
+     ],
+     "ParticleType": "Sequence"
+    }
+   }
+  ]
+ },
+ {
+  "Key": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList",
+  "Value": [
+   {
+    "Key": "Microsoft365",
+    "Value": {
+     "ChildrenParticles": [
+      {
+       "ChildrenParticles": [
+        {
+         "ChildrenParticles": [
+          {
+           "ElementType": "DocumentFormat.OpenXml.Presentation.Extension",
+           "MaxOccurs": 0,
+           "MinOccurs": 0
+          }
+         ],
+         "ParticleType": "Sequence"
+        }
+       ],
+       "MinOccurs": 0,
+       "ParticleType": "Group"
+      }
+     ],
+     "ParticleType": "Sequence"
+    }
+   }
+  ]
+ },
+ {
+  "Key": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskAnchor",
+  "Value": [
+   {
+    "Key": "Microsoft365",
+    "Value": {
+     "ChildrenParticles": [
+      {
+       "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.CommentAnchor"
+      },
+      {
+       "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList",
+       "MinOccurs": 0
+      }
+     ],
+     "ParticleType": "Sequence"
+    }
+   }
+  ]
+ },
+ {
+  "Key": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistory",
+  "Value": [
+   {
+    "Key": "Microsoft365",
+    "Value": {
+     "ChildrenParticles": [
+      {
+       "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistoryEvent",
+       "MaxOccurs": 0,
+       "MinOccurs": 0
+      }
+     ],
+     "ParticleType": "Sequence"
+    }
+   }
+  ]
+ },
+ {
+  "Key": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistoryDetails",
+  "Value": [
+   {
+    "Key": "Microsoft365",
+    "Value": {
+     "ChildrenParticles": [
+      {
+       "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistory"
+      },
+      {
+       "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList",
+       "MinOccurs": 0
+      }
+     ],
+     "ParticleType": "Sequence"
+    }
+   }
+  ]
+ },
+ {
+  "Key": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistoryEvent",
+  "Value": [
+   {
+    "Key": "Microsoft365",
+    "Value": {
+     "ChildrenParticles": [
+      {
+       "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AtrbtnTaskAssignUnassignUser"
+      },
+      {
+       "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskAnchor",
+       "MinOccurs": 0
+      },
+      {
+       "ChildrenParticles": [
+        {
+         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AsgnTaskAssignUnassignUser"
+        },
+        {
+         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.UnAsgnTaskAssignUnassignUser"
+        },
+        {
+         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AddEmpty",
+         "MinOccurs": 0
+        },
+        {
+         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskTitleEventInfo"
+        },
+        {
+         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskScheduleEventInfo"
+        },
+        {
+         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskProgressEventInfo"
+        },
+        {
+         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskPriorityRecord"
+        },
+        {
+         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.UnasgnAllEmpty",
+         "MinOccurs": 0
+        },
+        {
+         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskUndo"
+        },
+        {
+         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskUnknownRecord"
+        }
+       ],
+       "MinOccurs": 0,
+       "ParticleType": "Choice"
+      },
+      {
+       "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList",
        "MinOccurs": 0
       }
      ],

--- a/test/DocumentFormat.OpenXml.Packaging.Tests/data/Particles.json
+++ b/test/DocumentFormat.OpenXml.Packaging.Tests/data/Particles.json
@@ -1513,10 +1513,10 @@
        "ElementType": "DocumentFormat.OpenXml.Office2019.Drawing.PictureAttributionSourceURL"
       },
       {
-       "ElementType": "DocumentFormat.OpenXml.Office.Word._2020.OEmbed.OEmbed"
+       "ElementType": "DocumentFormat.OpenXml.Office.Word.Y2020.OEmbed.OEmbed"
       },
       {
-       "ElementType": "DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OEmbedShared"
+       "ElementType": "DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OEmbedShared"
       },
       {
        "MinOccurs": 0,
@@ -15414,7 +15414,7 @@
        "ElementType": "DocumentFormat.OpenXml.Office2021.Drawing.DocumentClassification.ClassificationOutcome"
       },
       {
-       "ElementType": "DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.ScriptLink"
+       "ElementType": "DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.ScriptLink"
       },
       {
        "MinOccurs": 0,
@@ -32960,14 +32960,14 @@
   ]
  },
  {
-  "Key": "DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OEmbedShared",
+  "Key": "DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OEmbedShared",
   "Value": [
    {
     "Key": "Microsoft365",
     "Value": {
      "ChildrenParticles": [
       {
-       "ElementType": "DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OfficeArtExtensionList",
+       "ElementType": "DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OfficeArtExtensionList",
        "MinOccurs": 0
       }
      ],
@@ -32977,7 +32977,7 @@
   ]
  },
  {
-  "Key": "DocumentFormat.OpenXml.Office.Drawing._2021.OEmbed.OfficeArtExtensionList",
+  "Key": "DocumentFormat.OpenXml.Office.Drawing.Y2021.OEmbed.OfficeArtExtensionList",
   "Value": [
    {
     "Key": "Microsoft365",
@@ -33005,7 +33005,7 @@
   ]
  },
  {
-  "Key": "DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.OfficeArtExtensionList",
+  "Key": "DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.OfficeArtExtensionList",
   "Value": [
    {
     "Key": "Microsoft365",
@@ -33033,14 +33033,14 @@
   ]
  },
  {
-  "Key": "DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.ScriptLink",
+  "Key": "DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.ScriptLink",
   "Value": [
    {
     "Key": "Microsoft365",
     "Value": {
      "ChildrenParticles": [
       {
-       "ElementType": "DocumentFormat.OpenXml.Office.Drawing._2021.ScriptLink.OfficeArtExtensionList",
+       "ElementType": "DocumentFormat.OpenXml.Office.Drawing.Y2021.ScriptLink.OfficeArtExtensionList",
        "MinOccurs": 0
       }
      ],
@@ -33358,7 +33358,7 @@
   ]
  },
  {
-  "Key": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList",
+  "Key": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList",
   "Value": [
    {
     "Key": "Microsoft365",
@@ -33387,17 +33387,17 @@
   ]
  },
  {
-  "Key": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskAnchor",
+  "Key": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskAnchor",
   "Value": [
    {
     "Key": "Microsoft365",
     "Value": {
      "ChildrenParticles": [
       {
-       "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.CommentAnchor"
+       "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.CommentAnchor"
       },
       {
-       "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList",
+       "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList",
        "MinOccurs": 0
       }
      ],
@@ -33407,14 +33407,14 @@
   ]
  },
  {
-  "Key": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistory",
+  "Key": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistory",
   "Value": [
    {
     "Key": "Microsoft365",
     "Value": {
      "ChildrenParticles": [
       {
-       "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistoryEvent",
+       "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryEvent",
        "MaxOccurs": 0,
        "MinOccurs": 0
       }
@@ -33425,17 +33425,17 @@
   ]
  },
  {
-  "Key": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistoryDetails",
+  "Key": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryDetails",
   "Value": [
    {
     "Key": "Microsoft365",
     "Value": {
      "ChildrenParticles": [
       {
-       "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistory"
+       "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistory"
       },
       {
-       "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList",
+       "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList",
        "MinOccurs": 0
       }
      ],
@@ -33445,59 +33445,59 @@
   ]
  },
  {
-  "Key": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskHistoryEvent",
+  "Key": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskHistoryEvent",
   "Value": [
    {
     "Key": "Microsoft365",
     "Value": {
      "ChildrenParticles": [
       {
-       "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AtrbtnTaskAssignUnassignUser"
+       "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AtrbtnTaskAssignUnassignUser"
       },
       {
-       "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskAnchor",
+       "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskAnchor",
        "MinOccurs": 0
       },
       {
        "ChildrenParticles": [
         {
-         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AsgnTaskAssignUnassignUser"
+         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AsgnTaskAssignUnassignUser"
         },
         {
-         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.UnAsgnTaskAssignUnassignUser"
+         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.UnAsgnTaskAssignUnassignUser"
         },
         {
-         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.AddEmpty",
+         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.AddEmpty",
          "MinOccurs": 0
         },
         {
-         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskTitleEventInfo"
+         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskTitleEventInfo"
         },
         {
-         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskScheduleEventInfo"
+         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskScheduleEventInfo"
         },
         {
-         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskProgressEventInfo"
+         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskProgressEventInfo"
         },
         {
-         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskPriorityRecord"
+         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskPriorityRecord"
         },
         {
-         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.UnasgnAllEmpty",
+         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.UnasgnAllEmpty",
          "MinOccurs": 0
         },
         {
-         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskUndo"
+         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskUndo"
         },
         {
-         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.TaskUnknownRecord"
+         "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.TaskUnknownRecord"
         }
        ],
        "MinOccurs": 0,
        "ParticleType": "Choice"
       },
       {
-       "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint._2021._06.Main.ExtensionList",
+       "ElementType": "DocumentFormat.OpenXml.Office.PowerPoint.Y2021.M06.Main.ExtensionList",
        "MinOccurs": 0
       }
      ],


### PR DESCRIPTION
this update renames the C# namespaces only for the new Microsoft 365 subscription model types and constraints that were just released. 