### PR TITLE
Remove prefix property

### DIFF
--- a/gen/DocumentFormat.OpenXml.Generator.Linq/Program.cs
+++ b/gen/DocumentFormat.OpenXml.Generator.Linq/Program.cs
@@ -421,7 +421,7 @@ namespace DocumentFormat.OpenXml.Generator.Linq
             /// <summary>
             /// Gets the XML prefix, e.g., "w".
             /// </summary>
-            public string Prefix => QName.Namespace.Prefix;
+            public string Prefix => TypedFeatures.Shared.GetNamespaceResolver().LookupPrefix(QName.Namespace.Uri) ?? string.Empty;
 
             /// <summary>
             /// Gets the XML namespace name, e.g., "http://schemas.openxmlformats.org/wordprocessingml/2006/main".
@@ -483,7 +483,7 @@ namespace DocumentFormat.OpenXml.Generator.Linq
 
             private static string GetQualifiedName(OpenXmlQualifiedName qName)
             {
-                string prefix = qName.Namespace.Prefix;
+                string prefix = TypedFeatures.Shared.GetNamespaceResolver().LookupPrefix(qName.Namespace.Uri) ?? string.Empty;
                 return string.IsNullOrEmpty(prefix) ? qName.Name : prefix + ":" + qName.Name;
             }
 

--- a/src/DocumentFormat.OpenXml/AlternateContent.cs
+++ b/src/DocumentFormat.OpenXml/AlternateContent.cs
@@ -16,7 +16,7 @@ namespace DocumentFormat.OpenXml
     /// </summary>
     public class AlternateContent : OpenXmlCompositeElement
     {
-        internal static readonly OpenXmlQualifiedName InternalQName = FeatureCollection.TypedOrDefault.GetNamespaceResolver().CreateQName(@"http://schemas.openxmlformats.org/markup-compatibility/2006", "AlternateContent");
+        internal static readonly OpenXmlQualifiedName InternalQName = new(@"http://schemas.openxmlformats.org/markup-compatibility/2006", "AlternateContent");
 
         /// <summary>
         /// Initializes a new instance of the AlternateContent

--- a/src/DocumentFormat.OpenXml/Features/OpenXmlNamespaceResolver.cs
+++ b/src/DocumentFormat.OpenXml/Features/OpenXmlNamespaceResolver.cs
@@ -5,207 +5,193 @@ using DocumentFormat.OpenXml.Framework;
 using System.Collections.Generic;
 using System.Xml;
 
-namespace DocumentFormat.OpenXml.Features
+namespace DocumentFormat.OpenXml.Features;
+
+internal partial class OpenXmlNamespaceResolver : IOpenXmlNamespaceResolver
 {
-    internal partial class OpenXmlNamespaceResolver : IOpenXmlNamespaceResolver
+    // The namespaces listed here are somewhat obsolete ones that we need to support. Before we try to get the index of a namespace,
+    // we check if it's in this list to rename to the expected correct namespace.
+    private readonly Dictionary<OpenXmlNamespace, OpenXmlNamespace> _extendedNamespaces;
+
+    // This dictionary contains the Strict and Transitional namespaces pairs to be interpreted equivalent.
+    private readonly Dictionary<OpenXmlNamespace, OpenXmlNamespace> _strictTransitionalNamespaces;
+
+    // This dictionary contains the Strict and Transitional relationship pairs to be interpreted equivalent.
+    private readonly Dictionary<OpenXmlNamespace, OpenXmlNamespace> _strictTransitionalRelationshipPairs;
+
+    public OpenXmlNamespaceResolver()
     {
-        // The namespaces listed here are somewhat obsolete ones that we need to support. Before we try to get the index of a namespace,
-        // we check if it's in this list to rename to the expected correct namespace.
-        private readonly Dictionary<OpenXmlNamespace, OpenXmlNamespace> _extendedNamespaces;
-
-        // This dictionary contains the Strict and Transitional namespaces pairs to be interpreted equivalent.
-        private readonly Dictionary<OpenXmlNamespace, OpenXmlNamespace> _strictTransitionalNamespaces;
-
-        // This dictionary contains the Strict and Transitional relationship pairs to be interpreted equivalent.
-        private readonly Dictionary<OpenXmlNamespace, OpenXmlNamespace> _strictTransitionalRelationshipPairs;
-
-        public OpenXmlNamespaceResolver()
+        _extendedNamespaces = new()
         {
-            _extendedNamespaces = new NamespaceDictionary(this)
-            {
-                { "http://schemas.openxmlformats.org/wordprocessingml/2006/3/main", "http://schemas.openxmlformats.org/wordprocessingml/2006/main" },
-                { "http://schemas.openxmlformats.org/wordprocessingml/2006/5/main", "http://schemas.openxmlformats.org/wordprocessingml/2006/main" },
-                { "http://schemas.openxmlformats.org/wordprocessingml/2006/6/main", "http://schemas.openxmlformats.org/wordprocessingml/2006/main" },
-                { "http://schemas.openxmlformats.org/spreadsheetml/2006/5/main", "http://schemas.openxmlformats.org/spreadsheetml/2006/main" },
-                { "http://schemas.openxmlformats.org/spreadsheetml/2006/7/main", "http://schemas.openxmlformats.org/spreadsheetml/2006/main" },
-                { "http://schemas.openxmlformats.org/presentationml/2006/3/main", "http://schemas.openxmlformats.org/presentationml/2006/main" },
-                { "http://schemas.openxmlformats.org/drawingml/2006/3/main", "http://schemas.openxmlformats.org/drawingml/2006/main" },
-                { "http://schemas.microsoft.com/office/word/2010/11/wordml", "http://schemas.microsoft.com/office/word/2012/wordml" },
-            };
+            { "http://schemas.openxmlformats.org/wordprocessingml/2006/3/main", "http://schemas.openxmlformats.org/wordprocessingml/2006/main" },
+            { "http://schemas.openxmlformats.org/wordprocessingml/2006/5/main", "http://schemas.openxmlformats.org/wordprocessingml/2006/main" },
+            { "http://schemas.openxmlformats.org/wordprocessingml/2006/6/main", "http://schemas.openxmlformats.org/wordprocessingml/2006/main" },
+            { "http://schemas.openxmlformats.org/spreadsheetml/2006/5/main", "http://schemas.openxmlformats.org/spreadsheetml/2006/main" },
+            { "http://schemas.openxmlformats.org/spreadsheetml/2006/7/main", "http://schemas.openxmlformats.org/spreadsheetml/2006/main" },
+            { "http://schemas.openxmlformats.org/presentationml/2006/3/main", "http://schemas.openxmlformats.org/presentationml/2006/main" },
+            { "http://schemas.openxmlformats.org/drawingml/2006/3/main", "http://schemas.openxmlformats.org/drawingml/2006/main" },
+            { "http://schemas.microsoft.com/office/word/2010/11/wordml", "http://schemas.microsoft.com/office/word/2012/wordml" },
+        };
 
-            _strictTransitionalNamespaces = new NamespaceDictionary(this)
-            {
-                // Namespaces
-                { "http://purl.oclc.org/ooxml/descriptions/base", "http://descriptions.openxmlformats.org/description/base" },
-                { "http://purl.oclc.org/ooxml/descriptions/full", "http://descriptions.openxmlformats.org/description/full" },
-                { "http://purl.oclc.org/ooxml/drawingml/chart", "http://schemas.openxmlformats.org/drawingml/2006/chart" },
-                { "http://purl.oclc.org/ooxml/drawingml/chartDrawing", "http://schemas.openxmlformats.org/drawingml/2006/chartDrawing" },
-                { "http://purl.oclc.org/ooxml/drawingml/diagram", "http://schemas.openxmlformats.org/drawingml/2006/diagram" },
-                { "http://purl.oclc.org/ooxml/drawingml/main", "http://schemas.openxmlformats.org/drawingml/2006/main" },
-                { "http://purl.oclc.org/ooxml/drawingml/picture", "http://schemas.openxmlformats.org/drawingml/2006/picture" },
-                { "http://purl.oclc.org/ooxml/drawingml/spreadsheetDrawing", "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" },
-                { "http://purl.oclc.org/ooxml/drawingml/wordprocessingDrawing", "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" },
-                { "http://purl.oclc.org/ooxml/officeDocument/bibliography", "http://schemas.openxmlformats.org/officeDocument/2006/bibliography" },
-                { "http://purl.oclc.org/ooxml/officeDocument/customProperties", "http://schemas.openxmlformats.org/officeDocument/2006/custom-properties" },
-                { "http://purl.oclc.org/ooxml/officeDocument/customXml", "http://schemas.openxmlformats.org/officeDocument/2006/customXml" },
-                { "http://purl.oclc.org/ooxml/officeDocument/customXmlDataProps", "http://schemas.openxmlformats.org/officeDocument/2006/customXmlDataProps" },
-                { "http://purl.oclc.org/ooxml/officeDocument/docPropsVTypes", "http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes" },
-                { "http://purl.oclc.org/ooxml/officeDocument/extendedProperties", "http://schemas.openxmlformats.org/officeDocument/2006/extended-properties" },
-                { "http://purl.oclc.org/ooxml/officeDocument/math", "http://schemas.openxmlformats.org/officeDocument/2006/math" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships", "http://schemas.openxmlformats.org/officeDocument/2006/relationships" },
-                { "http://purl.oclc.org/ooxml/presentationml/main", "http://schemas.openxmlformats.org/presentationml/2006/main" },
-                { "http://purl.oclc.org/ooxml/schemaLibrary/main", "http://schemas.openxmlformats.org/schemaLibrary/2006/main" },
-                { "http://purl.oclc.org/ooxml/spreadsheetml/main", "http://schemas.openxmlformats.org/spreadsheetml/2006/main" },
-                { "http://purl.oclc.org/ooxml/wordprocessingml/main", "http://schemas.openxmlformats.org/wordprocessingml/2006/main" },
-                { "http://purl.org/dc/dcmitype/", "http://purl.org/dc/dcmitype/" },
-                { "http://purl.org/dc/elements/1.1/", "http://purl.org/dc/elements/1.1/" },
-                { "http://purl.org/dc/terms/", "http://purl.org/dc/terms/" },
-                { "http://www.w3.org/2001/XMLSchema", "http://www.w3.org/2001/XMLSchema" },
-                { "http://www.w3.org/2001/XMLSchema-instance", "http://www.w3.org/2001/XMLSchema-instance" },
-                { "http://purl.oclc.org/ooxml/drawingml/lockedCanvas", "http://schemas.openxmlformats.org/drawingml/2006/lockedCanvas" },
-                { "http://purl.oclc.org/ooxml/drawingml/compatibility", "http://schemas.openxmlformats.org/drawingml/2006/compatibility" },
-                { "http://purl.oclc.org/ooxml/officeDocument/sharedTypes", "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes" },
+        _strictTransitionalNamespaces = new()
+        {
+            // Namespaces
+            { "http://purl.oclc.org/ooxml/descriptions/base", "http://descriptions.openxmlformats.org/description/base" },
+            { "http://purl.oclc.org/ooxml/descriptions/full", "http://descriptions.openxmlformats.org/description/full" },
+            { "http://purl.oclc.org/ooxml/drawingml/chart", "http://schemas.openxmlformats.org/drawingml/2006/chart" },
+            { "http://purl.oclc.org/ooxml/drawingml/chartDrawing", "http://schemas.openxmlformats.org/drawingml/2006/chartDrawing" },
+            { "http://purl.oclc.org/ooxml/drawingml/diagram", "http://schemas.openxmlformats.org/drawingml/2006/diagram" },
+            { "http://purl.oclc.org/ooxml/drawingml/main", "http://schemas.openxmlformats.org/drawingml/2006/main" },
+            { "http://purl.oclc.org/ooxml/drawingml/picture", "http://schemas.openxmlformats.org/drawingml/2006/picture" },
+            { "http://purl.oclc.org/ooxml/drawingml/spreadsheetDrawing", "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" },
+            { "http://purl.oclc.org/ooxml/drawingml/wordprocessingDrawing", "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" },
+            { "http://purl.oclc.org/ooxml/officeDocument/bibliography", "http://schemas.openxmlformats.org/officeDocument/2006/bibliography" },
+            { "http://purl.oclc.org/ooxml/officeDocument/customProperties", "http://schemas.openxmlformats.org/officeDocument/2006/custom-properties" },
+            { "http://purl.oclc.org/ooxml/officeDocument/customXml", "http://schemas.openxmlformats.org/officeDocument/2006/customXml" },
+            { "http://purl.oclc.org/ooxml/officeDocument/customXmlDataProps", "http://schemas.openxmlformats.org/officeDocument/2006/customXmlDataProps" },
+            { "http://purl.oclc.org/ooxml/officeDocument/docPropsVTypes", "http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes" },
+            { "http://purl.oclc.org/ooxml/officeDocument/extendedProperties", "http://schemas.openxmlformats.org/officeDocument/2006/extended-properties" },
+            { "http://purl.oclc.org/ooxml/officeDocument/math", "http://schemas.openxmlformats.org/officeDocument/2006/math" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships", "http://schemas.openxmlformats.org/officeDocument/2006/relationships" },
+            { "http://purl.oclc.org/ooxml/presentationml/main", "http://schemas.openxmlformats.org/presentationml/2006/main" },
+            { "http://purl.oclc.org/ooxml/schemaLibrary/main", "http://schemas.openxmlformats.org/schemaLibrary/2006/main" },
+            { "http://purl.oclc.org/ooxml/spreadsheetml/main", "http://schemas.openxmlformats.org/spreadsheetml/2006/main" },
+            { "http://purl.oclc.org/ooxml/wordprocessingml/main", "http://schemas.openxmlformats.org/wordprocessingml/2006/main" },
+            { "http://purl.org/dc/dcmitype/", "http://purl.org/dc/dcmitype/" },
+            { "http://purl.org/dc/elements/1.1/", "http://purl.org/dc/elements/1.1/" },
+            { "http://purl.org/dc/terms/", "http://purl.org/dc/terms/" },
+            { "http://www.w3.org/2001/XMLSchema", "http://www.w3.org/2001/XMLSchema" },
+            { "http://www.w3.org/2001/XMLSchema-instance", "http://www.w3.org/2001/XMLSchema-instance" },
+            { "http://purl.oclc.org/ooxml/drawingml/lockedCanvas", "http://schemas.openxmlformats.org/drawingml/2006/lockedCanvas" },
+            { "http://purl.oclc.org/ooxml/drawingml/compatibility", "http://schemas.openxmlformats.org/drawingml/2006/compatibility" },
+            { "http://purl.oclc.org/ooxml/officeDocument/sharedTypes", "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes" },
 
-                // This is a namespace conversion. Workaround for a bug in ISO spec. https://www.assembla.com/code/IS29500/subversion/changesets/160
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/customXml", "http://schemas.openxmlformats.org/officeDocument/2006/customXml" },
-            };
+            // This is a namespace conversion. Workaround for a bug in ISO spec. https://www.assembla.com/code/IS29500/subversion/changesets/160
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/customXml", "http://schemas.openxmlformats.org/officeDocument/2006/customXml" },
+        };
 
-            _strictTransitionalRelationshipPairs = new NamespaceDictionary(this)
-            {
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/aFChunk", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/aFChunk" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/attachedTemplate", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/attachedTemplate" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/audio", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/audio" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/calcChain", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/calcChain" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/chart", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/chartsheet", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chartsheet" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/chartUserShapes", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chartUserShapes" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/commentAuthors", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/commentAuthors" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/comments", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/connections", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/connections" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/control", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/control" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/customProperties", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/custom-properties" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/customProperty", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/customProperty" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/customXml", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/customXml" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/customXmlProps", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/customXmlProps" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/diagramColors", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/diagramColors" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/diagramData", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/diagramData" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/diagramLayout", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/diagramLayout" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/diagramQuickStyle", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/diagramQuickStyle" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/dialogsheet", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/dialogsheet" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/drawing", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/endnotes", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/endnotes" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/extendedProperties", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/externalLink", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/externalLink" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/externalLinkPath", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/externalLinkPath" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/font", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/font" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/fontTable", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/fontTable" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/footer", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/footnotes", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/frame", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/frame" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/glossaryDocument", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/glossaryDocument" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/handoutMaster", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/handoutMaster" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/header", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/header" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/htmlPubSaveAs", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/htmlPubSaveAs" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/hyperlink", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/image", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/mailMergeHeaderSource", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/mailMergeHeaderSource" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/mailMergeRecipientData", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/mailMergeRecipientData" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/mailMergeSource", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/mailMergeSource" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/metadata/thumbnail", "http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/movie", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/movie" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/notesMaster", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesMaster" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/notesSlide", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesSlide" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/numbering", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/officeDocument", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/oleObject", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/oleObject" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/package", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/package" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/pivotCacheDefinition", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/pivotCacheRecords", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/pivotTable", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/presProps", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/presProps" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/printerSettings", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/printerSettings" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/queryTable", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/queryTable" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/revisionHeaders", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/revisionHeaders" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/revisionLog", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/revisionLog" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/settings", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/settings" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/sharedStrings", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/sheetMetadata", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/slide", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/slideLayout", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/slideMaster", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/slideUpdateInfo", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideUpdateInfo" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/slideUpdateUrl", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideUpdateUrl" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/styles", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/subDocument", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/subDocument" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/table", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/table" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/tableSingleCells", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/tableSingleCells" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/tableStyles", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/tableStyles" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/tags", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/tags" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/theme", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/themeOverride", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/themeOverride" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/transform", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/transform" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/usernames", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/usernames" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/video", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/video" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/viewProps", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/viewProps" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/volatileDependencies", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/volatileDependencies" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/webSettings", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/webSettings" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/worksheet", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" },
-                { "http://purl.oclc.org/ooxml/officeDocument/relationships/xmlMaps", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/xmlMaps" },
-            };
+        _strictTransitionalRelationshipPairs = new()
+        {
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/aFChunk", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/aFChunk" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/attachedTemplate", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/attachedTemplate" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/audio", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/audio" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/calcChain", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/calcChain" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/chart", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/chartsheet", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chartsheet" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/chartUserShapes", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chartUserShapes" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/commentAuthors", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/commentAuthors" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/comments", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/connections", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/connections" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/control", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/control" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/customProperties", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/custom-properties" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/customProperty", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/customProperty" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/customXml", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/customXml" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/customXmlProps", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/customXmlProps" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/diagramColors", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/diagramColors" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/diagramData", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/diagramData" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/diagramLayout", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/diagramLayout" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/diagramQuickStyle", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/diagramQuickStyle" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/dialogsheet", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/dialogsheet" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/drawing", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/endnotes", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/endnotes" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/extendedProperties", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/externalLink", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/externalLink" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/externalLinkPath", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/externalLinkPath" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/font", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/font" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/fontTable", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/fontTable" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/footer", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/footnotes", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/frame", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/frame" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/glossaryDocument", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/glossaryDocument" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/handoutMaster", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/handoutMaster" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/header", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/header" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/htmlPubSaveAs", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/htmlPubSaveAs" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/hyperlink", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/image", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/mailMergeHeaderSource", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/mailMergeHeaderSource" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/mailMergeRecipientData", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/mailMergeRecipientData" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/mailMergeSource", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/mailMergeSource" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/metadata/thumbnail", "http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/movie", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/movie" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/notesMaster", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesMaster" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/notesSlide", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesSlide" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/numbering", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/officeDocument", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/oleObject", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/oleObject" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/package", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/package" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/pivotCacheDefinition", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/pivotCacheRecords", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/pivotTable", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/presProps", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/presProps" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/printerSettings", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/printerSettings" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/queryTable", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/queryTable" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/revisionHeaders", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/revisionHeaders" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/revisionLog", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/revisionLog" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/settings", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/settings" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/sharedStrings", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/sheetMetadata", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/slide", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/slideLayout", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/slideMaster", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/slideUpdateInfo", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideUpdateInfo" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/slideUpdateUrl", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideUpdateUrl" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/styles", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/subDocument", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/subDocument" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/table", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/table" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/tableSingleCells", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/tableSingleCells" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/tableStyles", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/tableStyles" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/tags", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/tags" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/theme", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/themeOverride", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/themeOverride" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/transform", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/transform" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/usernames", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/usernames" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/video", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/video" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/viewProps", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/viewProps" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/volatileDependencies", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/volatileDependencies" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/webSettings", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/webSettings" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/worksheet", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" },
+            { "http://purl.oclc.org/ooxml/officeDocument/relationships/xmlMaps", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/xmlMaps" },
+        };
+    }
+
+    private string NormalizeNamespace(in OpenXmlNamespace ns)
+    {
+        if (TryGetExtendedNamespace(ns, out var result))
+        {
+            return result.Uri;
         }
 
-        private string NormalizeNamespace(in OpenXmlNamespace ns)
-        {
-            if (TryGetExtendedNamespace(ns, out var result))
-            {
-                return result.Uri;
-            }
+        return ns.Uri;
+    }
 
-            return ns.Uri;
+    public IDictionary<string, string> GetNamespacesInScope(XmlNamespaceScope scope) => _urlToPrefix;
+
+    public string? LookupNamespace(string prefix) => _prefixToUrl.TryGetValue(prefix, out var result) ? result : null;
+
+    public string? LookupPrefix(string namespaceName) => _urlToPrefix.TryGetValue(namespaceName, out var result) ? result : null;
+
+    /// <inheritdoc />
+    public bool TryGetTransitionalNamespace(OpenXmlNamespace ns, out OpenXmlNamespace transitionalNamespace)
+        => _strictTransitionalNamespaces.TryGetValue(ns, out transitionalNamespace);
+
+    /// <inheritdoc />
+    public bool TryGetTransitionalRelationship(OpenXmlNamespace ns, out OpenXmlNamespace transitionalRelationship)
+        => _strictTransitionalRelationshipPairs.TryGetValue(ns, out transitionalRelationship);
+
+    /// <inheritdoc />
+    public bool TryGetExtendedNamespace(OpenXmlNamespace ns, out OpenXmlNamespace extNamespaceUri)
+        => _extendedNamespaces.TryGetValue(ns, out extNamespaceUri);
+
+    /// <inheritdoc />
+    public FileFormatVersions GetVersion(OpenXmlNamespace ns)
+    {
+        var normalized = NormalizeNamespace(ns);
+
+        if (_urlToPrefix.TryGetValue(normalized, out var prefix) && _prefixToVersion.TryGetValue(prefix, out var version))
+        {
+            return version;
         }
 
-        public IDictionary<string, string> GetNamespacesInScope(XmlNamespaceScope scope) => _urlToPrefix;
-
-        public string? LookupNamespace(string prefix) => _prefixToUrl.TryGetValue(prefix, out var result) ? result : null;
-
-        public string? LookupPrefix(string namespaceName) => _urlToPrefix.TryGetValue(namespaceName, out var result) ? result : null;
-
-        /// <inheritdoc />
-        public bool TryGetTransitionalNamespace(OpenXmlNamespace ns, out OpenXmlNamespace transitionalNamespace)
-            => _strictTransitionalNamespaces.TryGetValue(ns, out transitionalNamespace);
-
-        /// <inheritdoc />
-        public bool TryGetTransitionalRelationship(OpenXmlNamespace ns, out OpenXmlNamespace transitionalRelationship)
-            => _strictTransitionalRelationshipPairs.TryGetValue(ns, out transitionalRelationship);
-
-        /// <inheritdoc />
-        public bool TryGetExtendedNamespace(OpenXmlNamespace ns, out OpenXmlNamespace extNamespaceUri)
-            => _extendedNamespaces.TryGetValue(ns, out extNamespaceUri);
-
-        /// <inheritdoc />
-        public FileFormatVersions GetVersion(OpenXmlNamespace ns)
-        {
-            var normalized = NormalizeNamespace(ns);
-
-            if (_urlToPrefix.TryGetValue(normalized, out var prefix) && _prefixToVersion.TryGetValue(prefix, out var version))
-            {
-                return version;
-            }
-
-            return FileFormatVersions.None;
-        }
-
-        private sealed class NamespaceDictionary : Dictionary<OpenXmlNamespace, OpenXmlNamespace>
-        {
-            private readonly OpenXmlNamespaceResolver _resolver;
-
-            public NamespaceDictionary(OpenXmlNamespaceResolver resolver)
-            {
-                _resolver = resolver;
-            }
-
-            public void Add(string key, string value)
-                => Add(key, value);
-        }
+        return FileFormatVersions.None;
     }
 }

--- a/src/DocumentFormat.OpenXml/Features/OpenXmlNamespaceResolver.cs
+++ b/src/DocumentFormat.OpenXml/Features/OpenXmlNamespaceResolver.cs
@@ -195,8 +195,6 @@ namespace DocumentFormat.OpenXml.Features
             return FileFormatVersions.None;
         }
 
-        private OpenXmlNamespace CreateNamespace(string uri) => new(uri, LookupPrefix(uri) ?? string.Empty);
-
         private sealed class NamespaceDictionary : Dictionary<OpenXmlNamespace, OpenXmlNamespace>
         {
             private readonly OpenXmlNamespaceResolver _resolver;
@@ -207,7 +205,7 @@ namespace DocumentFormat.OpenXml.Features
             }
 
             public void Add(string key, string value)
-                => Add(_resolver.CreateNamespace(key), _resolver.CreateNamespace(value));
+                => Add(key, value);
         }
     }
 }

--- a/src/DocumentFormat.OpenXml/Framework/Metadata/ElementMetadata.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Metadata/ElementMetadata.cs
@@ -63,17 +63,15 @@ namespace DocumentFormat.OpenXml.Framework.Metadata
             private static readonly Lazy<ElementFactoryCollection> _lazy = new Lazy<ElementFactoryCollection>(() => ElementFactoryCollection.Empty, true);
 
             private readonly Type _type;
-            private readonly IOpenXmlNamespaceResolver _resolver;
 
             private List<IMetadataBuilder<AttributeMetadata>>? _attributes;
             private HashSet<IMetadataBuilder<ElementFactory>>? _children;
             private List<IValidator>? _constraints;
             private OpenXmlQualifiedName _qname;
 
-            public Builder(Type type, IOpenXmlNamespaceResolver resolver)
+            public Builder(Type type)
             {
                 _type = type;
-                _resolver = resolver;
             }
 
             public Builder<TElement> AddElement<TElement>()
@@ -98,7 +96,7 @@ namespace DocumentFormat.OpenXml.Framework.Metadata
                 => _qname = qname;
 
             public void SetSchema(string ns, string localName)
-                => SetSchema(_resolver.CreateQName(ns, localName));
+                => SetSchema(new(ns, localName));
 
             public void AddChild<T>()
                 where T : OpenXmlElement, new()

--- a/src/DocumentFormat.OpenXml/Framework/Metadata/ElementMetadataProviderFeature.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Metadata/ElementMetadataProviderFeature.cs
@@ -35,7 +35,7 @@ namespace DocumentFormat.OpenXml.Framework.Metadata
 
         private static ElementMetadata CreateMetadata(OpenXmlElement element)
         {
-            var builder = new ElementMetadata.Builder(element.GetType(), element.Features.GetNamespaceResolver());
+            var builder = new ElementMetadata.Builder(element.GetType());
 
             element.ConfigureMetadata(builder);
 

--- a/src/DocumentFormat.OpenXml/Framework/NamespaceExtensions.cs
+++ b/src/DocumentFormat.OpenXml/Framework/NamespaceExtensions.cs
@@ -3,7 +3,6 @@
 
 using DocumentFormat.OpenXml.Features;
 using DocumentFormat.OpenXml.Framework;
-using System;
 
 namespace DocumentFormat.OpenXml;
 
@@ -17,33 +16,10 @@ internal static class NamespaceExtensions
     public static bool HasVersion(this IOpenXmlNamespaceResolver resolver, OpenXmlNamespace ns, FileFormatVersions version)
         => resolver.GetVersion(ns) == version;
 
-    public static OpenXmlNamespace CreateNamespace(this IOpenXmlNamespaceResolver resolver, string name, string? prefix = null)
-        => prefix is not null ? new(name, prefix) : new(name, resolver.LookupPrefix(name) ?? string.Empty);
-
-    public static OpenXmlQualifiedName CreateQName(this IOpenXmlNamespaceResolver resolver, string nsUri, string name)
-        => new(resolver.CreateNamespace(nsUri), name);
-
     public static OpenXmlQualifiedName ParseQName(this IOpenXmlNamespaceResolver resolver, string name, string? nsUri = null)
     {
-#if NET5_0
-        var idx = name.IndexOf(':', StringComparison.Ordinal);
-#else
-        var idx = name.IndexOf(':');
-#endif
+        var parsed = PrefixName.Parse(name);
 
-        if (((idx == -1) || (idx == 0)) || ((name.Length - 1) == idx))
-        {
-            var start = idx + 1;
-
-            return resolver.CreateQName(nsUri ?? string.Empty, name.Substring(start));
-        }
-        else
-        {
-            var prefix = name.Substring(0, idx);
-            var uri = nsUri ?? resolver.LookupNamespace(prefix) ?? string.Empty;
-            var localName = name.Substring(idx + 1);
-
-            return new OpenXmlQualifiedName(new OpenXmlNamespace(uri, prefix), localName);
-        }
+        return new(nsUri ?? resolver.LookupNamespace(parsed.Prefix) ?? string.Empty, parsed.Name);
     }
 }

--- a/src/DocumentFormat.OpenXml/Framework/OpenXmlNamespace.cs
+++ b/src/DocumentFormat.OpenXml/Framework/OpenXmlNamespace.cs
@@ -3,42 +3,39 @@
 
 using System;
 
-namespace DocumentFormat.OpenXml.Framework
+namespace DocumentFormat.OpenXml.Framework;
+
+internal readonly partial struct OpenXmlNamespace : IComparable<OpenXmlNamespace>, IEquatable<OpenXmlNamespace>
 {
-    internal readonly partial struct OpenXmlNamespace : IComparable<OpenXmlNamespace>, IEquatable<OpenXmlNamespace>
+    private readonly string? _uri;
+
+    public OpenXmlNamespace(string nsUri)
     {
-        private readonly string? _prefix;
-        private readonly string? _uri;
-
-        public OpenXmlNamespace(string nsUri, string prefix)
-        {
-            _uri = nsUri;
-            _prefix = prefix;
-        }
-
-        public string Uri => _uri ?? string.Empty;
-
-        public string Prefix => _prefix ?? string.Empty;
-
-        public bool IsEmpty => string.IsNullOrEmpty(Uri);
-
-        public override bool Equals(object? obj) => obj is OpenXmlNamespace ns && Equals(ns);
-
-        public bool Equals(OpenXmlNamespace other)
-            => string.Equals(Uri, other.Uri, StringComparison.Ordinal);
-
-        public override int GetHashCode()
-        {
-            var hashcode = default(HashCode);
-
-            hashcode.Add(Uri, StringComparer.Ordinal);
-
-            return hashcode.ToHashCode();
-        }
-
-        public override string ToString() => Uri;
-
-        public int CompareTo(OpenXmlNamespace other)
-            => string.CompareOrdinal(Uri, other.Uri);
+        _uri = nsUri;
     }
+
+    public string Uri => _uri ?? string.Empty;
+
+    public bool IsEmpty => string.IsNullOrEmpty(Uri);
+
+    public override bool Equals(object? obj) => obj is OpenXmlNamespace ns && Equals(ns);
+
+    public bool Equals(OpenXmlNamespace other)
+        => string.Equals(Uri, other.Uri, StringComparison.Ordinal);
+
+    public override int GetHashCode()
+    {
+        var hashcode = default(HashCode);
+
+        hashcode.Add(Uri, StringComparer.Ordinal);
+
+        return hashcode.ToHashCode();
+    }
+
+    public override string ToString() => Uri;
+
+    public int CompareTo(OpenXmlNamespace other)
+        => string.CompareOrdinal(Uri, other.Uri);
+
+    public static implicit operator OpenXmlNamespace(string nsUri) => new(nsUri);
 }

--- a/src/DocumentFormat.OpenXml/Framework/OpenXmlQualifiedName.cs
+++ b/src/DocumentFormat.OpenXml/Framework/OpenXmlQualifiedName.cs
@@ -51,7 +51,7 @@ namespace DocumentFormat.OpenXml.Framework
         public static implicit operator OpenXmlQualifiedName(string input) => Parse(input);
 
         public static OpenXmlQualifiedName Create(string nsUri, string prefix, string name)
-            => new OpenXmlQualifiedName(new OpenXmlNamespace(nsUri, prefix), name);
+            => new(nsUri, name);
 
         public static OpenXmlQualifiedName Parse(string name, string? nsUri = null)
             => FeatureCollection.TypedOrDefault.GetNamespaceResolver().ParseQName(name, nsUri);

--- a/src/DocumentFormat.OpenXml/Framework/PrefixName.cs
+++ b/src/DocumentFormat.OpenXml/Framework/PrefixName.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DocumentFormat.OpenXml;
+
+internal readonly struct PrefixName
+{
+    public PrefixName(string prefix, string name)
+    {
+        Prefix = prefix;
+        Name = name;
+    }
+
+    public string Prefix { get; }
+
+    public string Name { get; }
+
+    public static PrefixName Parse(string name)
+    {
+#if NET5_0
+        var idx = name.IndexOf(':', StringComparison.Ordinal);
+#else
+        var idx = name.IndexOf(':');
+#endif
+
+        if (((idx == -1) || (idx == 0)) || ((name.Length - 1) == idx))
+        {
+            var start = idx + 1;
+
+            return new(string.Empty, name.Substring(start));
+        }
+        else
+        {
+            var prefix = name.Substring(0, idx);
+            var localName = name.Substring(idx + 1);
+
+            return new(prefix, localName);
+        }
+    }
+}

--- a/src/DocumentFormat.OpenXml/Framework/SchemaAttrAttribute.cs
+++ b/src/DocumentFormat.OpenXml/Framework/SchemaAttrAttribute.cs
@@ -34,7 +34,7 @@ namespace DocumentFormat.OpenXml
             var prefix = features.GetRequired<IOpenXmlNamespaceIdResolver>().GetPrefix(nsId);
             var uri = features.GetRequired<IOpenXmlNamespaceResolver>().LookupNamespace(prefix);
 
-            _qname = new OpenXmlQualifiedName(new OpenXmlNamespace(uri ?? string.Empty, prefix), tag);
+            _qname = new OpenXmlQualifiedName(uri ?? string.Empty, tag);
         }
 
         /// <summary>
@@ -64,9 +64,7 @@ namespace DocumentFormat.OpenXml
                 throw new ArgumentNullException(nameof(tag));
             }
 
-            var resolver = FeatureCollection.TypedOrDefault.GetNamespaceResolver();
-
-            _qname = resolver.CreateQName(ns, tag);
+            _qname = new(ns, tag);
         }
 
         /// <summary>

--- a/src/DocumentFormat.OpenXml/MCContext.cs
+++ b/src/DocumentFormat.OpenXml/MCContext.cs
@@ -440,7 +440,7 @@ namespace DocumentFormat.OpenXml
                         }
                     }
 
-                    var ns = _resolver.CreateNamespace(uri);
+                    var ns = new OpenXmlNamespace(uri);
 
                     if (!_resolver.HasVersion(ns, format))
                     {

--- a/src/DocumentFormat.OpenXml/OpenXmlAttribute.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlAttribute.cs
@@ -16,11 +16,13 @@ namespace DocumentFormat.OpenXml
         private const string ObsoleteMessage = "OpenXmlAttribute is a struct so setters may not behave as you might expect. Mutable setters will be removed in a future version.";
 
         private string? _value;
+        private string _prefix;
 
-        internal OpenXmlAttribute(in OpenXmlQualifiedName qname, string? value)
+        internal OpenXmlAttribute(in OpenXmlQualifiedName qname, string prefix, string? value)
         {
             QName = qname;
             _value = value;
+            _prefix = prefix;
         }
 
         /// <summary>
@@ -36,9 +38,10 @@ namespace DocumentFormat.OpenXml
                 throw new ArgumentNullException(nameof(qualifiedName));
             }
 
-            var qname = OpenXmlQualifiedName.Parse(qualifiedName);
+            var parsed = PrefixName.Parse(qualifiedName);
 
-            QName = new(new(namespaceUri, qname.Namespace.Prefix), qname.Name);
+            QName = new(namespaceUri, parsed.Name);
+            _prefix = parsed.Prefix;
             _value = value;
         }
 
@@ -56,7 +59,8 @@ namespace DocumentFormat.OpenXml
                 throw new ArgumentNullException(nameof(localName));
             }
 
-            QName = new(new(namespaceUri, prefix), localName);
+            QName = new(namespaceUri, localName);
+            _prefix = prefix;
             _value = value;
         }
 
@@ -67,7 +71,7 @@ namespace DocumentFormat.OpenXml
         {
             get => QName.Namespace.Uri;
             [Obsolete(ObsoleteMessage)]
-            set => QName = new(new(value, Prefix), LocalName);
+            set => QName = new(value, LocalName);
         }
 
         /// <summary>
@@ -85,9 +89,9 @@ namespace DocumentFormat.OpenXml
         /// </summary>
         public string Prefix
         {
-            get => QName.Namespace.Prefix;
+            get => _prefix;
             [Obsolete(ObsoleteMessage)]
-            set => QName = new(new(NamespaceUri, value), LocalName);
+            set => _prefix = value;
         }
 
         /// <summary>
@@ -119,9 +123,8 @@ namespace DocumentFormat.OpenXml
         /// <returns>Returns true if instances are equal; otherwise, returns false.</returns>
         public bool Equals(OpenXmlAttribute other)
             => string.Equals(Value, other.Value, StringComparison.Ordinal)
-            && string.Equals(QName.Name, other.QName.Name, StringComparison.Ordinal)
-            && string.Equals(QName.Namespace.Uri, other.QName.Namespace.Uri, StringComparison.Ordinal)
-            && string.Equals(QName.Namespace.Prefix, other.QName.Namespace.Prefix, StringComparison.Ordinal);
+            && QName.Equals(other.QName)
+            && string.Equals(_prefix, other._prefix, StringComparison.Ordinal);
 
         /// <summary>
         /// Determines if two instances of OpenXmlAttribute structures are equal.
@@ -158,9 +161,8 @@ namespace DocumentFormat.OpenXml
             var hashcode = default(HashCode);
 
             hashcode.Add(Value, StringComparer.Ordinal);
-            hashcode.Add(QName.Name, StringComparer.Ordinal);
-            hashcode.Add(QName.Namespace.Uri, StringComparer.Ordinal);
-            hashcode.Add(QName.Namespace.Prefix, StringComparer.Ordinal);
+            hashcode.Add(QName);
+            hashcode.Add(_prefix, StringComparer.Ordinal);
 
             return hashcode.ToHashCode();
         }

--- a/src/DocumentFormat.OpenXml/OpenXmlCompositeElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlCompositeElement.cs
@@ -709,7 +709,7 @@ namespace DocumentFormat.OpenXml
                                     // If node is an UnknowElement, we should try to see whether the parent element can load the node as strong typed element
                                     if (node is OpenXmlUnknownElement)
                                     {
-                                        newnode = CreateElement(OpenXmlQualifiedName.Create(node.NamespaceUri, node.Prefix, node.LocalName));
+                                        newnode = CreateElement(OpenXmlQualifiedName.Create(node.NamespaceUri, node.Prefix, node.LocalName), node.Prefix);
                                         if (!(newnode is OpenXmlUnknownElement))
                                         {
                                             // The following method will load teh element in MCMode.Full

--- a/src/DocumentFormat.OpenXml/OpenXmlElementExtensionMethods.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlElementExtensionMethods.cs
@@ -157,7 +157,7 @@ namespace DocumentFormat.OpenXml
         {
             Debug.Assert(parent is OpenXmlCompositeElement);
 
-            var newElement = parent.CreateElement(OpenXmlQualifiedName.Create(namespaceUri, string.Empty, localName));
+            var newElement = parent.CreateElement(OpenXmlQualifiedName.Create(namespaceUri, string.Empty, localName), string.Empty);
             if (newElement is OpenXmlUnknownElement || !newElement.IsInVersion(fileFormat))
             {
                 return null;

--- a/src/DocumentFormat.OpenXml/OpenXmlPartReader.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlPartReader.cs
@@ -787,7 +787,7 @@ namespace DocumentFormat.OpenXml
             }
 
             // create the root element object
-            var rootElement = CreateElement(_resolver.CreateQName(_xmlReader.NamespaceURI, _xmlReader.LocalName));
+            var rootElement = CreateElement(new(_xmlReader.NamespaceURI, _xmlReader.LocalName));
 
             if (rootElement is null)
             {

--- a/src/DocumentFormat.OpenXml/OpenXmlPartRootElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlPartRootElement.cs
@@ -152,7 +152,7 @@ namespace DocumentFormat.OpenXml
                 }
 
                 var resolver = Features.GetNamespaceResolver();
-                var qname = resolver.CreateQName(xmlReader.NamespaceURI, xmlReader.LocalName);
+                var qname = new OpenXmlQualifiedName(xmlReader.NamespaceURI, xmlReader.LocalName);
 
                 if (!resolver.IsKnown(qname.Namespace) || !QName.Equals(qname))
                 {
@@ -303,7 +303,7 @@ namespace DocumentFormat.OpenXml
                 // in this case, we use the predefined prefix
                 if (prefix.IsNullOrEmpty())
                 {
-                    prefix = QName.Namespace.Prefix;
+                    prefix = Features.GetNamespaceResolver().LookupPrefix(QName.Namespace.Uri);
                 }
 
                 xmlWriter.WriteStartElement(prefix, LocalName, NamespaceUri);

--- a/src/DocumentFormat.OpenXml/OpenXmlUnknownElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlUnknownElement.cs
@@ -48,10 +48,10 @@ namespace DocumentFormat.OpenXml
                 throw new ArgumentNullException(nameof(name));
             }
 
-            var schema = OpenXmlQualifiedName.Parse(name);
+            var parsed = PrefixName.Parse(name);
 
-            _prefix = schema.Namespace.Prefix;
-            _tagName = schema.Name;
+            _prefix = parsed.Prefix;
+            _tagName = parsed.Name;
         }
 
         /// <summary>
@@ -68,15 +68,15 @@ namespace DocumentFormat.OpenXml
                 throw new ArgumentNullException(nameof(qualifiedName));
             }
 
-            var schema = OpenXmlQualifiedName.Parse(qualifiedName);
+            var parsed = PrefixName.Parse(qualifiedName);
 
-            _prefix = schema.Namespace.Prefix;
-            _tagName = schema.Name;
+            _prefix = parsed.Prefix;
+            _tagName = parsed.Name;
             _namespaceUri = namespaceUri;
         }
 
-        internal OpenXmlUnknownElement(in OpenXmlQualifiedName qname)
-            : this(qname.Namespace.Prefix, qname.Name, qname.Namespace.Uri)
+        internal OpenXmlUnknownElement(in OpenXmlQualifiedName qname, string prefix)
+            : this(prefix, qname.Name, qname.Namespace.Uri)
         {
         }
 

--- a/src/DocumentFormat.OpenXml/Packaging/RelationshipCollection.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/RelationshipCollection.cs
@@ -40,7 +40,7 @@ namespace DocumentFormat.OpenXml.Packaging
                 relationshipProperty.Id = relationship.Id;
                 relationshipProperty.RelationshipType = relationship.RelationshipType;
 
-                var ns = resolver.CreateNamespace(relationshipProperty.RelationshipType);
+                var ns = new OpenXmlNamespace(relationshipProperty.RelationshipType);
 
                 // If packageRel.RelationshipType is something for Strict, it tries to get the equivalent in Transitional.
                 if (resolver.TryGetTransitionalRelationship(ns, out var transitionalNamespace))

--- a/src/DocumentFormat.OpenXml/XmlConvertingReader.cs
+++ b/src/DocumentFormat.OpenXml/XmlConvertingReader.cs
@@ -174,10 +174,8 @@ namespace DocumentFormat.OpenXml
 
         bool IXmlLineInfo.HasLineInfo() => XmlLineInfo.Get(BaseReader).HasLineInfo();
 
-        private string ApplyStrictTranslation(string nsUri)
+        private string ApplyStrictTranslation(OpenXmlNamespace ns)
         {
-            var ns = _resolver.CreateNamespace(nsUri);
-
             if (StrictRelationshipFound)
             {
                 if (_resolver.TryGetTransitionalNamespace(ns, out var transitionalNamespace))

--- a/test/DocumentFormat.OpenXml.Framework.Tests/OpenXmlNamespaceTests.cs
+++ b/test/DocumentFormat.OpenXml.Framework.Tests/OpenXmlNamespaceTests.cs
@@ -111,12 +111,10 @@ namespace DocumentFormat.OpenXml.Framework.Tests
             var idPrefix = idResolver.GetPrefix(id);
             var idUri = resolver.LookupNamespace(idPrefix);
 
-            var nsFromNs = new OpenXmlNamespace(ns, prefix);
-            var nsFromId = new OpenXmlNamespace(idUri, idPrefix);
+            var nsFromNs = new OpenXmlNamespace(ns);
+            var nsFromId = new OpenXmlNamespace(idUri);
 
             Assert.Equal(nsFromNs, nsFromId);
-            Assert.Equal(prefix, nsFromNs.Prefix);
-            Assert.Equal(prefix, nsFromId.Prefix);
             Assert.Equal(ns, resolver.LookupNamespace(prefix));
             Assert.Equal(prefix, resolver.LookupPrefix(ns));
 

--- a/test/DocumentFormat.OpenXml.Framework.Tests/PropertyBuilderTests.cs
+++ b/test/DocumentFormat.OpenXml.Framework.Tests/PropertyBuilderTests.cs
@@ -16,7 +16,7 @@ namespace DocumentFormat.OpenXml.Framework.Tests
         [Fact]
         public void Sanity()
         {
-            var builder = new ElementMetadata.Builder(typeof(OpenXmlElement), new OpenXmlNamespaceResolver());
+            var builder = new ElementMetadata.Builder(typeof(OpenXmlElement));
             builder.AddElement<SomeElement>()
                 .AddAttribute("s", a => a.Str, a =>
                 {
@@ -43,7 +43,7 @@ namespace DocumentFormat.OpenXml.Framework.Tests
         [Fact]
         public void IsRequired()
         {
-            var builder = new ElementMetadata.Builder(typeof(OpenXmlElement), new OpenXmlNamespaceResolver());
+            var builder = new ElementMetadata.Builder(typeof(OpenXmlElement));
             builder.AddElement<SomeElement>()
                 .AddAttribute("s", a => a.Str, a =>
                 {

--- a/test/DocumentFormat.OpenXml.Tests/Extensions/OpenXmlElementExtensions.cs
+++ b/test/DocumentFormat.OpenXml.Tests/Extensions/OpenXmlElementExtensions.cs
@@ -116,7 +116,10 @@ namespace DocumentFormat.OpenXml.Tests
 
             foreach (var attribute in e.ParsedState.Attributes)
             {
-                yield return new OpenXmlAttribute(attribute.Property.QName, attribute.Value?.InnerText);
+                var qname = attribute.Property.QName;
+                var prefix = e.Features.GetNamespaceResolver().LookupPrefix(qname.Namespace.Uri) ?? string.Empty;
+
+                yield return new OpenXmlAttribute(qname, prefix, attribute.Value?.InnerText);
             }
         }
 


### PR DESCRIPTION
This value can be retrieved from the IOpenXmlNamespaceResolver when needed rather than at construction. This simplifies the usage of this type drastically and makes it something we should probably just expose publicly.