### PR TITLE
Include .NET Core 2.1 runtime for signing task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,6 @@ project.lock.json
 msbuild.binlog
 
 /.idea/
+
+Microsoft.Interop.JavaScript.JSImportGenerator/
+Microsoft.Interop.LibraryImportGenerator/

--- a/build/sign.yml
+++ b/build/sign.yml
@@ -12,6 +12,12 @@ steps:
       gci -r
     workingDirectory: '$(Pipeline.Workspace)/unsigned'
 
+    - task: UseDotNet@2
+      displayName: 'Install .NET Core 2.1 runtime for signing'
+      inputs:
+        packageType: 'runtime'
+        version: 2.1.0
+
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
     displayName: 'OpenXML SDK Assembly ESRP CodeSigning'
     inputs:

--- a/build/sign.yml
+++ b/build/sign.yml
@@ -12,11 +12,11 @@ steps:
       gci -r
     workingDirectory: '$(Pipeline.Workspace)/unsigned'
 
-    - task: UseDotNet@2
-      displayName: 'Install .NET Core 2.1 runtime for signing'
-      inputs:
-        packageType: 'runtime'
-        version: 2.1.0
+  - task: UseDotNet@2
+    displayName: 'Install .NET Core 2.1 runtime for signing'
+    inputs:
+      packageType: 'runtime'
+      version: 2.1.0
 
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
     displayName: 'OpenXML SDK Assembly ESRP CodeSigning'


### PR DESCRIPTION
.NET Core 2.1 is now out of support, but the codesigning task requires it. This change also adds some files we don't need to track to .gitignore