### PR TITLE
feat(actions): add nuget trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
         - completed
 permissions: 
     issues: write
+    id-token: write
 
 jobs: 
     releaseInfo: 
@@ -37,6 +38,8 @@ jobs:
       needs: [releaseInfo]
       if: needs.releaseInfo.outputs.IS_RELEASE == 'true'      
       runs-on: ubuntu-latest
+      permissions:
+        id-token: write
       steps:
         - name: Download and Extract Artifacts from build
           uses: dawidd6/action-download-artifact@v9
@@ -60,9 +63,15 @@ jobs:
               additional-approved-words: ''
               additional-denied-words: ''
 
+        - name: NuGet login
+          uses: NuGet/login@v1
+          id: nuget-login
+          with:
+            user: ${{ secrets.NUGET_USER }}
+            
         - name: Publish NuGet package
           shell: pwsh
           run: |
             foreach($file in (Get-ChildItem "${{ github.workspace }}/artifacts" -Recurse -Include *.nupkg)) {
-                dotnet nuget push $file --api-key "${{ secrets.NUGET_APIKEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+                dotnet nuget push $file --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
             }


### PR DESCRIPTION
#### Motivation

As described in [the official announcement](https://devblogs.microsoft.com/dotnet/enhanced-security-is-here-with-the-new-trust-publishing-on-nuget-org/), the new **Trusted Publishing** feature greatly enhances package publishing security on NuGet.org.

We successfully tested this approach with our own NuGet library:

- [GitHub Actions run example](https://github.com/micheloliveira-com/ReactiveLock/actions/runs/18042183860/workflow)  
- [Corresponding commit](https://github.com/micheloliveira-com/ReactiveLock/blob/a9353d6ddc7cb45f386e816c6ab5ea2837bd1513/.github/workflows/k6-test-multi.yml)

#### Required changes in this repository

> **Recommendation followed from announcement:**  
> For security, always use a GitHub secret like `${{ secrets.NUGET_USER }}` for your NuGet.org username (profile name), **not your email address**.

- Add `secrets.NUGET_USER` to this repository, using the **NuGet.org username (profile name)** of the package owner (
dotnetfoundation in this case).  
- The old `secrets.NUGET_APIKEY` secret can be removed from this repository **and also from the NuGet.org account** if it was only used here.  

#### One-time configuration on NuGet.org

According to the documentation:

1. Sign in to NuGet.org.  
2. Open your user menu (top-right) → **Trusted Publishing** (next to “API Keys”).  
3. Create a policy:  
   - **Package owner:** you or your organization (e.g. `dotnetfoundation`).  
   - **Repository owner:** your GitHub org/user (e.g. `dotnet`).  
   - **Repository name:** repository name (e.g. `Open-XML-SDK`).  
   - **Workflow file:** the YAML file under `.github/workflows/` (e.g. `release.yml`).  
   - **Environment (optional):** specify if your workflow uses GitHub Actions environments.

This setup eliminates the need for long-lived API keys and improves the overall security of the publishing process.