### PR TITLE
Remove .NET 5.0 requirement

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,8 +11,7 @@
          - net35:              .NET Framework 3.5
          - net40:              .NET Framework 4.0
          - net46:              .NET Framework 4.6
-         - netstandard1_3:     .NET 6.0 (but running .NET Standard 1.3 build)
-         - net5_0:             .NET 5.0
+         - netstandard1_3:     .NET 7.0 (but running .NET Standard 1.3 build)
          - net6_0:             .NET 6.0
          - net7_0:             .NET 7.0
          - All:                Will build for all platforms
@@ -70,22 +69,12 @@
     <When Condition=" '$(ProjectLoadStyle)' == 'netstandard1_3' ">
       <PropertyGroup>
         <ProductTargetFrameworks>netstandard1.3</ProductTargetFrameworks>
-        <TestTargetFrameworks>net6.0</TestTargetFrameworks>
+        <TestTargetFrameworks>net7.0</TestTargetFrameworks>
         <AssetsTargetFrameworks>netstandard1.3</AssetsTargetFrameworks>
-        <!-- BenchmarkDotNet only supports .NET Standard 2.0-->
-        <LatestTargetFramework>net6.0</LatestTargetFramework>
-        <SamplesFrameworks>net6.0</SamplesFrameworks>
+        <LatestTargetFramework>net7.0</LatestTargetFramework>
+        <SamplesFrameworks>net7.0</SamplesFrameworks>
         <!-- Used to special case some tests for running netstandard1.3 build on .NET Core 2.1 -->
         <DefineConstants>$(DefineConstants);NETSTANDARD1_3_SDK</DefineConstants>
-      </PropertyGroup>
-    </When>
-    <When Condition=" '$(ProjectLoadStyle)' == 'net5_0' ">
-      <PropertyGroup>
-        <ProductTargetFrameworks>net5.0</ProductTargetFrameworks>
-        <TestTargetFrameworks>net5.0</TestTargetFrameworks>
-        <AssetsTargetFrameworks>netstandard1.3</AssetsTargetFrameworks>
-        <LatestTargetFramework>net5.0</LatestTargetFramework>
-        <SamplesFrameworks>net5.0</SamplesFrameworks>
       </PropertyGroup>
     </When>
     <When Condition=" '$(ProjectLoadStyle)' == 'net6_0' ">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -27,16 +27,16 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net452' ">
     <DefineConstants>$(DefineConstants);FEATURE_CONCURRENT_COLLECTIONS;FEATURE_CANCELLATION_TOKEN</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' ">
     <DefineConstants> $(DefineConstants);FEATURE_ARRAY_EMPTY;FEATURE_CONCURRENT_COLLECTIONS;FEATURE_CANCELLATION_TOKEN</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' ">
     <DefineConstants>$(DefineConstants);FEATURE_ABSTRACT_XML_CLOSE;FEATURE_CLOSE;FEATURE_SCHEMA_GENERATOR;FEATURE_SERIALIZATION;FEATURE_SYSTEMEXCEPTION;FEATURE_XML_QUOTECHAR;FEATURE_XML_SCHEMA;FEATURE_CANCELLATION_TOKEN</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <DefineConstants>$(DefineConstants);FEATURE_PACKAGE_FLUSH</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' ">
     <DefineConstants>$(DefineConstants);FEATURE_SPAN</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -24,53 +24,36 @@ stages:
         parameters:
           buildTargets:
             - name: net35
-              runtimes:
-                - 6.0.11
               vmImages: 
-                - image: 'windows-2019'
+                - image: 'windows-latest'
                   name: 'windows'
             - name: net40
-              runtimes:
-                - 6.0.11
               vmImages: 
-                - image: 'windows-2019'
+                - image: 'windows-latest'
                   name: 'windows'
             - name: net46
-              runtimes:
-                - 6.0.11
               vmImages: 
-                - image: 'windows-2019'
+                - image: 'windows-latest'
                   name: 'windows'
             - name: netstandard1_3
-              runtimes:
-                - 6.0.11
               vmImages: 
-                - image: 'windows-2019'
+                - image: 'windows-latest'
                   name: 'windows'
-                - image: 'ubuntu-20.04'
-                  name: 'linux'
-            - name: net5_0
-              runtimes:
-                - 5.0.17
-                - 6.0.11
-              vmImages: 
-                - image: 'windows-2019'
-                  name: 'windows'
-                - image: 'ubuntu-20.04'
+                - image: 'ubuntu-latest'
                   name: 'linux'
             - name: net6_0
               runtimes:
                 - 6.0.11
               vmImages: 
-                - image: 'windows-2019'
+                - image: 'windows-latest'
                   name: 'windows'
-                - image: 'ubuntu-20.04'
+                - image: 'ubuntu-latest'
                   name: 'linux'
             - name: net7_0
               vmImages: 
-                - image: 'windows-2019'
+                - image: 'windows-latest'
                   name: 'windows'
-                - image: 'ubuntu-20.04'
+                - image: 'ubuntu-latest'
                   name: 'linux'
 
   - stage: Sign
@@ -78,7 +61,7 @@ stages:
     - job: Sign
       displayName: Sign assemblies and package
       pool:
-        vmImage: 'windows-2019'
+        vmImage: 'windows-latest'
       steps:
         - template: sign.yml
     dependsOn: Build

--- a/build/build.yml
+++ b/build/build.yml
@@ -24,12 +24,6 @@ jobs:
           packageType: 'sdk'
           useGlobalJson: true
 
-      - task: UseDotNet@2
-        displayName: 'Install .NET 5 SDK'
-        inputs:
-          packageType: 'sdk'
-          version: 5.x 
-
       - ${{ each runtime in buildTarget.runtimes }}:
         - task: UseDotNet@2
           displayName: 'Install .NET Runtime ${{ runtime }}'

--- a/build/package.yml
+++ b/build/package.yml
@@ -4,7 +4,7 @@ jobs:
       ProjectLoadStyle: All
       Configuration: Release
     pool:
-      vmImage: 'windows-2019' # Needed for PEVerify
+      vmImage: 'windows-latest' # Needed for PEVerify
     steps:
     - task: UseDotNet@2
       displayName: 'Install global.json SDK'
@@ -13,10 +13,10 @@ jobs:
         useGlobalJson: true
 
     - task: UseDotNet@2
-      displayName: 'Install .NET 5 SDK for GitVersion'
+      displayName: 'Install .NET 6 SDK for GitVersion'
       inputs:
         packageType: 'sdk'
-        version: 5.x 
+        version: 6.x 
 
     - task: PowerShell@2
       displayName: 'Update version'

--- a/src/DocumentFormat.OpenXml/DocumentFormat.OpenXml.csproj
+++ b/src/DocumentFormat.OpenXml/DocumentFormat.OpenXml.csproj
@@ -85,7 +85,7 @@
       </ItemGroup>
     </When>
 
-    <When Condition=" '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' ">
+    <When Condition=" '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' ">
       <ItemGroup>
         <PackageReference Include="System.IO.Packaging" />
       </ItemGroup>

--- a/test/DocumentFormat.OpenXml.Framework.Tests/DocumentFormat.OpenXml.Framework.Tests.csproj
+++ b/test/DocumentFormat.OpenXml.Framework.Tests/DocumentFormat.OpenXml.Framework.Tests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' ">
     <Compile Remove="HashCodeTests.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
.NET 5.0 is out of support and the new STS is .NET 7.0. We no longer need to build/test on this configuration
