### PR TITLE
Fix ValidIdentifierHelper.IsValidIdentifier accepting @ as valid

### DIFF
--- a/Open-XML-SDK.slnx
+++ b/Open-XML-SDK.slnx
@@ -48,6 +48,7 @@
     <Project Path="test/DocumentFormat.OpenXml.Benchmarks/DocumentFormat.OpenXml.Benchmarks.csproj" />
     <Project Path="test/DocumentFormat.OpenXml.Framework.Features.Tests/DocumentFormat.OpenXml.Framework.Features.Tests.csproj" />
     <Project Path="test/DocumentFormat.OpenXml.Framework.Tests/DocumentFormat.OpenXml.Framework.Tests.csproj" />
+    <Project Path="test/DocumentFormat.OpenXml.Generator.Models.Tests/DocumentFormat.OpenXml.Generator.Models.Tests.csproj" />
     <Project Path="test/DocumentFormat.OpenXml.Linq.Tests/DocumentFormat.OpenXml.Linq.Tests.csproj" />
     <Project Path="test/DocumentFormat.OpenXml.Packaging.Tests/DocumentFormat.OpenXml.Packaging.Tests.csproj" />
     <Project Path="test/DocumentFormat.OpenXml.Tests.Assets/DocumentFormat.OpenXml.Tests.Assets.csproj" />

--- a/gen/DocumentFormat.OpenXml.Generator.Models/DocumentFormat.OpenXml.Generator.Models.csproj
+++ b/gen/DocumentFormat.OpenXml.Generator.Models/DocumentFormat.OpenXml.Generator.Models.csproj
@@ -14,4 +14,7 @@
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="DocumentFormat.OpenXml.Generator.Models.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010061d8931836c82bf25ca6b773dfd6e7b3ab4e43fba60cf4a86347170373415a165ccc40da3da4a52163822db9fa91f15828236d32d6a9fe754859f10d1f8262646c1f3fb6b4348123f14d733db0ff11c3198b7cf56caaebbf14563990446a6c32aff36d5a7097194294c127fe3cdf9f2609daae5f4daf26f8b6227f203d2a8bbf" />
+  </ItemGroup>
 </Project>

--- a/gen/DocumentFormat.OpenXml.Generator.Models/Generators/Linq/ValidIdentifierHelper.cs
+++ b/gen/DocumentFormat.OpenXml.Generator.Models/Generators/Linq/ValidIdentifierHelper.cs
@@ -113,14 +113,9 @@ internal class ValidIdentifierHelper
                 return false;
             }
         }
-        else
+        else if (value.Length < 2)
         {
-            value = value.Substring(1);
-
-            if (value.Length == 0)
-            {
-                return false;
-            }
+            return false;
         }
 
         return true;

--- a/gen/DocumentFormat.OpenXml.Generator.Models/Generators/Linq/ValidIdentifierHelper.cs
+++ b/gen/DocumentFormat.OpenXml.Generator.Models/Generators/Linq/ValidIdentifierHelper.cs
@@ -116,6 +116,11 @@ internal class ValidIdentifierHelper
         else
         {
             value = value.Substring(1);
+
+            if (value.Length == 0)
+            {
+                return false;
+            }
         }
 
         return true;

--- a/test/DocumentFormat.OpenXml.Generator.Models.Tests/DocumentFormat.OpenXml.Generator.Models.Tests.csproj
+++ b/test/DocumentFormat.OpenXml.Generator.Models.Tests/DocumentFormat.OpenXml.Generator.Models.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
+    <IsTestProject>true</IsTestProject>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\gen\DocumentFormat.OpenXml.Generator.Models\DocumentFormat.OpenXml.Generator.Models.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/DocumentFormat.OpenXml.Generator.Models.Tests/ValidIdentifierHelperTests.cs
+++ b/test/DocumentFormat.OpenXml.Generator.Models.Tests/ValidIdentifierHelperTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Generator;
+using Xunit;
+
+namespace DocumentFormat.OpenXml.Generator.Models.Tests;
+
+public class ValidIdentifierHelperTests
+{
+    [Fact]
+    public void NullReturnsFalse()
+    {
+        Assert.False(ValidIdentifierHelper.IsValidIdentifier(null!));
+    }
+
+    [Fact]
+    public void EmptyStringReturnsFalse()
+    {
+        Assert.False(ValidIdentifierHelper.IsValidIdentifier(string.Empty));
+    }
+
+    [Fact]
+    public void LongerThan512ReturnsFalse()
+    {
+        Assert.False(ValidIdentifierHelper.IsValidIdentifier(new string('a', 513)));
+    }
+
+    [Fact]
+    public void Exactly512ReturnsTrue()
+    {
+        Assert.True(ValidIdentifierHelper.IsValidIdentifier(new string('a', 512)));
+    }
+
+    [Fact]
+    public void KeywordReturnsFalse()
+    {
+        Assert.False(ValidIdentifierHelper.IsValidIdentifier("class"));
+    }
+
+    [Fact]
+    public void NonKeywordReturnsTrue()
+    {
+        Assert.True(ValidIdentifierHelper.IsValidIdentifier("myVariable"));
+    }
+
+    [Fact]
+    public void AtPrefixedKeywordReturnsTrue()
+    {
+        Assert.True(ValidIdentifierHelper.IsValidIdentifier("@class"));
+    }
+
+    [Fact]
+    public void AtPrefixedNonKeywordReturnsTrue()
+    {
+        Assert.True(ValidIdentifierHelper.IsValidIdentifier("@myVariable"));
+    }
+
+    [Fact]
+    public void AtAloneReturnsFalse()
+    {
+        // "@" alone is not a valid identifier — after stripping '@', the remaining value is empty
+        Assert.False(ValidIdentifierHelper.IsValidIdentifier("@"));
+    }
+}


### PR DESCRIPTION
The else branch stripped the '@' prefix via Substring(1) but never validated the remaining value, so "@" alone was accepted as a valid identifier. Add an empty check after stripping and add tests.