### PR TITLE
make line endings in generated files oncistent with git settings

### DIFF
--- a/gen/DocumentFormat.OpenXml.Generator.Models/Generators/Linq/LinqGeneratorExtensions.cs
+++ b/gen/DocumentFormat.OpenXml.Generator.Models/Generators/Linq/LinqGeneratorExtensions.cs
@@ -60,7 +60,7 @@ public static class LinqGeneratorExtensions
 
             var className = GetClassName(prefix);
 
-            using var output = new StringWriter();
+            using var output = new StringWriter() { NewLine = "\n" };
 
             GenerateClassFilePreamble(output);
             GenerateClass(output, prefix, namespaceName, classFieldInfos, fieldInfos);

--- a/gen/DocumentFormat.OpenXml.Generator/NamespaceGeneration/NamespaceGeneratorExtensions.cs
+++ b/gen/DocumentFormat.OpenXml.Generator/NamespaceGeneration/NamespaceGeneratorExtensions.cs
@@ -11,7 +11,7 @@ internal static class NamespaceGeneratorExtensions
 {
     public static string Generate(this IEnumerable<NamespaceInfo> namespaces)
     {
-        var sb = new StringWriter();
+        var sb = new StringWriter() { NewLine = "\n" };
         var writer = new IndentedTextWriter(sb);
 
         writer.WriteFileHeader();

--- a/gen/DocumentFormat.OpenXml.Generator/PackageGeneratorExtensions.cs
+++ b/gen/DocumentFormat.OpenXml.Generator/PackageGeneratorExtensions.cs
@@ -80,7 +80,7 @@ internal static class PackageGeneratorExtensions
             var features = builder.Build(gContext).ToList();
 
             var sb = new StringBuilder();
-            var writer = new IndentedTextWriter(new StringWriter(sb));
+            var writer = new IndentedTextWriter(new StringWriter(sb) { NewLine = "\n" });
 
             foreach (var feature in features)
             {

--- a/gen/DocumentFormat.OpenXml.Generator/PartGenerator.cs
+++ b/gen/DocumentFormat.OpenXml.Generator/PartGenerator.cs
@@ -19,7 +19,7 @@ public static class PartGenerator
         }
 
         var sb = new StringBuilder();
-        var sw = new StringWriter(sb);
+        var sw = new StringWriter(sb) { NewLine = "\n" };
         var writer = new IndentedTextWriter(sw);
 
         foreach (var part in openXml.DataSource.Parts.Concat(openXml.DataSource.Packages))

--- a/gen/DocumentFormat.OpenXml.Generator/SchemaGenerator.cs
+++ b/gen/DocumentFormat.OpenXml.Generator/SchemaGenerator.cs
@@ -14,7 +14,7 @@ public static class SchemaGenerator
 {
     public static void WriteSchemaFiles(SourceProductionContext context, OpenXmlGeneratorServices openXml, SchemaNamespace namespaces)
     {
-        var sw = new StringWriter();
+        var sw = new StringWriter() { NewLine = "\n" };
         var writer = new IndentedTextWriter(sw);
 
         writer.WriteFileHeader();


### PR DESCRIPTION
This ensures generated .g.cs files always have LF endings, matching the git-normalized content regardless of OS.


prevents this 
<img width="1621" height="713" alt="Screenshot 2026-03-29 170248" src="https://github.com/user-attachments/assets/26297b78-6f80-4e72-9a50-1be07561e216" />
