### PR TITLE
Add a strongly typed layer for parts and elements

### DIFF
--- a/gen/DocumentFormat.OpenXml.Generator.Models/Generators/Parts/PartWriter.cs
+++ b/gen/DocumentFormat.OpenXml.Generator.Models/Generators/Parts/PartWriter.cs
@@ -49,6 +49,7 @@ public static class PartWriter
             writer.Write("public partial class ");
             writer.Write(type.Name);
             writer.Write(" : ");
+
             writer.Write(type.Base);
 
             if (type.HasFixedContent)

--- a/gen/DocumentFormat.OpenXml.Generator.Models/Models/Part.cs
+++ b/gen/DocumentFormat.OpenXml.Generator.Models/Models/Part.cs
@@ -5,9 +5,15 @@ namespace DocumentFormat.OpenXml.Generator.Models;
 
 public class Part
 {
+    private string _base = null!;
+
     public string Name { get; set; } = null!;
 
-    public string Base { get; set; } = null!;
+    public string Base
+    {
+        get => _base;
+        set => _base = value.Equals("OpenXmlPart") ? "TypedOpenXmlPart" : value;
+    }
 
     public bool HasFixedContent => ContentType is not null;
 

--- a/src/DocumentFormat.OpenXml/AlternateContent.cs
+++ b/src/DocumentFormat.OpenXml/AlternateContent.cs
@@ -117,14 +117,44 @@ namespace DocumentFormat.OpenXml
             return CloneImp<AlternateContent>(deep);
         }
 
-        internal override void ConfigureMetadata(ElementMetadata.Builder builder)
+        private protected override IFeatureCollection CreateFeatures() => new AlternateContentFeatures(this);
+
+        private class AlternateContentFeatures : ElementFeatureCollection, IElementMetadata
         {
-            base.ConfigureMetadata(builder);
+            public AlternateContentFeatures(OpenXmlElement owner)
+                : base(owner)
+            {
+            }
 
-            builder.SetSchema(InternalQName);
+            public override TFeature Get<TFeature>()
+            {
+                if (typeof(TFeature) == typeof(IElementMetadata))
+                {
+                    return (TFeature)(object)this;
+                }
 
-            builder.AddChild<AlternateContentChoice>();
-            builder.AddChild<AlternateContentFallback>();
+                return base.Get<TFeature>()!;
+            }
+
+            Type IElementMetadata.Type => typeof(AlternateContent);
+
+            ReadOnlyArray<AttributeMetadata> IElementMetadata.Attributes => default;
+
+            FileFormatVersions IElementMetadata.Availability => FileFormatVersions.Office2007;
+
+            ElementFactoryCollection IElementMetadata.Children { get; } = new(new[]
+            {
+                new ElementFactory(typeof(AlternateContentChoice), AlternateContentChoice.InternalQName, static () => new AlternateContentChoice()),
+                new ElementFactory(typeof(AlternateContentFallback), AlternateContentFallback.InternalQName, static () => new AlternateContentFallback()),
+            });
+
+            ReadOnlyArray<IValidator> IElementMetadata.Constraints => default;
+
+            CompiledParticle? IElementMetadata.Particle => new(null);
+
+            OpenXmlQualifiedName IElementMetadata.QName => InternalQName;
+
+            ReadOnlyArray<IValidator> IElementMetadata.Validators => default;
         }
     }
 }

--- a/src/DocumentFormat.OpenXml/AlternateContent.cs
+++ b/src/DocumentFormat.OpenXml/AlternateContent.cs
@@ -117,44 +117,14 @@ namespace DocumentFormat.OpenXml
             return CloneImp<AlternateContent>(deep);
         }
 
-        private protected override IFeatureCollection CreateFeatures() => new AlternateContentFeatures(this);
-
-        private class AlternateContentFeatures : ElementFeatureCollection, IElementMetadata
+        internal override void ConfigureMetadata(ElementMetadata.Builder builder)
         {
-            public AlternateContentFeatures(OpenXmlElement owner)
-                : base(owner)
-            {
-            }
+            base.ConfigureMetadata(builder);
 
-            public override TFeature Get<TFeature>()
-            {
-                if (typeof(TFeature) == typeof(IElementMetadata))
-                {
-                    return (TFeature)(object)this;
-                }
+            builder.SetSchema(InternalQName);
 
-                return base.Get<TFeature>()!;
-            }
-
-            Type IElementMetadata.Type => typeof(AlternateContent);
-
-            ReadOnlyArray<AttributeMetadata> IElementMetadata.Attributes => default;
-
-            FileFormatVersions IElementMetadata.Availability => FileFormatVersions.Office2007;
-
-            ElementFactoryCollection IElementMetadata.Children { get; } = new(new[]
-            {
-                new ElementFactory(typeof(AlternateContentChoice), AlternateContentChoice.InternalQName, static () => new AlternateContentChoice()),
-                new ElementFactory(typeof(AlternateContentFallback), AlternateContentFallback.InternalQName, static () => new AlternateContentFallback()),
-            });
-
-            ReadOnlyArray<IValidator> IElementMetadata.Constraints => default;
-
-            CompiledParticle? IElementMetadata.Particle => new(null);
-
-            OpenXmlQualifiedName IElementMetadata.QName => InternalQName;
-
-            ReadOnlyArray<IValidator> IElementMetadata.Validators => default;
+            builder.AddChild<AlternateContentChoice>();
+            builder.AddChild<AlternateContentFallback>();
         }
     }
 }

--- a/src/DocumentFormat.OpenXml/AlternateContentChoice.cs
+++ b/src/DocumentFormat.OpenXml/AlternateContentChoice.cs
@@ -10,7 +10,7 @@ namespace DocumentFormat.OpenXml
     /// <summary>
     /// Defines an mc:Choice element in mc:AlternateContent.
     /// </summary>
-    public class AlternateContentChoice : TypedOpenXmlCompositeElement
+    public class AlternateContentChoice : OpenXmlCompositeElement
     {
         internal static OpenXmlQualifiedName InternalQName => new(AlternateContent.InternalQName.Namespace.Uri, Name);
 

--- a/src/DocumentFormat.OpenXml/AlternateContentChoice.cs
+++ b/src/DocumentFormat.OpenXml/AlternateContentChoice.cs
@@ -10,8 +10,10 @@ namespace DocumentFormat.OpenXml
     /// <summary>
     /// Defines an mc:Choice element in mc:AlternateContent.
     /// </summary>
-    public class AlternateContentChoice : OpenXmlCompositeElement
+    public class AlternateContentChoice : TypedOpenXmlCompositeElement
     {
+        internal static OpenXmlQualifiedName InternalQName => new(AlternateContent.InternalQName.Namespace.Uri, Name);
+
         private const string Name = "Choice";
 
         /// <summary>

--- a/src/DocumentFormat.OpenXml/AlternateContentFallback.cs
+++ b/src/DocumentFormat.OpenXml/AlternateContentFallback.cs
@@ -10,7 +10,7 @@ namespace DocumentFormat.OpenXml
     /// <summary>
     /// Defines a mc:Fallback element in mc:AlternateContent.
     /// </summary>
-    public class AlternateContentFallback : TypedOpenXmlCompositeElement
+    public class AlternateContentFallback : OpenXmlCompositeElement
     {
         internal static OpenXmlQualifiedName InternalQName => new(AlternateContent.InternalQName.Namespace.Uri, Name);
 

--- a/src/DocumentFormat.OpenXml/AlternateContentFallback.cs
+++ b/src/DocumentFormat.OpenXml/AlternateContentFallback.cs
@@ -10,8 +10,10 @@ namespace DocumentFormat.OpenXml
     /// <summary>
     /// Defines a mc:Fallback element in mc:AlternateContent.
     /// </summary>
-    public class AlternateContentFallback : OpenXmlCompositeElement
+    public class AlternateContentFallback : TypedOpenXmlCompositeElement
     {
+        internal static OpenXmlQualifiedName InternalQName => new(AlternateContent.InternalQName.Namespace.Uri, Name);
+
         private const string Name = "Fallback";
 
         /// <summary>

--- a/src/DocumentFormat.OpenXml/Features/DefaultFeatures.cs
+++ b/src/DocumentFormat.OpenXml/Features/DefaultFeatures.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using DocumentFormat.OpenXml.Framework.Metadata;
 using System;
 
 namespace DocumentFormat.OpenXml.Features
@@ -14,6 +15,8 @@ namespace DocumentFormat.OpenXml.Features
         public int Revision => 0;
 
         [KnownFeature(typeof(IOpenXmlNamespaceIdResolver), typeof(OpenXmlNamespaceIdResolver))]
+        [KnownFeature(typeof(IOpenXmlNamespaceResolver), typeof(NoDataNamespaceResolver))]
+        [KnownFeature(typeof(IElementMetadataFactoryFeature), typeof(ElementMetadataFactoryFeature))]
         [ThreadSafe]
         public partial TFeature? Get<TFeature>();
 

--- a/src/DocumentFormat.OpenXml/Features/NoDataNamespaceResolver.cs
+++ b/src/DocumentFormat.OpenXml/Features/NoDataNamespaceResolver.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Framework;
+using DocumentFormat.OpenXml.Framework.Metadata;
+using System;
+using System.Collections.Generic;
+using System.Xml;
+
+namespace DocumentFormat.OpenXml.Features
+{
+    internal class NoDataNamespaceResolver : IOpenXmlNamespaceResolver
+    {
+        public IDictionary<string, string> GetNamespacesInScope(XmlNamespaceScope scope) => new Dictionary<string, string>();
+
+        public FileFormatVersions GetVersion(OpenXmlNamespace ns) => FileFormatVersions.Office2007;
+
+        public string? LookupNamespace(string prefix) => null;
+
+        public string? LookupPrefix(string namespaceName) => null;
+
+        public bool TryGetExtendedNamespace(OpenXmlNamespace ns, out OpenXmlNamespace extNamespaceUri)
+        {
+            extNamespaceUri = default;
+            return false;
+        }
+
+        public bool TryGetTransitionalNamespace(OpenXmlNamespace ns, out OpenXmlNamespace transitionalNamespace)
+        {
+            transitionalNamespace = default;
+            return false;
+        }
+
+        public bool TryGetTransitionalRelationship(OpenXmlNamespace ns, out OpenXmlNamespace transitionalRelationship)
+        {
+            transitionalRelationship = default;
+            return false;
+        }
+    }
+}

--- a/src/DocumentFormat.OpenXml/Features/TypedFeatures.cs
+++ b/src/DocumentFormat.OpenXml/Features/TypedFeatures.cs
@@ -32,7 +32,6 @@ internal partial class TypedFeatures : IFeatureCollection
     [KnownFeature(typeof(IRootElementFactory), typeof(ReflectionBasedRootElementFactory))]
     [KnownFeature(typeof(IPartMetadataFeature), typeof(CachedPartMetadataProvider))]
     [KnownFeature(typeof(IOpenXmlNamespaceResolver), typeof(OpenXmlNamespaceResolver))]
-    [KnownFeature(typeof(IElementMetadataFactoryFeature), typeof(TypedElementMetadataFactoryFeature))]
     [KnownFeature(typeof(IPartFactory), typeof(ReflectionPartFactory))]
     [DelegatedFeature(nameof(FeatureCollection.Default), typeof(FeatureCollection))]
     [ThreadSafe]

--- a/src/DocumentFormat.OpenXml/Framework/Metadata/ElementMetadataFactoryFeature.cs
+++ b/src/DocumentFormat.OpenXml/Framework/Metadata/ElementMetadataFactoryFeature.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 
 namespace DocumentFormat.OpenXml.Framework.Metadata
 {
-    internal class TypedElementMetadataFactoryFeature : IElementMetadataFactoryFeature
+    internal class ElementMetadataFactoryFeature : IElementMetadataFactoryFeature
     {
         private readonly ConcurrentDictionary<Type, ElementMetadata> _lookup = new(new[]
         {

--- a/src/DocumentFormat.OpenXml/OpenXmlCompositeElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlCompositeElement.cs
@@ -19,6 +19,8 @@ namespace DocumentFormat.OpenXml
     /// </summary>
     public abstract class OpenXmlCompositeElement : OpenXmlElement
     {
+        private protected const string UseGenericVersion = "Should use the generic version of this. This overload will be removed in a future version.";
+
         private OpenXmlElement? _lastChild;
 
         /// <summary>
@@ -42,7 +44,7 @@ namespace DocumentFormat.OpenXml
         /// Initializes a new instance of the OpenXmlCompositeElement class using the supplied collection of elements.
         /// </summary>
         /// <param name="childrenElements">A collection of elements.</param>
-        [Obsolete("Should use the generic version of this. This overload will be removed in a future version.")]
+        [Obsolete(UseGenericVersion)]
         protected OpenXmlCompositeElement(IEnumerable childrenElements)
             : this()
         {

--- a/src/DocumentFormat.OpenXml/OpenXmlElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlElement.cs
@@ -2620,27 +2620,19 @@ namespace DocumentFormat.OpenXml
 
             public bool IsReadOnly => true;
 
-            public int Revision => GetParentFeatures()?.Revision ?? 0;
+            public int Revision => GetPartFeatures()?.Revision ?? 0;
 
             public virtual IFeatureCollection Default => FeatureCollection.Default;
 
             [KnownFeature(typeof(AnnotationsFeature))]
             [KnownFeature(typeof(IElementMetadata), Factory = nameof(CreateMetadata))]
-            [DelegatedFeature(nameof(GetParentFeatures))]
+            [DelegatedFeature(nameof(GetPartFeatures))]
             [DelegatedFeature(nameof(Default))]
             private partial TFeature? GetBuiltIn<TFeature>();
 
             public virtual TFeature? Get<TFeature>() => GetBuiltIn<TFeature>();
 
-            private IFeatureCollection? GetParentFeatures()
-            {
-                if (_owner is OpenXmlPartRootElement root)
-                {
-                    return root.OpenXmlPart?.Features;
-                }
-
-                return _owner.Parent?.Features;
-            }
+            private IFeatureCollection? GetPartFeatures() => _owner.GetPart()?.Features;
 
             private IElementMetadata CreateMetadata() => this.GetRequired<IElementMetadataFactoryFeature>().GetMetadata(_owner);
 

--- a/src/DocumentFormat.OpenXml/OpenXmlMiscNode.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlMiscNode.cs
@@ -13,7 +13,7 @@ namespace DocumentFormat.OpenXml
     /// <summary>
     /// Represents an Open XML non element node (i.e. PT, Comments, Entity, Notation, XmlDeclaration).
     /// </summary>
-    public class OpenXmlMiscNode : OpenXmlElement
+    public class OpenXmlMiscNode : TypedOpenXmlElement
     {
         private const string StrCDataSectionName = "#cdata-section";
         private const string StrCommentName = "#comment";

--- a/src/DocumentFormat.OpenXml/OpenXmlMiscNode.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlMiscNode.cs
@@ -13,7 +13,7 @@ namespace DocumentFormat.OpenXml
     /// <summary>
     /// Represents an Open XML non element node (i.e. PT, Comments, Entity, Notation, XmlDeclaration).
     /// </summary>
-    public class OpenXmlMiscNode : TypedOpenXmlElement
+    public class OpenXmlMiscNode : OpenXmlElement
     {
         private const string StrCDataSectionName = "#cdata-section";
         private const string StrCommentName = "#comment";

--- a/src/DocumentFormat.OpenXml/OpenXmlUnknownElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlUnknownElement.cs
@@ -3,6 +3,7 @@
 
 using DocumentFormat.OpenXml.Features;
 using DocumentFormat.OpenXml.Framework;
+using DocumentFormat.OpenXml.Framework.Metadata;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -14,7 +15,7 @@ namespace DocumentFormat.OpenXml
     /// Represents elements that are not defined in the Office Open XML ECMA standard.
     /// </summary>
     [OfficeAvailability(FileFormatVersions.None)]
-    public class OpenXmlUnknownElement : TypedOpenXmlCompositeElement
+    public class OpenXmlUnknownElement : OpenXmlCompositeElement
     {
         private string _namespaceUri;
         private string _tagName;

--- a/src/DocumentFormat.OpenXml/OpenXmlUnknownElement.cs
+++ b/src/DocumentFormat.OpenXml/OpenXmlUnknownElement.cs
@@ -14,7 +14,7 @@ namespace DocumentFormat.OpenXml
     /// Represents elements that are not defined in the Office Open XML ECMA standard.
     /// </summary>
     [OfficeAvailability(FileFormatVersions.None)]
-    public class OpenXmlUnknownElement : OpenXmlCompositeElement
+    public class OpenXmlUnknownElement : TypedOpenXmlCompositeElement
     {
         private string _namespaceUri;
         private string _tagName;

--- a/src/DocumentFormat.OpenXml/Packaging/MailMergeRecipientDataPart.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/MailMergeRecipientDataPart.cs
@@ -9,7 +9,7 @@ namespace DocumentFormat.OpenXml.Packaging
     /// <summary>
     /// Defines MailMergeRecipientDataPart.
     /// </summary>
-    public partial class MailMergeRecipientDataPart : OpenXmlPart
+    public partial class MailMergeRecipientDataPart
     {
         private OpenXmlPartRootElement? _rootEle;
 

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
@@ -20,7 +20,7 @@ namespace DocumentFormat.OpenXml.Packaging
     /// </summary>
     public abstract partial class OpenXmlPackage : OpenXmlPartContainer, IDisposable
     {
-        private protected const string ObsoleteMessage = "The parameterless constructor never initialized anything. This will be removed in future updates.";
+        private protected const string DoNotUseParameterlessConstructor = "The parameterless constructor never initialized anything. This will be removed in future updates.";
 
         private readonly PartExtensionProvider _partExtensionProvider = new PartExtensionProvider();
         private readonly LinkedList<DataPart> _dataPartList = new LinkedList<DataPart>();
@@ -33,7 +33,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Initializes a new instance of the OpenXmlPackage class.
         /// </summary>
-        [Obsolete(ObsoleteMessage)]
+        [Obsolete(DoNotUseParameterlessConstructor)]
         protected OpenXmlPackage()
             : base()
         {

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPartContainer.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPartContainer.cs
@@ -1949,27 +1949,31 @@ namespace DocumentFormat.OpenXml.Packaging
             }
         }
 
-        internal virtual IFeatureCollection CreatePartFeatures(IFeatureCollection? other = null) => new PartContainerFeatureCollection(FeatureCollection.Default, other);
+        internal virtual IFeatureCollection CreatePartFeatures(IFeatureCollection? other = null) => new PartContainerFeatureCollection(other);
 
-        internal sealed partial class PartContainerFeatureCollection : IFeatureCollection
+        internal partial class PartContainerFeatureCollection : IFeatureCollection
         {
             private readonly IFeatureCollection? _other;
-            private readonly IFeatureCollection _defaultCollection;
 
             public bool IsReadOnly => true;
 
             public int Revision => 0;
 
-            public PartContainerFeatureCollection(IFeatureCollection defaultCollection, IFeatureCollection? other = null)
+            public PartContainerFeatureCollection(IFeatureCollection? other = null)
             {
                 _other = other;
-                _defaultCollection = defaultCollection;
             }
+
+            protected virtual IFeatureCollection Default => FeatureCollection.Default;
+
+            protected virtual TFeature? GetPartFeature<TFeature>() => default;
 
             [KnownFeature(typeof(AnnotationsFeature))]
             [DelegatedFeature(nameof(_other))]
-            [DelegatedFeature(nameof(_defaultCollection))]
-            public partial TFeature? Get<TFeature>();
+            [DelegatedFeature(nameof(Default))]
+            private partial TFeature? GetDefault<TFeature>();
+
+            public TFeature? Get<TFeature>() => GetPartFeature<TFeature>() ?? GetDefault<TFeature>();
 
             public void Set<TFeature>(TFeature? instance)
             {

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPartContainer.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPartContainer.cs
@@ -1966,14 +1966,12 @@ namespace DocumentFormat.OpenXml.Packaging
 
             protected virtual IFeatureCollection Default => FeatureCollection.Default;
 
-            protected virtual TFeature? GetPartFeature<TFeature>() => default;
-
             [KnownFeature(typeof(AnnotationsFeature))]
             [DelegatedFeature(nameof(_other))]
             [DelegatedFeature(nameof(Default))]
             private partial TFeature? GetDefault<TFeature>();
 
-            public TFeature? Get<TFeature>() => GetPartFeature<TFeature>() ?? GetDefault<TFeature>();
+            public TFeature? Get<TFeature>() => GetDefault<TFeature>();
 
             public void Set<TFeature>(TFeature? instance)
             {

--- a/src/DocumentFormat.OpenXml/Packaging/PresentationDocument.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/PresentationDocument.cs
@@ -25,7 +25,7 @@ namespace DocumentFormat.OpenXml.Packaging
     [PartConstraint(typeof(RibbonAndBackstageCustomizationsPart), false, false)]
     [PartConstraint(typeof(WebExTaskpanesPart), false, false)]
     [PartConstraint(typeof(LabelInfoPart), false, false)]
-    public partial class PresentationDocument : OpenXmlPackage
+    public partial class PresentationDocument : TypedOpenXmlPackage
     {
         /// <summary>
         /// Gets the relationship type of the main part.
@@ -64,7 +64,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates a PresentationDocument.
         /// </summary>
-        [Obsolete(ObsoleteMessage)]
+        [Obsolete(DoNotUseParameterlessConstructor)]
         protected PresentationDocument()
             : base()
         {
@@ -783,7 +783,5 @@ namespace DocumentFormat.OpenXml.Packaging
         #endregion Package-based cloning
 
         #endregion cloning
-
-        internal override IFeatureCollection CreatePartFeatures(IFeatureCollection? other) => new PartContainerFeatureCollection(TypedFeatures.Shared, other);
     }
 }

--- a/src/DocumentFormat.OpenXml/Packaging/SpreadsheetDocument.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/SpreadsheetDocument.cs
@@ -25,7 +25,7 @@ namespace DocumentFormat.OpenXml.Packaging
     [PartConstraint(typeof(RibbonAndBackstageCustomizationsPart), false, false)]
     [PartConstraint(typeof(WebExTaskpanesPart), false, false)]
     [PartConstraint(typeof(LabelInfoPart), false, false)]
-    public partial class SpreadsheetDocument : OpenXmlPackage
+    public partial class SpreadsheetDocument : TypedOpenXmlPackage
     {
         /// <summary>
         /// Gets the relationship type of the main part.
@@ -62,7 +62,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates a SpreadsheetDocument.
         /// </summary>
-        [Obsolete(ObsoleteMessage)]
+        [Obsolete(DoNotUseParameterlessConstructor)]
         protected SpreadsheetDocument()
             : base()
         {
@@ -783,7 +783,5 @@ namespace DocumentFormat.OpenXml.Packaging
         #endregion Package-based cloning
 
         #endregion cloning
-
-        internal override IFeatureCollection CreatePartFeatures(IFeatureCollection? other) => new PartContainerFeatureCollection(TypedFeatures.Shared, other);
     }
 }

--- a/src/DocumentFormat.OpenXml/Packaging/TypedOpenXmlPackage.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/TypedOpenXmlPackage.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Features;
+using System;
+using System.ComponentModel;
+
+namespace DocumentFormat.OpenXml.Packaging;
+
+/// <summary>
+/// An implementation of <see cref="OpenXmlPackage"/> that provides strongly-typed services.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public abstract class TypedOpenXmlPackage : OpenXmlPackage
+{
+    [Obsolete(DoNotUseParameterlessConstructor)]
+    private protected TypedOpenXmlPackage()
+    {
+    }
+
+    private protected TypedOpenXmlPackage(in PackageLoader package, OpenSettings settings)
+        : base(package, settings)
+    {
+    }
+
+    internal override IFeatureCollection CreatePartFeatures(IFeatureCollection? other = null) => new TypedPartFeatures(other);
+
+    private class TypedPartFeatures : PartContainerFeatureCollection
+    {
+        public TypedPartFeatures(IFeatureCollection? other = null)
+            : base(other)
+        {
+        }
+
+        protected override IFeatureCollection Default => TypedFeatures.Shared;
+    }
+}

--- a/src/DocumentFormat.OpenXml/Packaging/TypedOpenXmlPart.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/TypedOpenXmlPart.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Features;
+using System.ComponentModel;
+
+namespace DocumentFormat.OpenXml.Packaging;
+
+/// <summary>
+/// An implementation that is used to provide information for strongly typed <see cref="OpenXmlPart"/>.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public abstract partial class TypedOpenXmlPart : OpenXmlPart
+{
+    private protected TypedOpenXmlPart()
+    {
+    }
+
+    internal override IFeatureCollection CreatePartFeatures(IFeatureCollection? other = null)
+        => new PartContainerFeatureCollection(other);
+
+    private class TypedPartFeatures : PartContainerFeatureCollection
+    {
+        public TypedPartFeatures(IFeatureCollection? other)
+            : base(other)
+        {
+        }
+
+        protected override IFeatureCollection Default => TypedFeatures.Shared;
+    }
+}

--- a/src/DocumentFormat.OpenXml/Packaging/WordprocessingDocument.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/WordprocessingDocument.cs
@@ -26,7 +26,7 @@ namespace DocumentFormat.OpenXml.Packaging
     [PartConstraint(typeof(RibbonAndBackstageCustomizationsPart), false, false)]
     [PartConstraint(typeof(WebExTaskpanesPart), false, false)]
     [PartConstraint(typeof(LabelInfoPart), false, false)]
-    public partial class WordprocessingDocument : OpenXmlPackage
+    public partial class WordprocessingDocument : TypedOpenXmlPackage
     {
         /// <summary>
         /// Gets the relationship type of the main part.
@@ -62,7 +62,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates a WordprocessingDocument.
         /// </summary>
-        [Obsolete(ObsoleteMessage)]
+        [Obsolete(DoNotUseParameterlessConstructor)]
         protected WordprocessingDocument()
         {
         }
@@ -823,7 +823,5 @@ namespace DocumentFormat.OpenXml.Packaging
         #endregion Package-based cloning
 
         #endregion cloning
-
-        internal override IFeatureCollection CreatePartFeatures(IFeatureCollection? other) => new PartContainerFeatureCollection(TypedFeatures.Shared, other);
     }
 }

--- a/src/DocumentFormat.OpenXml/Schema/AdditionalCharacteristics/AdditionalCharacteristicsInfo.cs
+++ b/src/DocumentFormat.OpenXml/Schema/AdditionalCharacteristics/AdditionalCharacteristicsInfo.cs
@@ -8,7 +8,7 @@ namespace DocumentFormat.OpenXml.AdditionalCharacteristics
     /// <summary>
     /// Defines AdditionalCharacteristics.
     /// </summary>
-    public partial class AdditionalCharacteristicsInfo : OpenXmlPartRootElement
+    public partial class AdditionalCharacteristicsInfo
     {
         /// <summary>
         /// AdditionalCharacteristics constructor.

--- a/src/DocumentFormat.OpenXml/Schema/Bibliography/Sources.cs
+++ b/src/DocumentFormat.OpenXml/Schema/Bibliography/Sources.cs
@@ -8,7 +8,7 @@ namespace DocumentFormat.OpenXml.Bibliography
     /// <summary>
     /// Defines Sources.
     /// </summary>
-    public partial class Sources : OpenXmlPartRootElement
+    public partial class Sources
     {
         /// <summary>
         /// Sources constructor.

--- a/src/DocumentFormat.OpenXml/Schema/InkML/Ink.cs
+++ b/src/DocumentFormat.OpenXml/Schema/InkML/Ink.cs
@@ -8,7 +8,7 @@ namespace DocumentFormat.OpenXml.InkML
     /// <summary>
     /// Defines Ink.
     /// </summary>
-    public partial class Ink : OpenXmlPartRootElement
+    public partial class Ink
     {
         /// <summary>
         /// Ink constructor.

--- a/src/DocumentFormat.OpenXml/Schema/Office/CustomUI/CustomUI.cs
+++ b/src/DocumentFormat.OpenXml/Schema/Office/CustomUI/CustomUI.cs
@@ -8,7 +8,7 @@ namespace DocumentFormat.OpenXml.Office.CustomUI
     /// <summary>
     /// Defines CustomUI.
     /// </summary>
-    public partial class CustomUI : OpenXmlPartRootElement
+    public partial class CustomUI
     {
         /// <summary>
         /// CustomUI constructor.

--- a/src/DocumentFormat.OpenXml/Schema/Office/Word/MailMergeRecipients.cs
+++ b/src/DocumentFormat.OpenXml/Schema/Office/Word/MailMergeRecipients.cs
@@ -8,7 +8,7 @@ namespace DocumentFormat.OpenXml.Office.Word
     /// <summary>
     /// Defines MailMergeRecipients.
     /// </summary>
-    public partial class MailMergeRecipients : OpenXmlPartRootElement
+    public partial class MailMergeRecipients
     {
         /// <summary>
         /// MailMergeRecipients constructor.

--- a/src/DocumentFormat.OpenXml/Schema/Office2013/Word/Word.cs
+++ b/src/DocumentFormat.OpenXml/Schema/Office2013/Word/Word.cs
@@ -6,7 +6,7 @@ using System.ComponentModel;
 
 namespace DocumentFormat.OpenXml.Office2013.Word
 {
-    public partial class Person : OpenXmlCompositeElement
+    public partial class Person
     {
         /// <summary>
         /// Gets or sets the <see cref="Contact"/> value. It is only available for backwards compatibility

--- a/src/DocumentFormat.OpenXml/Schema/Office2016/Drawing/ChartDrawing/ChartDrawing.cs
+++ b/src/DocumentFormat.OpenXml/Schema/Office2016/Drawing/ChartDrawing/ChartDrawing.cs
@@ -13,7 +13,7 @@ namespace DocumentFormat.OpenXml.Office2016.Drawing.ChartDrawing
     /// </summary>
     [Obsolete("Please use UnsignedIntegerType as this type will be removed in a future version")]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public partial class IdxXsdunsignedInt : OpenXmlLeafTextElement
+    public partial class IdxXsdunsignedInt : TypedOpenXmlLeafTextElement
     {
         /// <summary>
         /// Initializes a new instance of the IdxXsdunsignedInt class.

--- a/src/DocumentFormat.OpenXml/Schema/Wordprocessing/CustomXmlElement.cs
+++ b/src/DocumentFormat.OpenXml/Schema/Wordprocessing/CustomXmlElement.cs
@@ -10,7 +10,7 @@ namespace DocumentFormat.OpenXml.Wordprocessing
     /// <summary>
     /// Defines CustomXmlElement - the base class for the customXml elements.
     /// </summary>
-    public abstract class CustomXmlElement : OpenXmlCompositeElement
+    public abstract class CustomXmlElement : TypedOpenXmlCompositeElement
     {
         /// <summary>
         /// Initializes a new instance of the CustomXmlElement class with the specified child elements.

--- a/src/DocumentFormat.OpenXml/Schema/Wordprocessing/Recipients.cs
+++ b/src/DocumentFormat.OpenXml/Schema/Wordprocessing/Recipients.cs
@@ -8,7 +8,7 @@ namespace DocumentFormat.OpenXml.Wordprocessing
     /// <summary>
     /// Defines Recipients.
     /// </summary>
-    public partial class Recipients : OpenXmlPartRootElement
+    public partial class Recipients
     {
         /// <summary>
         /// Recipients constructor.

--- a/src/DocumentFormat.OpenXml/Schema/Wordprocessing/SdtElement.cs
+++ b/src/DocumentFormat.OpenXml/Schema/Wordprocessing/SdtElement.cs
@@ -6,7 +6,7 @@ namespace DocumentFormat.OpenXml.Wordprocessing
     /// <summary>
     /// Defines SdtElement - the base class for the sdt elements.
     /// </summary>
-    public abstract class SdtElement : OpenXmlCompositeElement
+    public abstract class SdtElement : TypedOpenXmlCompositeElement
     {
         /// <summary>
         /// Initializes a new instance of the SdtElement class.

--- a/src/DocumentFormat.OpenXml/Schema/Wordprocessing/Styles.cs
+++ b/src/DocumentFormat.OpenXml/Schema/Wordprocessing/Styles.cs
@@ -8,7 +8,7 @@ namespace DocumentFormat.OpenXml.Wordprocessing
     /// <summary>
     /// Defines Styles.
     /// </summary>
-    public partial class Styles : OpenXmlPartRootElement
+    public partial class Styles
     {
         /// <summary>
         /// Styles constructor.

--- a/src/DocumentFormat.OpenXml/Typed/TypedOpenXmlCompositeElement.cs
+++ b/src/DocumentFormat.OpenXml/Typed/TypedOpenXmlCompositeElement.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Features;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace DocumentFormat.OpenXml;
+
+/// <summary>
+/// An implementation of <see cref="OpenXmlCompositeElement"/> that provides strongly-typed services.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public abstract class TypedOpenXmlCompositeElement : OpenXmlCompositeElement
+{
+    private protected TypedOpenXmlCompositeElement()
+    {
+    }
+
+    private protected TypedOpenXmlCompositeElement(IEnumerable<OpenXmlElement> elements)
+        : base(elements)
+    {
+    }
+
+    private protected TypedOpenXmlCompositeElement(string outerXml)
+        : base(outerXml)
+    {
+    }
+
+    [Obsolete(UseGenericVersion)]
+    private protected TypedOpenXmlCompositeElement(IEnumerable elements)
+        : base(elements)
+    {
+    }
+
+    private protected override IFeatureCollection CreateFeatures() => TypedOpenXmlElement.GetTypedElementFeatures(this);
+}

--- a/src/DocumentFormat.OpenXml/Typed/TypedOpenXmlElement.cs
+++ b/src/DocumentFormat.OpenXml/Typed/TypedOpenXmlElement.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Features;
+using System.ComponentModel;
+
+namespace DocumentFormat.OpenXml;
+
+/// <summary>
+/// An implementation of <see cref="OpenXmlElement"/> that provides strongly-typed services.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public abstract class TypedOpenXmlElement : OpenXmlElement
+{
+    private protected TypedOpenXmlElement()
+        : base()
+    {
+    }
+
+    private protected TypedOpenXmlElement(string outerXml)
+        : base(outerXml)
+    {
+    }
+
+    private protected override IFeatureCollection CreateFeatures() => GetTypedElementFeatures(this);
+
+    internal static IFeatureCollection GetTypedElementFeatures(OpenXmlElement owner) => new TypedElementFeatures(owner);
+
+    private sealed class TypedElementFeatures : ElementFeatureCollection
+    {
+        public TypedElementFeatures(OpenXmlElement owner)
+            : base(owner)
+        {
+        }
+
+        public override IFeatureCollection Default => TypedFeatures.Shared;
+    }
+}

--- a/src/DocumentFormat.OpenXml/Typed/TypedOpenXmlLeafElement.cs
+++ b/src/DocumentFormat.OpenXml/Typed/TypedOpenXmlLeafElement.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Features;
+using System.ComponentModel;
+
+namespace DocumentFormat.OpenXml;
+
+/// <summary>
+/// An implementation of <see cref="OpenXmlLeafElement"/> that provides strongly-typed services.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public abstract class TypedOpenXmlLeafElement : OpenXmlLeafElement
+{
+    private protected TypedOpenXmlLeafElement()
+    {
+    }
+
+    private protected override IFeatureCollection CreateFeatures() => TypedOpenXmlElement.GetTypedElementFeatures(this);
+}

--- a/src/DocumentFormat.OpenXml/Typed/TypedOpenXmlLeafTextElement.cs
+++ b/src/DocumentFormat.OpenXml/Typed/TypedOpenXmlLeafTextElement.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Features;
+using System.ComponentModel;
+
+namespace DocumentFormat.OpenXml;
+
+/// <summary>
+/// An implementation of <see cref="OpenXmlLeafTextElement"/> that provides strongly-typed services.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public abstract class TypedOpenXmlLeafTextElement : OpenXmlLeafTextElement
+{
+    private protected TypedOpenXmlLeafTextElement()
+    {
+    }
+
+    private protected TypedOpenXmlLeafTextElement(string text)
+        : base(text)
+    {
+    }
+
+    private protected override IFeatureCollection CreateFeatures() => TypedOpenXmlElement.GetTypedElementFeatures(this);
+}

--- a/src/DocumentFormat.OpenXml/Typed/TypedOpenXmlPartRootElement.cs
+++ b/src/DocumentFormat.OpenXml/Typed/TypedOpenXmlPartRootElement.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Features;
+using DocumentFormat.OpenXml.Packaging;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace DocumentFormat.OpenXml;
+
+/// <summary>
+/// An implementation of <see cref="OpenXmlPartRootElement"/> that provides strongly-typed services.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public abstract class TypedOpenXmlPartRootElement : OpenXmlPartRootElement
+{
+    private protected TypedOpenXmlPartRootElement()
+    {
+    }
+
+    private protected TypedOpenXmlPartRootElement(IEnumerable<OpenXmlElement> elements)
+        : base(elements)
+    {
+    }
+
+    private protected TypedOpenXmlPartRootElement(OpenXmlPart part)
+        : base(part)
+    {
+    }
+
+    private protected TypedOpenXmlPartRootElement(string outerXml)
+        : base(outerXml)
+    {
+    }
+
+    private protected override IFeatureCollection CreateFeatures() => TypedOpenXmlElement.GetTypedElementFeatures(this);
+}

--- a/test/DocumentFormat.OpenXml.Benchmarks/ElementMetadataTests.cs
+++ b/test/DocumentFormat.OpenXml.Benchmarks/ElementMetadataTests.cs
@@ -9,13 +9,13 @@ namespace DocumentFormat.OpenXml.Benchmarks
     public class ElementMetadataTests
     {
         private OpenXmlElement _element;
-        private TypedElementMetadataFactoryFeature _provider;
+        private ElementMetadataFactoryFeature _provider;
 
         [GlobalSetup]
         public void Setup()
         {
             _element = new AlternateContent();
-            _provider = new TypedElementMetadataFactoryFeature();
+            _provider = new ElementMetadataFactoryFeature();
         }
 
         [Benchmark]

--- a/test/DocumentFormat.OpenXml.Framework.Tests/ValidatorAttributeTests.cs
+++ b/test/DocumentFormat.OpenXml.Framework.Tests/ValidatorAttributeTests.cs
@@ -90,7 +90,7 @@ namespace DocumentFormat.OpenXml.Framework.Tests
                 });
         }
 
-        private class BaseElement : OpenXmlElement
+        private class BaseElement : TypedOpenXmlElement
         {
             public override bool HasChildren => throw new NotImplementedException();
 

--- a/test/DocumentFormat.OpenXml.Framework.Tests/ValidatorAttributeTests.cs
+++ b/test/DocumentFormat.OpenXml.Framework.Tests/ValidatorAttributeTests.cs
@@ -13,7 +13,7 @@ namespace DocumentFormat.OpenXml.Framework.Tests
         [Fact]
         public void NoValidators()
         {
-            var provider = new TypedElementMetadataFactoryFeature();
+            var provider = new ElementMetadataFactoryFeature();
             var attributes = provider.GetMetadata(new NoValidatorsElement());
             var attribute = Assert.Single(attributes.Attributes);
 
@@ -25,7 +25,7 @@ namespace DocumentFormat.OpenXml.Framework.Tests
         [Fact]
         public void RequiredValidation()
         {
-            var provider = new TypedElementMetadataFactoryFeature();
+            var provider = new ElementMetadataFactoryFeature();
             var attributes = provider.GetMetadata(new ContainsRequiredValidator());
             var attribute = Assert.Single(attributes.Attributes);
 
@@ -38,7 +38,7 @@ namespace DocumentFormat.OpenXml.Framework.Tests
         [Fact]
         public void JustUnion()
         {
-            var provider = new TypedElementMetadataFactoryFeature();
+            var provider = new ElementMetadataFactoryFeature();
             var attributes = provider.GetMetadata(new JustUnionValidator());
             var attribute = Assert.Single(attributes.Attributes);
 

--- a/test/DocumentFormat.OpenXml.Packaging.Tests/PartConstraintRuleTests.cs
+++ b/test/DocumentFormat.OpenXml.Packaging.Tests/PartConstraintRuleTests.cs
@@ -42,6 +42,7 @@ namespace DocumentFormat.OpenXml.Tests
                 .GetTypeInfo()
                 .Assembly
                 .DefinedTypes
+                .Where(t => t != typeof(TypedOpenXmlPart))
                 .Concat(fromFramework)
                 .Distinct()
                 .Where(t => typeof(OpenXmlPart).GetTypeInfo().IsAssignableFrom(t))
@@ -151,6 +152,7 @@ namespace DocumentFormat.OpenXml.Tests
                 .GetTypeInfo()
                 .Assembly
                 .GetTypes()
+                .Where(t => !t.IsAbstract)
                 .Where(typeof(OpenXmlPart).IsAssignableFrom)
                 .Where(a => !_abstractOpenXmlParts.Contains(a))
                 .Select(a => (OpenXmlPart)Activator.CreateInstance(a, true));

--- a/test/DocumentFormat.OpenXml.Tests/MockedOpenXmlElement.cs
+++ b/test/DocumentFormat.OpenXml.Tests/MockedOpenXmlElement.cs
@@ -6,7 +6,7 @@ using System.Xml;
 
 namespace DocumentFormat.OpenXml.Tests
 {
-    internal class MockedOpenXmlElement : OpenXmlElement
+    internal class MockedOpenXmlElement : TypedOpenXmlElement
     {
         public override bool HasChildren => throw new NotImplementedException();
 

--- a/test/DocumentFormat.OpenXml.Tests/Validation/Semantic/AttributeRequiredConditionToValueTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/Validation/Semantic/AttributeRequiredConditionToValueTests.cs
@@ -55,7 +55,7 @@ namespace DocumentFormat.OpenXml.Tests.Validation.Semantic
             Assert.Equal(ValidationErrorType.Semantic, error.ErrorType);
         }
 
-        private class TestElement : OpenXmlCompositeElement
+        private class TestElement : TypedOpenXmlCompositeElement
         {
             public StringValue Required
             {

--- a/test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlElementTest2.cs
+++ b/test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlElementTest2.cs
@@ -196,7 +196,7 @@ namespace DocumentFormat.OpenXml.Tests
             Assert.Null(cell.Child);
         }
 
-        private class WithChildElement : OpenXmlCompositeElement
+        private class WithChildElement : TypedOpenXmlCompositeElement
         {
             public ChildElement Child
             {


### PR DESCRIPTION
This allows for decoupling the strongly-typed infrastructure more easily so that the underlying types don't need to know about the strongly typed information.
