### PR TITLE
Create separate features for statically typed classes

### DIFF
--- a/gen/DocumentFormat.OpenXml.Generator.Linq/Program.cs
+++ b/gen/DocumentFormat.OpenXml.Generator.Linq/Program.cs
@@ -309,7 +309,7 @@ namespace DocumentFormat.OpenXml.Generator.Linq
             var visitedElementTypes = new HashSet<Type>();
             var elementMetadataCollection = new List<ElementMetadata>();
 
-            foreach (var elementChild in FeatureCollection.Default.GetRequired<IRootElementFactory>().Collection.Elements)
+            foreach (var elementChild in FeatureCollection.StaticOrDefault.GetRequired<IRootElementFactory>().Collection.Elements)
             {
                 AssembleElementMetatata(ElementMetadata.None, elementChild, visitedElementTypes, elementMetadataCollection, fieldInfos);
             }

--- a/src/DocumentFormat.OpenXml/Features/FeatureCollection.cs
+++ b/src/DocumentFormat.OpenXml/Features/FeatureCollection.cs
@@ -113,6 +113,8 @@ namespace DocumentFormat.OpenXml.Features
 
         internal static IFeatureCollection Default => DefaultFeatures.Shared;
 
+        internal static IFeatureCollection StaticOrDefault => StaticTypesFeatures.Shared;
+
         private class EmptyFeatures : IFeatureCollection
         {
             public bool IsReadOnly => true;

--- a/src/DocumentFormat.OpenXml/Features/IElementMetadataFeature.cs
+++ b/src/DocumentFormat.OpenXml/Features/IElementMetadataFeature.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Framework.Metadata;
+
+namespace DocumentFormat.OpenXml.Features
+{
+    internal interface IElementMetadataFeature
+    {
+        public ElementMetadata GetMetadata(OpenXmlElement element);
+    }
+}

--- a/src/DocumentFormat.OpenXml/Features/IElementMetadataFeature.cs
+++ b/src/DocumentFormat.OpenXml/Features/IElementMetadataFeature.cs
@@ -3,10 +3,9 @@
 
 using DocumentFormat.OpenXml.Framework.Metadata;
 
-namespace DocumentFormat.OpenXml.Features
+namespace DocumentFormat.OpenXml.Features;
+
+internal interface IElementMetadataFeature
 {
-    internal interface IElementMetadataFeature
-    {
-        public ElementMetadata GetMetadata(OpenXmlElement element);
-    }
+    public ElementMetadata GetMetadata(OpenXmlElement element);
 }

--- a/src/DocumentFormat.OpenXml/Features/StaticTypesFeatures.cs
+++ b/src/DocumentFormat.OpenXml/Features/StaticTypesFeatures.cs
@@ -5,31 +5,30 @@ using DocumentFormat.OpenXml.Framework;
 using DocumentFormat.OpenXml.Framework.Metadata;
 using System;
 
-namespace DocumentFormat.OpenXml.Features
+namespace DocumentFormat.OpenXml.Features;
+
+internal partial class StaticTypesFeatures : IFeatureCollection
 {
-    internal partial class StaticTypesFeatures : IFeatureCollection
+    public StaticTypesFeatures()
     {
-        public StaticTypesFeatures()
-        {
-        }
+    }
 
-        public static IFeatureCollection Shared { get; } = new StaticTypesFeatures();
+    public static IFeatureCollection Shared { get; } = new StaticTypesFeatures();
 
-        public bool IsReadOnly => true;
+    public bool IsReadOnly => true;
 
-        public int Revision => 0;
+    public int Revision => 0;
 
-        [KnownFeature(typeof(IRootElementFactory), typeof(ReflectionBasedRootElementFactory))]
-        [KnownFeature(typeof(IPartMetadataFeature), typeof(CachedPartMetadataProvider))]
-        [KnownFeature(typeof(IOpenXmlNamespaceResolver), typeof(OpenXmlNamespaceResolver))]
-        [KnownFeature(typeof(IElementMetadataFeature), typeof(ElementMetadataProviderFeature))]
-        [DelegatedFeature(nameof(FeatureCollection.Default), typeof(FeatureCollection))]
-        [ThreadSafe]
-        public partial TFeature? Get<TFeature>();
+    [KnownFeature(typeof(IRootElementFactory), typeof(ReflectionBasedRootElementFactory))]
+    [KnownFeature(typeof(IPartMetadataFeature), typeof(CachedPartMetadataProvider))]
+    [KnownFeature(typeof(IOpenXmlNamespaceResolver), typeof(OpenXmlNamespaceResolver))]
+    [KnownFeature(typeof(IElementMetadataFeature), typeof(ElementMetadataProviderFeature))]
+    [DelegatedFeature(nameof(FeatureCollection.Default), typeof(FeatureCollection))]
+    [ThreadSafe]
+    public partial TFeature? Get<TFeature>();
 
-        public void Set<TFeature>(TFeature? instance)
-        {
-            throw new NotSupportedException();
-        }
+    public void Set<TFeature>(TFeature? instance)
+    {
+        throw new NotSupportedException();
     }
 }

--- a/src/DocumentFormat.OpenXml/Features/StaticTypesFeatures.cs
+++ b/src/DocumentFormat.OpenXml/Features/StaticTypesFeatures.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Framework;
+using DocumentFormat.OpenXml.Framework.Metadata;
+using System;
+
+namespace DocumentFormat.OpenXml.Features
+{
+    internal partial class StaticTypesFeatures : IFeatureCollection
+    {
+        public StaticTypesFeatures()
+        {
+        }
+
+        public static IFeatureCollection Shared { get; } = new StaticTypesFeatures();
+
+        public bool IsReadOnly => true;
+
+        public int Revision => 0;
+
+        [KnownFeature(typeof(IRootElementFactory), typeof(ReflectionBasedRootElementFactory))]
+        [KnownFeature(typeof(IPartMetadataFeature), typeof(CachedPartMetadataProvider))]
+        [KnownFeature(typeof(IOpenXmlNamespaceResolver), typeof(OpenXmlNamespaceResolver))]
+        [KnownFeature(typeof(IElementMetadataFeature), typeof(ElementMetadataProviderFeature))]
+        [DelegatedFeature(nameof(FeatureCollection.Default), typeof(FeatureCollection))]
+        [ThreadSafe]
+        public partial TFeature? Get<TFeature>();
+
+        public void Set<TFeature>(TFeature? instance)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/DocumentFormat.OpenXml/Framework/Metadata/ElementMetadataProviderFeature.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Metadata/ElementMetadataProviderFeature.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using DocumentFormat.OpenXml.Features;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace DocumentFormat.OpenXml.Framework.Metadata
 {
-    internal class ElementMetadataProviderFeature
+    internal class ElementMetadataProviderFeature : IElementMetadataFeature
     {
         private readonly ConcurrentDictionary<Type, ElementMetadata> _lookup = new(new[]
         {

--- a/src/DocumentFormat.OpenXml/Framework/OpenXmlNamespace.cs
+++ b/src/DocumentFormat.OpenXml/Framework/OpenXmlNamespace.cs
@@ -13,8 +13,8 @@ namespace DocumentFormat.OpenXml.Framework
 
         internal OpenXmlNamespace(byte nsId)
         {
-            _prefix = FeatureCollection.Default.GetRequired<IOpenXmlNamespaceIdResolver>().GetPrefix(nsId);
-            _uri = FeatureCollection.Default.GetRequired<IOpenXmlNamespaceResolver>().LookupNamespace(_prefix);
+            _prefix = FeatureCollection.StaticOrDefault.GetRequired<IOpenXmlNamespaceIdResolver>().GetPrefix(nsId);
+            _uri = FeatureCollection.StaticOrDefault.GetRequired<IOpenXmlNamespaceResolver>().LookupNamespace(_prefix);
         }
 
         public OpenXmlNamespace(string? nsUri, string? prefix = null)
@@ -31,7 +31,7 @@ namespace DocumentFormat.OpenXml.Framework
 
         public bool IsEmpty => string.IsNullOrEmpty(Uri);
 
-        public FileFormatVersions Version => FeatureCollection.Default.GetRequired<IOpenXmlNamespaceResolver>().GetVersion(this);
+        public FileFormatVersions Version => FeatureCollection.StaticOrDefault.GetRequired<IOpenXmlNamespaceResolver>().GetVersion(this);
 
         public bool HasVersion(FileFormatVersions version) => Version == version;
 
@@ -40,21 +40,21 @@ namespace DocumentFormat.OpenXml.Framework
         /// </summary>
         /// <param name="transitionalNamespace">An equivalent namespace in Transitional.</param>
         /// <returns>Returns true when a Transitional equivalent namespace is found, returns false when it is not found.</returns>
-        public bool TryGetTransitionalNamespace(out OpenXmlNamespace transitionalNamespace) => FeatureCollection.Default.GetRequired<IOpenXmlNamespaceResolver>().TryGetTransitionalNamespace(this, out transitionalNamespace);
+        public bool TryGetTransitionalNamespace(out OpenXmlNamespace transitionalNamespace) => FeatureCollection.StaticOrDefault.GetRequired<IOpenXmlNamespaceResolver>().TryGetTransitionalNamespace(this, out transitionalNamespace);
 
         /// <summary>
         /// Attempts to get the Transitional equivalent relationship.
         /// </summary>
         /// <param name="transitionalRelationship">An equivalent relationship in Transitional.</param>
         /// <returns>Returns true when a Transitional equivalent relationship is found, returns false when it is not.</returns>
-        public bool TryGetTransitionalRelationship(out OpenXmlNamespace transitionalRelationship) => FeatureCollection.Default.GetRequired<IOpenXmlNamespaceResolver>().TryGetTransitionalRelationship(this, out transitionalRelationship);
+        public bool TryGetTransitionalRelationship(out OpenXmlNamespace transitionalRelationship) => FeatureCollection.StaticOrDefault.GetRequired<IOpenXmlNamespaceResolver>().TryGetTransitionalRelationship(this, out transitionalRelationship);
 
         /// <summary>
         /// Try to get the expected namespace if the passed namespace is an obsolete.
         /// </summary>
         /// <param name="extNamespaceUri">The expected namespace when the passed namespace is an obsolete.</param>
         /// <returns>True when the passed namespace is an obsolete and the expected namespace found</returns>
-        public bool TryGetExtendedNamespace(out OpenXmlNamespace extNamespaceUri) => FeatureCollection.Default.GetRequired<IOpenXmlNamespaceResolver>().TryGetExtendedNamespace(this, out extNamespaceUri);
+        public bool TryGetExtendedNamespace(out OpenXmlNamespace extNamespaceUri) => FeatureCollection.StaticOrDefault.GetRequired<IOpenXmlNamespaceResolver>().TryGetExtendedNamespace(this, out extNamespaceUri);
 
         public override bool Equals(object? obj) => obj is OpenXmlNamespace ns && Equals(ns);
 
@@ -82,13 +82,13 @@ namespace DocumentFormat.OpenXml.Framework
         /// </summary>
         /// <param name="prefix">The namespace prefix.</param>
         /// <returns></returns>
-        public static string? GetNamespaceUri(string prefix) => FeatureCollection.Default.GetRequired<IOpenXmlNamespaceResolver>().LookupNamespace(prefix);
+        public static string? GetNamespaceUri(string prefix) => FeatureCollection.StaticOrDefault.GetRequired<IOpenXmlNamespaceResolver>().LookupNamespace(prefix);
 
         /// <summary>
         /// Gets the default namespace prefix for the specified namespace URI.
         /// </summary>
         /// <param name="namespaceUri">The namespace URI.</param>
         /// <returns>The default namespace prefix.</returns>
-        public static string? GetNamespacePrefix(string namespaceUri) => FeatureCollection.Default.GetRequired<IOpenXmlNamespaceResolver>().LookupPrefix(namespaceUri);
+        public static string? GetNamespacePrefix(string namespaceUri) => FeatureCollection.StaticOrDefault.GetRequired<IOpenXmlNamespaceResolver>().LookupPrefix(namespaceUri);
     }
 }

--- a/src/DocumentFormat.OpenXml/OpenXmlElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlElement.cs
@@ -2608,7 +2608,7 @@ namespace DocumentFormat.OpenXml
             [KnownFeature(typeof(AnnotationsFeature))]
             [KnownFeature(typeof(ElementMetadata), Factory = nameof(CreateMetadata))]
             [DelegatedFeature(nameof(GetPartFeatures))]
-            [DelegatedFeature(nameof(FeatureCollection.Default), typeof(FeatureCollection))]
+            [DelegatedFeature(nameof(FeatureCollection.StaticOrDefault), typeof(FeatureCollection))]
             public partial TFeature? Get<TFeature>();
 
             public IFeatureCollection? GetPartFeatures() => _owner.GetPart()?.Features;

--- a/src/DocumentFormat.OpenXml/OpenXmlPartReader.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlPartReader.cs
@@ -20,8 +20,7 @@ namespace DocumentFormat.OpenXml
     /// </summary>
     public class OpenXmlPartReader : OpenXmlReader
     {
-        private static readonly IRootElementFactory _factory = FeatureCollection.Default.GetRequired<IRootElementFactory>();
-
+        private readonly IRootElementFactory _factory;
         private readonly XmlReader _xmlReader;
         private readonly List<OpenXmlAttribute> _attributeList = new List<OpenXmlAttribute>();
         private readonly List<KeyValuePair<string, string>> _nsDecls = new List<KeyValuePair<string, string>>();
@@ -48,6 +47,7 @@ namespace DocumentFormat.OpenXml
             }
 
             _xmlReader = CreateReader(openXmlPart.GetStream(FileMode.Open), true, openXmlPart.MaxCharactersInPart, ignoreWhitespace: true, out _standalone, out _encoding);
+            _factory = openXmlPart.Features.GetRequired<IRootElementFactory>();
         }
 
         /// <summary>
@@ -64,6 +64,7 @@ namespace DocumentFormat.OpenXml
             }
 
             _xmlReader = CreateReader(openXmlPart.GetStream(FileMode.Open), true, openXmlPart.MaxCharactersInPart, ignoreWhitespace: true, out _standalone, out _encoding);
+            _factory = openXmlPart.Features.GetRequired<IRootElementFactory>();
         }
 
         /// <summary>
@@ -81,6 +82,7 @@ namespace DocumentFormat.OpenXml
             }
 
             _xmlReader = CreateReader(openXmlPart.GetStream(FileMode.Open), true, openXmlPart.MaxCharactersInPart, ignoreWhitespace, out _standalone, out _encoding);
+            _factory = openXmlPart.Features.GetRequired<IRootElementFactory>();
         }
 
         /// <summary>
@@ -96,6 +98,7 @@ namespace DocumentFormat.OpenXml
             }
 
             _xmlReader = CreateReader(partStream, false, 0, ignoreWhitespace: true, out _standalone, out _encoding);
+            _factory = GetDefaultFactory();
         }
 
         /// <summary>
@@ -112,6 +115,7 @@ namespace DocumentFormat.OpenXml
             }
 
             _xmlReader = CreateReader(partStream, false, 0, ignoreWhitespace: true, out _standalone, out _encoding);
+            _factory = GetDefaultFactory();
         }
 
         /// <summary>
@@ -129,7 +133,10 @@ namespace DocumentFormat.OpenXml
             }
 
             _xmlReader = CreateReader(partStream, false, 0, ignoreWhitespace, out _standalone, out _encoding);
+            _factory = GetDefaultFactory();
         }
+
+        private static IRootElementFactory GetDefaultFactory() => StaticTypesFeatures.Shared.GetRequired<IRootElementFactory>();
 
         /// <summary>
         /// Gets the encoding of the XML file.

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPart.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPart.cs
@@ -792,7 +792,17 @@ namespace DocumentFormat.OpenXml.Packaging
             {
                 if (_features is null)
                 {
-                    _features = new FeatureCollection(new PartContainerFeatureCollection(_openXmlPackage?.Features));
+                    if (_openXmlPackage is { } package)
+                    {
+                        _features = _openXmlPackage.CreatePartFeatures(_openXmlPackage.Features);
+                    }
+                    else
+                    {
+                        _features = CreatePartFeatures();
+                    }
+
+                    // Make writeable
+                    _features = new FeatureCollection(_features);
                 }
 
                 return _features;

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPartContainer.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPartContainer.cs
@@ -1942,29 +1942,33 @@ namespace DocumentFormat.OpenXml.Packaging
             {
                 if (_features is null)
                 {
-                    _features = new FeatureCollection(new PartContainerFeatureCollection());
+                    _features = new FeatureCollection(CreatePartFeatures());
                 }
 
                 return _features;
             }
         }
 
-        private protected sealed partial class PartContainerFeatureCollection : IFeatureCollection
+        internal virtual IFeatureCollection CreatePartFeatures(IFeatureCollection? other = null) => new PartContainerFeatureCollection(FeatureCollection.Default, other);
+
+        internal sealed partial class PartContainerFeatureCollection : IFeatureCollection
         {
             private readonly IFeatureCollection? _other;
+            private readonly IFeatureCollection _defaultCollection;
 
             public bool IsReadOnly => true;
 
             public int Revision => 0;
 
-            public PartContainerFeatureCollection(IFeatureCollection? other = null)
+            public PartContainerFeatureCollection(IFeatureCollection defaultCollection, IFeatureCollection? other = null)
             {
                 _other = other;
+                _defaultCollection = defaultCollection;
             }
 
             [KnownFeature(typeof(AnnotationsFeature))]
             [DelegatedFeature(nameof(_other))]
-            [DelegatedFeature(nameof(FeatureCollection.Default), typeof(FeatureCollection))]
+            [DelegatedFeature(nameof(_defaultCollection))]
             public partial TFeature? Get<TFeature>();
 
             public void Set<TFeature>(TFeature? instance)

--- a/src/DocumentFormat.OpenXml/Packaging/PresentationDocument.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/PresentationDocument.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using DocumentFormat.OpenXml.Features;
 using DocumentFormat.OpenXml.Framework;
 using System;
 using System.Collections.Generic;
@@ -782,5 +783,7 @@ namespace DocumentFormat.OpenXml.Packaging
         #endregion Package-based cloning
 
         #endregion cloning
+
+        internal override IFeatureCollection CreatePartFeatures(IFeatureCollection? other) => new PartContainerFeatureCollection(StaticTypesFeatures.Shared, other);
     }
 }

--- a/src/DocumentFormat.OpenXml/Packaging/SpreadsheetDocument.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/SpreadsheetDocument.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using DocumentFormat.OpenXml.Features;
 using DocumentFormat.OpenXml.Framework;
 using System;
 using System.Collections.Generic;
@@ -782,5 +783,7 @@ namespace DocumentFormat.OpenXml.Packaging
         #endregion Package-based cloning
 
         #endregion cloning
+
+        internal override IFeatureCollection CreatePartFeatures(IFeatureCollection? other) => new PartContainerFeatureCollection(StaticTypesFeatures.Shared, other);
     }
 }

--- a/src/DocumentFormat.OpenXml/Packaging/WordprocessingDocument.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/WordprocessingDocument.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using DocumentFormat.OpenXml.Features;
 using DocumentFormat.OpenXml.Framework;
 using DocumentFormat.OpenXml.Wordprocessing;
 using System;
@@ -822,5 +823,7 @@ namespace DocumentFormat.OpenXml.Packaging
         #endregion Package-based cloning
 
         #endregion cloning
+
+        internal override IFeatureCollection CreatePartFeatures(IFeatureCollection? other) => new PartContainerFeatureCollection(StaticTypesFeatures.Shared, other);
     }
 }


### PR DESCRIPTION
This is an initial attempt at separating out the infrastructure for
statically typed classes from the framework. This updates things to
start explicitly depending on the generated classes if they are needed.
Over time, we should be able to separate out the generated classes into
their own assembly and keep a "framework" of OpenXml related
functionality.
