### PR TITLE
Potential bug in TryWriteBytes

### DIFF
--- a/src/DocumentFormat.OpenXml.Framework/SimpleTypes/HexBinaryValue.cs
+++ b/src/DocumentFormat.OpenXml.Framework/SimpleTypes/HexBinaryValue.cs
@@ -139,7 +139,7 @@ namespace DocumentFormat.OpenXml
                 return false;
             }
 
-            if (InnerText.Length % 2 != 0 && bytes.Length != InnerText.Length / 2)
+            if (InnerText.Length % 2 != 0 || bytes.Length != InnerText.Length / 2)
             {
                 return false;
             }

--- a/test/DocumentFormat.OpenXml.Tests/SimpleTypes/HexBinaryValueTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/SimpleTypes/HexBinaryValueTests.cs
@@ -83,8 +83,9 @@ namespace DocumentFormat.OpenXml.Tests.SimpleTypes
             // so it falls through and the loop throws on the last Slice.
             var type = new HexBinaryValue("FFF");
             var buffer = new byte[1]; // InnerText.Length / 2 with integer division
+            Span<byte> span = new Span<byte>(buffer)
 
-            Assert.False(type.TryWriteBytes(buffer));
+            Assert.False(type.TryWriteBytes(span));
         }
 
         [Fact]

--- a/test/DocumentFormat.OpenXml.Tests/SimpleTypes/HexBinaryValueTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/SimpleTypes/HexBinaryValueTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using Xunit;
 
 namespace DocumentFormat.OpenXml.Tests.SimpleTypes
@@ -82,11 +81,10 @@ namespace DocumentFormat.OpenXml.Tests.SimpleTypes
             // InnerText.Length / 2 == 1, so a 1-byte buffer "matches" the
             // truncated size. The guard on line 142 uses && instead of ||,
             // so it falls through and the loop throws on the last Slice.
-            var type = new HexBinaryValue("FFF");
+            HexBinaryValue type = new ("FFF");
             var buffer = new byte[1]; // InnerText.Length / 2 with integer division
-            Span<byte> span = new Span<byte>(buffer);
 
-            Assert.False(type.TryWriteBytes(span));
+            Assert.False(type.TryWriteBytes(buffer));
         }
 
         [Fact]

--- a/test/DocumentFormat.OpenXml.Tests/SimpleTypes/HexBinaryValueTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/SimpleTypes/HexBinaryValueTests.cs
@@ -75,6 +75,19 @@ namespace DocumentFormat.OpenXml.Tests.SimpleTypes
         }
 
         [Fact]
+        public void TryWriteBytesWithOddLengthReturnsFalse()
+        {
+            // InnerText has odd length (3 chars). Integer division means
+            // InnerText.Length / 2 == 1, so a 1-byte buffer "matches" the
+            // truncated size. The guard on line 142 uses && instead of ||,
+            // so it falls through and the loop throws on the last Slice.
+            var type = new HexBinaryValue("FFF");
+            var buffer = new byte[1]; // InnerText.Length / 2 with integer division
+
+            Assert.False(type.TryWriteBytes(buffer));
+        }
+
+        [Fact]
         public void CreateFromBytes()
         {
             Assert.Equal(string.Empty, HexBinaryValue.Create().Value);

--- a/test/DocumentFormat.OpenXml.Tests/SimpleTypes/HexBinaryValueTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/SimpleTypes/HexBinaryValueTests.cs
@@ -83,7 +83,7 @@ namespace DocumentFormat.OpenXml.Tests.SimpleTypes
             // so it falls through and the loop throws on the last Slice.
             var type = new HexBinaryValue("FFF");
             var buffer = new byte[1]; // InnerText.Length / 2 with integer division
-            Span<byte> span = new Span<byte>(buffer)
+            Span<byte> span = new Span<byte>(buffer);
 
             Assert.False(type.TryWriteBytes(span));
         }

--- a/test/DocumentFormat.OpenXml.Tests/SimpleTypes/HexBinaryValueTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/SimpleTypes/HexBinaryValueTests.cs
@@ -81,7 +81,7 @@ namespace DocumentFormat.OpenXml.Tests.SimpleTypes
             // InnerText.Length / 2 == 1, so a 1-byte buffer "matches" the
             // truncated size. The guard on line 142 uses && instead of ||,
             // so it falls through and the loop throws on the last Slice.
-            HexBinaryValue type = new ("FFF");
+            HexBinaryValue type = new("FFF");
             var buffer = new byte[1]; // InnerText.Length / 2 with integer division
 
             Assert.False(type.TryWriteBytes(buffer));

--- a/test/DocumentFormat.OpenXml.Tests/SimpleTypes/HexBinaryValueTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/SimpleTypes/HexBinaryValueTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Xunit;
 
 namespace DocumentFormat.OpenXml.Tests.SimpleTypes


### PR DESCRIPTION
InnerText has odd length (3 chars). Integer division means InnerText.Length / 2 == 1, so a 1-byte buffer "matches" the truncated size. The guard on line 142 uses && instead of ||, so it falls through and the loop throws on the last Slice.