### PR TITLE
O(n²) loop in OpenXmlElementEqualityComparer.cs

### DIFF
--- a/src/DocumentFormat.OpenXml.Framework/Equality/OpenXmlElementEqualityComparer.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Equality/OpenXmlElementEqualityComparer.cs
@@ -6,7 +6,6 @@ using DocumentFormat.OpenXml.Framework;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace DocumentFormat.OpenXml
 {
@@ -141,14 +140,25 @@ namespace DocumentFormat.OpenXml
 
                 if (x.ExtendedAttributes != null && y.ExtendedAttributes != null)
                 {
-                    if (x.ExtendedAttributes.Count() != y.ExtendedAttributes.Count())
-                    {
-                        return false;
-                    }
+                    using var xe = x.ExtendedAttributes.GetEnumerator();
+                    using var ye = y.ExtendedAttributes.GetEnumerator();
 
-                    for (int i = 0; i < x.ExtendedAttributes.Count(); i++)
+                    while (true)
                     {
-                        if (!x.ExtendedAttributes.ElementAt(i).Equals(y.ExtendedAttributes.ElementAt(i)))
+                        var xMoved = xe.MoveNext();
+                        var yMoved = ye.MoveNext();
+
+                        if (xMoved != yMoved)
+                        {
+                            return false; // different count
+                        }
+
+                        if (!xMoved)
+                        {
+                            break; // both exhausted
+                        }
+
+                        if (!xe.Current.Equals(ye.Current))
                         {
                             return false;
                         }


### PR DESCRIPTION
```
  for (int i = 0; i < x.ExtendedAttributes.Count(); i++)  // Count() re-enumerates each iteration
  {
      if (!x.ExtendedAttributes.ElementAt(i).Equals(y.ExtendedAttributes.ElementAt(i)))  // ElementAt is O(n)
```

Count() is called every loop iteration (re-enumerates), and ElementAt(i) is O(n) on IEnumerable, making the entire  loop O(n³). Fix: materialize to a list/array once, or use SequenceEqual / paired foreach with two enumerators.