### PR TITLE
FlatOpc: avoid unnecessary MemoryStream.ToArray call

### DIFF
--- a/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.FlatOpc.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/OpenXmlPackage.FlatOpc.cs
@@ -132,22 +132,7 @@ namespace DocumentFormat.OpenXml.Packaging
             using var stream = part.GetStream();
             var size = checked((int)stream.Length);
             var buffer = new byte[size];
-
-#if NET7_0_OR_GREATER
             stream.ReadExactly(buffer);
-#else
-            var totalRead = 0;
-            while (totalRead < size)
-            {
-                var bytesRead = stream.Read(buffer, totalRead, size - totalRead);
-                if (bytesRead == 0)
-                {
-                    break;
-                }
-
-                totalRead += bytesRead;
-            }
-#endif
 
             return ToChunkedBase64String(buffer);
         }

--- a/src/common/FrameworkShims.targets
+++ b/src/common/FrameworkShims.targets
@@ -4,6 +4,10 @@
     <IncludeSpanShim Condition=" '$(IncludeSpanShim)' == '' ">true</IncludeSpanShim>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ShimFile Include="$(MSBuildThisFileDirectory)System\IO\StreamReadExtensions.cs" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
     <ShimFile Include="$(MSBuildThisFileDirectory)System\HashCode.cs" />
     <ShimFile Include="$(MSBuildThisFileDirectory)System\Lazy{T}.cs" />

--- a/src/common/System/IO/StreamReadExtensions.cs
+++ b/src/common/System/IO/StreamReadExtensions.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.IO
+{
+    internal static class StreamReadExtensions
+    {
+        public static void ReadExactly(this Stream source, byte[] destination)
+        {
+#if NET7_0_OR_GREATER
+            source.ReadExactly(destination);
+#else
+            var totalRead = 0;
+            while (totalRead < destination.Length)
+            {
+                var bytesRead = source.Read(destination, totalRead, destination.Length - totalRead);
+                if (bytesRead == 0)
+                {
+                    break;
+                }
+
+                totalRead += bytesRead;
+            }
+#endif
+        }
+    }
+}

--- a/src/common/System/IO/StreamReadExtensions.cs
+++ b/src/common/System/IO/StreamReadExtensions.cs
@@ -3,13 +3,11 @@
 
 namespace System.IO
 {
+#if !NET7_0_OR_GREATER
     internal static class StreamReadExtensions
     {
         public static void ReadExactly(this Stream source, byte[] destination)
         {
-#if NET7_0_OR_GREATER
-            source.ReadExactly(destination);
-#else
             var totalRead = 0;
             while (totalRead < destination.Length)
             {
@@ -21,7 +19,7 @@ namespace System.IO
 
                 totalRead += bytesRead;
             }
-#endif
         }
     }
+#endif
 }


### PR DESCRIPTION
There is an unnecessary allocation in PR #1232: it allocates a new byte array via `MemoryStream.ToArray()`.

It's possible to avoid this call and read the data into a byte array directly, as it was done before (but was broken due to the [net6 breaking change](https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams)).