### PR TITLE
Fix stream copy

### DIFF
--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.FlatOpc.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.FlatOpc.cs
@@ -129,12 +129,12 @@ namespace DocumentFormat.OpenXml.Packaging
 
         private static string ToChunkedBase64String(PackagePart part)
         {
-            using (Stream stream = part.GetStream())
-            {
-                var byteArray = new byte[stream.Length];
-                stream.Read(byteArray, 0, byteArray.Length);
-                return ToChunkedBase64String(byteArray);
-            }
+            using var stream = part.GetStream();
+            using var memory = new MemoryStream((int)stream.Length);
+
+            stream.CopyTo(memory);
+
+            return ToChunkedBase64String(memory.ToArray());
         }
 
         private static string ToChunkedBase64String(byte[] byteArray)

--- a/test/DocumentFormat.OpenXml.Tests/Documents/DocumentTests.FlatOpcTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/Documents/DocumentTests.FlatOpcTests.cs
@@ -13,11 +13,7 @@ namespace DocumentFormat.OpenXml.Tests
     public abstract partial class DocumentTests<T>
         where T : OpenXmlPackage
     {
-#if NET6_0_OR_GREATER
-        [Fact(Skip = "Fails on .NET 6+ for unknown reason")]
-#else
         [Fact]
-#endif
         public void CanCreateFlatOpcDocuments1()
         {
             using (var inputStream = GetStream(Path))
@@ -32,11 +28,7 @@ namespace DocumentFormat.OpenXml.Tests
             }
         }
 
-#if NET6_0_OR_GREATER
-        [Fact(Skip = "Fails on .NET 6+ for unknown reason")]
-#else
         [Fact]
-#endif
         public void CanCreateFlatOpcDocuments2()
         {
             using (var inputStream = GetStream(Path))
@@ -53,11 +45,7 @@ namespace DocumentFormat.OpenXml.Tests
             }
         }
 
-#if NET6_0_OR_GREATER
-        [Fact(Skip = "Fails on .NET 6+ for unknown reason")]
-#else
         [Fact]
-#endif
         public void CanCreateFlatOpcDocuments3()
         {
             using (var inputStream = GetStream(Path))
@@ -74,11 +62,7 @@ namespace DocumentFormat.OpenXml.Tests
             }
         }
 
-#if NET6_0_OR_GREATER
-        [Fact(Skip = "Fails on .NET 6+ for unknown reason")]
-#else
         [Fact]
-#endif
         public void CanCreateFlatOpcDocuments4()
         {
             using (var inputStream = GetStream(Path))
@@ -95,11 +79,7 @@ namespace DocumentFormat.OpenXml.Tests
             }
         }
 
-#if NET6_0_OR_GREATER
-        [Fact(Skip = "Fails on .NET 6+ for unknown reason")]
-#else
         [Fact]
-#endif
         public void CanCreateFlatOpcDocuments5()
         {
             using (var inputStream = GetStream(Path))
@@ -114,11 +94,7 @@ namespace DocumentFormat.OpenXml.Tests
             }
         }
 
-#if NET6_0_OR_GREATER
-        [Fact(Skip = "Fails on .NET 6+ for unknown reason")]
-#else
         [Fact]
-#endif
         public void CanCreateFlatOpcDocuments6()
         {
             using (var inputStream = GetStream(Path))
@@ -135,11 +111,7 @@ namespace DocumentFormat.OpenXml.Tests
             }
         }
 
-#if NET6_0_OR_GREATER
-        [Fact(Skip = "Fails on .NET 6+ for unknown reason")]
-#else
         [Fact]
-#endif
         public void CanCreateFlatOpcDocuments7()
         {
             using (var inputStream = GetStream(Path))
@@ -156,11 +128,7 @@ namespace DocumentFormat.OpenXml.Tests
             }
         }
 
-#if NET6_0_OR_GREATER
-        [Fact(Skip = "Fails on .NET 6+ for unknown reason")]
-#else
         [Fact]
-#endif
         public void CanCreateFlatOpcDocuments8()
         {
             using (var inputStream = GetStream(Path))


### PR DESCRIPTION
Using Stream.Read does not guarantee the requested bytes are read. This started failing in a test on .NET 6+, but could potentially fail everywhere this API is used without checking the return value
