### PR TITLE
Don't change part URIs on cloning (or SaveAs)

### DIFF
--- a/src/DocumentFormat.OpenXml/Features/IPartUriFeature.cs
+++ b/src/DocumentFormat.OpenXml/Features/IPartUriFeature.cs
@@ -7,9 +7,9 @@ namespace DocumentFormat.OpenXml.Packaging;
 
 internal interface IPartUriFeature
 {
-    Uri GetUniquePartUri(string contentType, Uri parentUri, string targetPath, string targetName, string targetExt);
+    Uri CreatePartUri(string contentType, Uri parentUri, string targetPath, string targetName, string targetExt, bool forceUnique = true);
 
-    Uri GetUniquePartUri(string contentType, Uri parentUri, Uri targetUri);
+    Uri EnsureUniquePartUri(string contentType, Uri parentUri, Uri targetUri);
 
     void ReserveUri(string contentType, Uri partUri);
 }

--- a/src/DocumentFormat.OpenXml/Features/IPartUriFeature.cs
+++ b/src/DocumentFormat.OpenXml/Features/IPartUriFeature.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DocumentFormat.OpenXml.Packaging;
+
+internal interface IPartUriFeature
+{
+    Uri GetUniquePartUri(string contentType, Uri parentUri, string targetPath, string targetName, string targetExt);
+
+    Uri GetUniquePartUri(string contentType, Uri parentUri, Uri targetUri);
+
+    void ReserveUri(string contentType, Uri partUri);
+}

--- a/src/DocumentFormat.OpenXml/Features/IPartUriFeature.cs
+++ b/src/DocumentFormat.OpenXml/Features/IPartUriFeature.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace DocumentFormat.OpenXml.Packaging;
+namespace DocumentFormat.OpenXml.Features;
 
 internal interface IPartUriFeature
 {

--- a/src/DocumentFormat.OpenXml/Packaging/CloneExtensions.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/CloneExtensions.cs
@@ -24,10 +24,10 @@ internal static class CloneExtensions
             _package.Features.Set<IPartUriFeature>(this);
         }
 
-        Uri IPartUriFeature.GetUniquePartUri(string contentType, Uri parentUri, string targetPath, string targetName, string targetExt)
-            => _partUri.GetUniquePartUri(contentType, parentUri, targetPath, targetName, targetExt);
+        Uri IPartUriFeature.CreatePartUri(string contentType, Uri parentUri, string targetPath, string targetName, string targetExt, bool forceUnique)
+            => _partUri.CreatePartUri(contentType, parentUri, targetPath, targetName, targetExt, forceUnique: false);
 
-        Uri IPartUriFeature.GetUniquePartUri(string contentType, Uri parentUri, Uri targetUri)
+        Uri IPartUriFeature.EnsureUniquePartUri(string contentType, Uri parentUri, Uri targetUri)
         {
             _partUri.ReserveUri(contentType, targetUri);
             return targetUri;

--- a/src/DocumentFormat.OpenXml/Packaging/CloneExtensions.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/CloneExtensions.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Features;
+using System;
+
+namespace DocumentFormat.OpenXml.Packaging;
+
+internal static class CloneExtensions
+{
+    public static IDisposable EnableCloningFeatures(this OpenXmlPackage package)
+        => new CloningFeatures(package);
+
+    private class CloningFeatures : IPartUriFeature, IDisposable
+    {
+        private readonly OpenXmlPackage _package;
+        private readonly IPartUriFeature _partUri;
+
+        public CloningFeatures(OpenXmlPackage package)
+        {
+            _package = package;
+            _partUri = package.Features.GetRequired<IPartUriFeature>();
+
+            _package.Features.Set<IPartUriFeature>(this);
+        }
+
+        Uri IPartUriFeature.GetUniquePartUri(string contentType, Uri parentUri, string targetPath, string targetName, string targetExt)
+            => _partUri.GetUniquePartUri(contentType, parentUri, targetPath, targetName, targetExt);
+
+        Uri IPartUriFeature.GetUniquePartUri(string contentType, Uri parentUri, Uri targetUri)
+        {
+            _partUri.ReserveUri(contentType, targetUri);
+            return targetUri;
+        }
+
+        void IPartUriFeature.ReserveUri(string contentType, Uri partUri)
+            => _partUri.ReserveUri(contentType, partUri);
+
+        void IDisposable.Dispose()
+        {
+            _package.Features.Set<IPartUriFeature>(_partUri);
+        }
+    }
+}

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
@@ -28,7 +28,6 @@ namespace DocumentFormat.OpenXml.Packaging
         private bool _disposed;
         private Package _package;
         private string _mainPartContentType;
-        private PartUriHelper _partUriHelper = new PartUriHelper();
 
         /// <summary>
         /// Initializes a new instance of the OpenXmlPackage class.
@@ -41,6 +40,8 @@ namespace DocumentFormat.OpenXml.Packaging
             _mainPartContentType = null!;
             OpenSettings = null!;
         }
+
+        private IPartUriFeature UriHelper => Features.GetRequired<IPartUriFeature>();
 
         private protected OpenXmlPackage(in PackageLoader loader, OpenSettings settings)
             : base()
@@ -433,7 +434,7 @@ namespace DocumentFormat.OpenXml.Packaging
         {
             ThrowIfObjectDisposed();
 
-            _partUriHelper.ReserveUri(contentType, partUri);
+            UriHelper.ReserveUri(contentType, partUri);
         }
 
         /// <summary>
@@ -455,7 +456,7 @@ namespace DocumentFormat.OpenXml.Packaging
             // check to avoid name conflict with orphan parts in the packages.
             do
             {
-                partUri = _partUriHelper.GetUniquePartUri(contentType, parentUri, targetPath, targetName, targetExt);
+                partUri = UriHelper.GetUniquePartUri(contentType, parentUri, targetPath, targetName, targetExt);
             }
             while (_package.PartExists(partUri));
 
@@ -479,7 +480,7 @@ namespace DocumentFormat.OpenXml.Packaging
             // check to avoid name conflict with orphan parts in the packages.
             do
             {
-                partUri = _partUriHelper.GetUniquePartUri(contentType, parentUri, targetUri);
+                partUri = UriHelper.GetUniquePartUri(contentType, parentUri, targetUri);
             }
             while (_package.PartExists(partUri));
 
@@ -527,7 +528,6 @@ namespace DocumentFormat.OpenXml.Packaging
                 _package = null!;
                 ChildrenRelationshipParts.Clear();
                 ReferenceRelationshipList.Clear();
-                _partUriHelper = null!;
 
                 closing?.OnChange(this, EventType.Closed);
             }
@@ -1140,7 +1140,8 @@ namespace DocumentFormat.OpenXml.Packaging
                 // thrown within OpenXmlPackage.OpenCore(string, bool) by the
                 //     this._metroPackage = Package.Open(path, ...);
                 // assignment.
-                using (OpenXmlPackage clone = CreateClone(stream))
+                using (var clone = CreateClone(stream))
+                using (clone.EnableCloningFeatures())
                 {
                     foreach (var part in Parts)
                     {
@@ -1207,7 +1208,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <param name="isEditable">In ReadWrite mode. False for Read only mode.</param>
         /// <param name="openSettings">The advanced settings for opening a document.</param>
         /// <returns>The cloned document.</returns>
-        public OpenXmlPackage Clone(string path, bool isEditable, OpenSettings openSettings)
+        public OpenXmlPackage Clone(string path, bool isEditable, OpenSettings? openSettings)
         {
             if (path is null)
             {
@@ -1234,7 +1235,8 @@ namespace DocumentFormat.OpenXml.Packaging
 
                 // Use the same approach as for the streams-based cloning, i.e., close
                 // and reopen the document.
-                using (OpenXmlPackage clone = CreateClone(path))
+                using (var clone = CreateClone(path))
+                using (clone.EnableCloningFeatures())
                 {
                     foreach (var part in Parts)
                     {
@@ -1343,5 +1345,36 @@ namespace DocumentFormat.OpenXml.Packaging
         #endregion Package-based cloning
 
         #endregion saving and cloning
+
+        internal override IFeatureCollection CreatePartFeatures(IFeatureCollection? other = null) => new PackageFeatureCollection(other);
+
+        internal partial class PackageFeatureCollection : IFeatureCollection
+        {
+            private readonly IFeatureCollection? _other;
+
+            public bool IsReadOnly => true;
+
+            public int Revision => 0;
+
+            public PackageFeatureCollection(IFeatureCollection? other)
+            {
+                _other = other;
+            }
+
+            protected virtual IFeatureCollection Default => FeatureCollection.Default;
+
+            [KnownFeature(typeof(IPartUriFeature), typeof(PartUriHelper))]
+            [KnownFeature(typeof(AnnotationsFeature))]
+            [DelegatedFeature(nameof(_other))]
+            [DelegatedFeature(nameof(Default))]
+            private partial T? GetDefault<T>();
+
+            public T? Get<T>() => GetDefault<T>();
+
+            public void Set<TFeature>(TFeature? instance)
+            {
+                throw new NotImplementedException();
+            }
+        }
     }
 }

--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.cs
@@ -456,7 +456,7 @@ namespace DocumentFormat.OpenXml.Packaging
             // check to avoid name conflict with orphan parts in the packages.
             do
             {
-                partUri = UriHelper.GetUniquePartUri(contentType, parentUri, targetPath, targetName, targetExt);
+                partUri = UriHelper.CreatePartUri(contentType, parentUri, targetPath, targetName, targetExt);
             }
             while (_package.PartExists(partUri));
 
@@ -480,7 +480,7 @@ namespace DocumentFormat.OpenXml.Packaging
             // check to avoid name conflict with orphan parts in the packages.
             do
             {
-                partUri = UriHelper.GetUniquePartUri(contentType, parentUri, targetUri);
+                partUri = UriHelper.EnsureUniquePartUri(contentType, parentUri, targetUri);
             }
             while (_package.PartExists(partUri));
 

--- a/src/DocumentFormat.OpenXml/Packaging/PartUriHelper.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/PartUriHelper.cs
@@ -9,7 +9,7 @@ using System.IO.Packaging;
 
 namespace DocumentFormat.OpenXml.Packaging
 {
-    internal class PartUriHelper
+    internal class PartUriHelper : IPartUriFeature
     {
         private readonly Dictionary<string, int> _sequenceNumbers = new Dictionary<string, int>(20, StringComparer.Ordinal);
         private readonly Dictionary<Uri, int> _reservedUri = new Dictionary<Uri, int>();

--- a/src/DocumentFormat.OpenXml/Packaging/PartUriHelper.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/PartUriHelper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using DocumentFormat.OpenXml.Features;
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/DocumentFormat.OpenXml/Packaging/TypedOpenXmlPackage.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/TypedOpenXmlPackage.cs
@@ -23,11 +23,11 @@ public abstract class TypedOpenXmlPackage : OpenXmlPackage
     {
     }
 
-    internal override IFeatureCollection CreatePartFeatures(IFeatureCollection? other = null) => new TypedPartFeatures(other);
+    internal override IFeatureCollection CreatePartFeatures(IFeatureCollection? other = null) => new TypedPackageFeature(other);
 
-    private class TypedPartFeatures : PartContainerFeatureCollection
+    private class TypedPackageFeature : PackageFeatureCollection
     {
-        public TypedPartFeatures(IFeatureCollection? other = null)
+        public TypedPackageFeature(IFeatureCollection? other = null)
             : base(other)
         {
         }

--- a/test/DocumentFormat.OpenXml.Packaging.Tests/PartUriHelperTests.cs
+++ b/test/DocumentFormat.OpenXml.Packaging.Tests/PartUriHelperTests.cs
@@ -17,10 +17,10 @@ namespace DocumentFormat.OpenXml.Packaging.Tests
         {
             var helper = new PartUriHelper();
 
-            var unique = helper.GetUniquePartUri(contentType, new Uri(parentUri, UriKind.Relative), new Uri(targetUri, UriKind.Relative));
+            var unique = helper.EnsureUniquePartUri(contentType, new Uri(parentUri, UriKind.Relative), new Uri(targetUri, UriKind.Relative));
             Assert.Equal(new Uri(expectedOnce, UriKind.Relative), unique);
 
-            var unique2 = helper.GetUniquePartUri(contentType, new Uri(parentUri, UriKind.Relative), new Uri(targetUri, UriKind.Relative));
+            var unique2 = helper.EnsureUniquePartUri(contentType, new Uri(parentUri, UriKind.Relative), new Uri(targetUri, UriKind.Relative));
             Assert.Equal(new Uri(expectedTwice, UriKind.Relative), unique2);
         }
 
@@ -29,21 +29,23 @@ namespace DocumentFormat.OpenXml.Packaging.Tests
         public void GetUniquePartUri5Arg(string contentType, string parentUri, string targetUri, string expectedOnce, string expectedTwice)
         {
             var helper = new PartUriHelper();
-            var unique1 = helper.GetUniquePartUri(
+            var unique1 = helper.CreatePartUri(
                 contentType,
                 PackUriHelper.ResolvePartUri(new Uri(parentUri, UriKind.Relative), new Uri(targetUri, UriKind.Relative)),
                 ".",
                 Path.GetFileNameWithoutExtension(targetUri),
-                Path.GetExtension(targetUri));
+                Path.GetExtension(targetUri),
+                forceUnique: true);
 
             Assert.Equal(new Uri(expectedOnce, UriKind.Relative), unique1);
 
-            var unique2 = helper.GetUniquePartUri(
+            var unique2 = helper.CreatePartUri(
                 contentType,
                 PackUriHelper.ResolvePartUri(new Uri(parentUri, UriKind.Relative), new Uri(targetUri, UriKind.Relative)),
                 ".",
                 Path.GetFileNameWithoutExtension(targetUri),
-                Path.GetExtension(targetUri));
+                Path.GetExtension(targetUri),
+                forceUnique: true);
 
             Assert.Equal(new Uri(expectedTwice, UriKind.Relative), unique2);
         }
@@ -60,7 +62,7 @@ namespace DocumentFormat.OpenXml.Packaging.Tests
 
             helper.ReserveUri(contentType, partUri);
 
-            var unique = helper.GetUniquePartUri(contentType, partUri, ".", Path.GetFileNameWithoutExtension(targetUri), Path.GetExtension(targetUri));
+            var unique = helper.CreatePartUri(contentType, partUri, ".", Path.GetFileNameWithoutExtension(targetUri), Path.GetExtension(targetUri), forceUnique: true);
 
             Assert.Equal(new Uri(expected2, UriKind.Relative), unique);
         }

--- a/test/DocumentFormat.OpenXml.Tests/SaveAndCloneTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/SaveAndCloneTests.cs
@@ -5,6 +5,7 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 using System.IO;
 using System.IO.Packaging;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
@@ -468,6 +469,28 @@ namespace DocumentFormat.OpenXml.Tests
                     PackageAssert.Equal(source, dest);
                 }
             }
+        }
+
+        [Fact]
+        public void CloneRetainsPartNames()
+        {
+            // Arrange
+            using var stream = new MemoryStream();
+            using var presentation = PresentationDocument.Create(stream, PresentationDocumentType.Presentation);
+
+            var presentationPart = presentation.AddPresentationPart();
+            var slidePart = presentationPart.AddNewPart<SlidePart>();
+
+            // Act
+            using var duplicate = (PresentationDocument)presentation.Clone();
+            duplicate.PresentationPart.AddNewPart<SlidePart>();
+            duplicate.Save();
+
+            // Assert
+            Assert.Collection(
+                duplicate.PresentationPart.SlideParts,
+                slide => Assert.Equal("/ppt/slides/slide1.xml", slide.Uri.ToString()),
+                slide => Assert.Equal("/ppt/slides/slide2.xml", slide.Uri.ToString()));
         }
     }
 }


### PR DESCRIPTION
This replaces direct calls to PartUriHelper with an indirection via IPartUriFeature. When cloning, this feature will be replaced so that it doesn't try to get a different URI.

Fixes #1197