### PR TITLE
Add forward only api with better performance 

### DIFF
--- a/docs/ForwardOnlyWriting.md
+++ b/docs/ForwardOnlyWriting.md
@@ -1,0 +1,196 @@
+# Forward-Only Document Writing
+
+> **Experimental**: This API is marked with `OOXML0005` and is subject to change.
+
+The `OpenXmlPackageWriter` enables forward-only creation of OpenXML documents (.docx, .xlsx, .pptx) directly to any writable stream, including non-seekable streams. This eliminates the need for a temporary `MemoryStream` that the standard `Create` methods require.
+
+## When to Use
+
+- Writing documents to HTTP response streams (`HttpResponse.Body`)
+- Writing to network streams or cloud storage upload streams
+- Generating large documents where you want to avoid buffering the entire package in memory
+- Any scenario where the target stream is not seekable
+
+## Quick Start
+
+### Word Document
+
+```csharp
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+using var writer = WordprocessingDocument.CreateForwardOnly(
+    outputStream, WordprocessingDocumentType.Document, leaveOpen: true);
+
+writer.WritePart(
+    new Uri("/word/document.xml", UriKind.Relative),
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml",
+    new Document(
+        new Body(
+            new Paragraph(
+                new Run(new Text("Hello, forward-only world!"))))));
+```
+
+### Spreadsheet
+
+```csharp
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+
+using var writer = SpreadsheetDocument.CreateForwardOnly(
+    outputStream, SpreadsheetDocumentType.Workbook);
+
+// Write the worksheet first
+writer.WritePart(
+    new Uri("/xl/worksheets/sheet1.xml", UriKind.Relative),
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml",
+    new Worksheet(new SheetData(
+        new Row(new Cell { CellValue = new CellValue("42"), DataType = CellValues.Number }))));
+
+// Write the workbook, referencing the worksheet
+writer.WritePart(
+    new Uri("/xl/workbook.xml", UriKind.Relative),
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml",
+    new Workbook(new Sheets(
+        new Sheet { Name = "Sheet1", SheetId = 1, Id = "rId1" })),
+    relationships: new[]
+    {
+        new PartRelationship(
+            new Uri("worksheets/sheet1.xml", UriKind.Relative),
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet",
+            id: "rId1"),
+    });
+```
+
+## Core API
+
+### OpenXmlPackageWriter
+
+The main writer class. Created via the constructor or typed factory methods.
+
+```csharp
+// Direct construction
+var writer = new OpenXmlPackageWriter(stream, leaveOpen: false);
+
+// Typed factory methods (pre-register main part relationship)
+var writer = WordprocessingDocument.CreateForwardOnly(stream, type, leaveOpen);
+var writer = SpreadsheetDocument.CreateForwardOnly(stream, type, leaveOpen);
+var writer = PresentationDocument.CreateForwardOnly(stream, type, leaveOpen);
+```
+
+**Methods:**
+
+| Method | Description |
+|--------|-------------|
+| `AddRelationship(partUri, relationshipType, id?)` | Adds a package-level relationship (written to `_rels/.rels`) |
+| `CreatePart(partUri, contentType)` | Creates a part and returns an `OpenXmlPartEntry` for streaming writes |
+| `WritePart(partUri, contentType, rootElement, relationships?)` | One-shot: writes an element tree as a complete part |
+| `Finish()` | Finalizes the package (writes content types and relationships) |
+| `Dispose()` / `DisposeAsync()` | Calls `Finish()` if needed, then closes the underlying ZIP |
+
+### OpenXmlPartEntry
+
+Returned by `CreatePart`. Provides access to the part's output stream for streaming XML writing.
+
+```csharp
+using var entry = writer.CreatePart(partUri, contentType);
+
+// Add part-level relationships
+entry.AddRelationship(targetUri, relationshipType, targetMode, id);
+
+// Write XML content using OpenXmlWriter
+using var xmlWriter = OpenXmlWriter.Create(entry.Stream);
+xmlWriter.WriteStartDocument();
+xmlWriter.WriteStartElement(new Worksheet());
+xmlWriter.WriteStartElement(new SheetData());
+foreach (var row in GetRows())
+{
+    xmlWriter.WriteElement(row);
+}
+xmlWriter.WriteEndElement(); // SheetData
+xmlWriter.WriteEndElement(); // Worksheet
+```
+
+### PartRelationship
+
+Used with `WritePart` to declare part-level relationships inline.
+
+```csharp
+new PartRelationship(
+    targetUri: new Uri("styles.xml", UriKind.Relative),
+    relationshipType: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles",
+    targetMode: TargetMode.Internal, // default
+    id: "rId1") // optional, auto-generated if null
+```
+
+## Key Behaviors
+
+- **Only one part can be open at a time.** Creating a new part auto-closes the previous one.
+- **Parts cannot be modified after writing.** This is a forward-only writer.
+- **Content types and relationships are written last** (during `Finish()`/`Dispose()`), so they capture all parts.
+- **The stream does not need to be seekable.** The writer uses `ZipArchive` in create mode.
+- **`Dispose()` finalizes the package.** You don't need to call `Finish()` explicitly.
+
+## Comparison with Standard API
+
+| | Standard `Create` | `CreateForwardOnly` |
+|---|---|---|
+| Requires seekable stream | Yes | No |
+| Requires `MemoryStream` | Often | Never |
+| Can modify parts after creation | Yes | No |
+| Can read parts | Yes | No |
+| DOM support | Full | Write-only |
+| `OpenXmlWriter` support | Yes | Yes |
+| Memory usage for large docs | Higher | Lower |
+
+## Benchmarks
+
+Measured on .NET 10.0 with BenchmarkDotNet (`MemoryDiagnoser`). Each scenario compares the standard `Create` API (backed by `System.IO.Packaging`) against `CreateForwardOnly` (backed by `ZipArchive`).
+
+### Word
+
+| Scenario | Approach | Mean | Allocated | Alloc vs Standard |
+|---|---|---:|---:|---:|
+| Simple (1 paragraph) | Standard | 23.29 us | 53.56 KB | 1.00 |
+| | ForwardOnly | 28.73 us | 26.99 KB | **0.50** |
+| Medium (20 paragraphs) | Standard | 51.48 us | 80.98 KB | 1.00 |
+| | ForwardOnly | 52.56 us | 52.87 KB | **0.65** |
+| Complex (100 paragraphs + styles) | Standard | 339.88 us | 366.91 KB | 1.00 |
+| | ForwardOnly | 286.56 us | 287.82 KB | **0.78** |
+
+### Spreadsheet
+
+| Scenario | Approach | Mean | Allocated | Alloc vs Standard |
+|---|---|---:|---:|---:|
+| Simple (1 sheet, 1 row) | Standard | 70.66 us | 84.23 KB | 1.00 |
+| | ForwardOnly | 49.94 us | 45.84 KB | **0.54** |
+| Medium (100 rows x 10 cols) | Standard | 724.24 us | 809.52 KB | 1.00 |
+| | ForwardOnly | 642.55 us | 681.31 KB | **0.84** |
+| Complex (3 sheets, 500x10 each) | Standard | 17,602 us | 10,946 KB | 1.00 |
+| | ForwardOnly | 9,934 us | 9,755 KB | **0.89** |
+
+### Presentation
+
+| Scenario | Approach | Mean | Allocated | Alloc vs Standard |
+|---|---|---:|---:|---:|
+| Simple (1 slide) | Standard | 67.68 us | 84.23 KB | 1.00 |
+| | ForwardOnly | 48.75 us | 45.61 KB | **0.54** |
+| Medium (10 slides) | Standard | 251.36 us | 283.25 KB | 1.00 |
+| | ForwardOnly | 164.86 us | 160.09 KB | **0.57** |
+| Complex (30 slides, 5 shapes each) | Standard | 1,373 us | 1,207 KB | 1.00 |
+| | ForwardOnly | 998 us | 829 KB | **0.69** |
+
+### Summary
+
+- **Memory**: ForwardOnly allocates 50-89% of what Standard does. Biggest wins on simple documents where `System.IO.Packaging` overhead dominates.
+- **Speed**: ForwardOnly is faster at scale -- up to 1.77x on large spreadsheets (17.6ms vs 9.9ms). Simple Word documents are roughly equivalent in speed.
+- **GC pressure**: ForwardOnly consistently triggers fewer Gen0/Gen1 collections and avoids Gen2 collections entirely (Standard hit Gen2 on the complex spreadsheet benchmark).
+
+Run the benchmarks yourself with:
+```
+dotnet run --project test/DocumentFormat.OpenXml.Benchmarks -c Release -- --filter "*ForwardOnly*"
+```
+
+## Platform Support
+
+Available on `netstandard2.0` and .NET 6+. Not available on .NET Framework 3.5, 4.0, or 4.6.

--- a/src/DocumentFormat.OpenXml.Framework/ExperimentalApis.cs
+++ b/src/DocumentFormat.OpenXml.Framework/ExperimentalApis.cs
@@ -12,4 +12,5 @@ internal static class ExperimentalApis
     public const string PackageBuilder = "OOXML0002";
     public const string AOT = "OOXML0003";
     public const string Framework = "OOXML0004";
+    public const string ForwardOnly = "OOXML0005";
 }

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/OpenXmlPackageWriter.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/OpenXmlPackageWriter.cs
@@ -1,0 +1,290 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NETSTANDARD || NETCOREAPP
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.IO.Packaging;
+#if NET6_0_OR_GREATER
+using System.Threading.Tasks;
+#endif
+using System.Xml;
+
+namespace DocumentFormat.OpenXml.Packaging;
+
+/// <summary>
+/// Writes an OPC package in forward-only mode to any writable stream,
+/// including non-seekable streams. Produces valid .docx/.xlsx/.pptx files
+/// without requiring a temporary <see cref="MemoryStream"/>.
+/// </summary>
+[Experimental(ExperimentalApis.ForwardOnly, UrlFormat = ExperimentalApis.UrlFormat)]
+[Obsolete(ExperimentalApis.Message, DiagnosticId = ExperimentalApis.ForwardOnly, UrlFormat = ExperimentalApis.UrlFormat)]
+public sealed class OpenXmlPackageWriter :
+#if NET6_0_OR_GREATER
+    IAsyncDisposable,
+#endif
+    IDisposable
+{
+    private readonly ZipArchive _archive;
+    private readonly List<(Uri PartUri, string ContentType)> _contentTypes = new();
+    private readonly List<(string Id, Uri TargetUri, string RelationshipType, TargetMode TargetMode)> _packageRelationships = new();
+    private readonly HashSet<string> _writtenParts = new(StringComparer.OrdinalIgnoreCase);
+    private OpenXmlPartEntry? _currentEntry;
+    private bool _finished;
+    private int _nextRelId;
+
+    /// <summary>
+    /// Creates a writer targeting the given stream.
+    /// The stream need not be seekable.
+    /// </summary>
+    /// <param name="stream">Target stream (write-only is sufficient).</param>
+    /// <param name="leaveOpen">Whether to leave the stream open after disposal.</param>
+    public OpenXmlPackageWriter(Stream stream, bool leaveOpen = false)
+    {
+        if (stream is null)
+        {
+            throw new ArgumentNullException(nameof(stream));
+        }
+
+        _archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen);
+    }
+
+    /// <summary>
+    /// Adds a package-level relationship (written to _rels/.rels on finalization).
+    /// </summary>
+    /// <param name="partUri">Target part URI (e.g., "/word/document.xml").</param>
+    /// <param name="relationshipType">The OPC relationship type URI.</param>
+    /// <param name="id">Optional explicit relationship ID. Auto-generated if null.</param>
+    /// <returns>The assigned relationship ID.</returns>
+    public string AddRelationship(Uri partUri, string relationshipType, string? id = null)
+    {
+        ThrowIfFinished();
+
+        if (partUri is null)
+        {
+            throw new ArgumentNullException(nameof(partUri));
+        }
+
+        if (relationshipType is null)
+        {
+            throw new ArgumentNullException(nameof(relationshipType));
+        }
+
+        id ??= "rId" + (++_nextRelId).ToString(CultureInfo.InvariantCulture);
+
+        _packageRelationships.Add((id, partUri, relationshipType, TargetMode.Internal));
+        return id;
+    }
+
+    /// <summary>
+    /// Creates a new part entry in the package and returns a context object
+    /// for writing content and part-level relationships.
+    /// Only one part may be open at a time. The previous part is
+    /// automatically closed when a new part is created or when the writer is disposed.
+    /// </summary>
+    /// <param name="partUri">The URI for this part (e.g., "/word/document.xml").</param>
+    /// <param name="contentType">The MIME content type.</param>
+    /// <returns>A part context for writing content and relationships.</returns>
+    public OpenXmlPartEntry CreatePart(Uri partUri, string contentType)
+    {
+        ThrowIfFinished();
+
+        if (partUri is null)
+        {
+            throw new ArgumentNullException(nameof(partUri));
+        }
+
+        if (contentType is null)
+        {
+            throw new ArgumentNullException(nameof(contentType));
+        }
+
+        // Close previous entry if still open
+        _currentEntry?.Dispose();
+
+        var entryPath = partUri.OriginalString.TrimStart('/');
+
+        if (!_writtenParts.Add(entryPath))
+        {
+            throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "A part with URI '{0}' has already been written.", partUri));
+        }
+
+        _contentTypes.Add((partUri, contentType));
+
+        var zipEntry = _archive.CreateEntry(entryPath, CompressionLevel.Optimal);
+        var stream = zipEntry.Open();
+
+        _currentEntry = new OpenXmlPartEntry(_archive, partUri, stream);
+        return _currentEntry;
+    }
+
+    /// <summary>
+    /// Creates a new part, writes the given element tree as its content,
+    /// and closes the part in one call.
+    /// </summary>
+    /// <param name="partUri">The URI for this part.</param>
+    /// <param name="contentType">The MIME content type.</param>
+    /// <param name="rootElement">The root element to serialize.</param>
+    /// <param name="relationships">Optional part-level relationships.</param>
+    public void WritePart(Uri partUri, string contentType, OpenXmlElement rootElement, IEnumerable<PartRelationship>? relationships = null)
+    {
+        if (rootElement is null)
+        {
+            throw new ArgumentNullException(nameof(rootElement));
+        }
+
+        using var entry = CreatePart(partUri, contentType);
+
+        if (relationships is not null)
+        {
+            foreach (var rel in relationships)
+            {
+                entry.AddRelationship(rel.TargetUri, rel.RelationshipType, rel.TargetMode, rel.Id);
+            }
+        }
+
+        using var xmlWriter = XmlWriter.Create(entry.Stream, new XmlWriterSettings
+        {
+            CloseOutput = false,
+            Encoding = System.Text.Encoding.UTF8,
+        });
+
+        rootElement.WriteTo(xmlWriter);
+    }
+
+    /// <summary>
+    /// Finalizes the package by writing _rels/.rels and [Content_Types].xml.
+    /// Called automatically by Dispose, but can be called explicitly.
+    /// After this call, no more parts can be added.
+    /// </summary>
+    public void Finish()
+    {
+        if (_finished)
+        {
+            return;
+        }
+
+        _finished = true;
+
+        // Close any open part entry
+        _currentEntry?.Dispose();
+        _currentEntry = null;
+
+        WritePackageRelationships();
+        WriteContentTypes();
+    }
+
+    /// <summary>
+    /// Disposes the writer, finalizing the package if not already done.
+    /// </summary>
+    public void Dispose()
+    {
+        Finish();
+        _archive.Dispose();
+    }
+
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Asynchronously disposes the writer, finalizing the package if not already done.
+    /// </summary>
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return default;
+    }
+#endif
+
+    private void WritePackageRelationships()
+    {
+        if (_packageRelationships.Count == 0)
+        {
+            return;
+        }
+
+        var entry = _archive.CreateEntry("_rels/.rels", CompressionLevel.Optimal);
+        using var stream = entry.Open();
+        WriteRelationshipsXml(stream, _packageRelationships);
+    }
+
+    internal static void WriteRelationshipsXml(Stream stream, List<(string Id, Uri TargetUri, string RelationshipType, TargetMode TargetMode)> relationships)
+    {
+        using var writer = XmlWriter.Create(stream, new XmlWriterSettings
+        {
+            CloseOutput = false,
+            Encoding = System.Text.Encoding.UTF8,
+        });
+
+        writer.WriteStartDocument();
+        writer.WriteStartElement("Relationships", "http://schemas.openxmlformats.org/package/2006/relationships");
+
+        foreach (var rel in relationships)
+        {
+            writer.WriteStartElement("Relationship");
+            writer.WriteAttributeString("Id", rel.Id);
+            writer.WriteAttributeString("Type", rel.RelationshipType);
+            writer.WriteAttributeString("Target", rel.TargetUri.OriginalString);
+
+            if (rel.TargetMode == TargetMode.External)
+            {
+                writer.WriteAttributeString("TargetMode", "External");
+            }
+
+            writer.WriteEndElement();
+        }
+
+        writer.WriteEndElement();
+    }
+
+    private void WriteContentTypes()
+    {
+        var entry = _archive.CreateEntry("[Content_Types].xml", CompressionLevel.Optimal);
+        using var stream = entry.Open();
+        using var writer = XmlWriter.Create(stream, new XmlWriterSettings
+        {
+            CloseOutput = false,
+            Encoding = System.Text.Encoding.UTF8,
+        });
+
+        writer.WriteStartDocument();
+        writer.WriteStartElement("Types", "http://schemas.openxmlformats.org/package/2006/content-types");
+
+        // Write default for .rels files
+        writer.WriteStartElement("Default");
+        writer.WriteAttributeString("Extension", "rels");
+        writer.WriteAttributeString("ContentType", "application/vnd.openxmlformats-package.relationships+xml");
+        writer.WriteEndElement();
+
+        // Write default for .xml files
+        writer.WriteStartElement("Default");
+        writer.WriteAttributeString("Extension", "xml");
+        writer.WriteAttributeString("ContentType", "application/xml");
+        writer.WriteEndElement();
+
+        // Write overrides for each part
+        foreach (var ct in _contentTypes)
+        {
+            writer.WriteStartElement("Override");
+            var partName = ct.PartUri.OriginalString;
+            writer.WriteAttributeString("PartName", partName.Length > 0 && partName[0] == '/' ? partName : "/" + partName);
+            writer.WriteAttributeString("ContentType", ct.ContentType);
+            writer.WriteEndElement();
+        }
+
+        writer.WriteEndElement();
+    }
+
+    private void ThrowIfFinished()
+    {
+        if (_finished)
+        {
+            throw new InvalidOperationException("The package writer has already been finalized. No more parts can be added.");
+        }
+    }
+}
+
+#endif

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/OpenXmlPartEntry.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/OpenXmlPartEntry.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NETSTANDARD || NETCOREAPP
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.IO.Compression;
+using System.IO.Packaging;
+using System.Xml;
+
+namespace DocumentFormat.OpenXml.Packaging;
+
+/// <summary>
+/// Represents a part being written in forward-only mode.
+/// Provides access to the part's output stream and the ability to add part-level relationships.
+/// </summary>
+[Experimental(ExperimentalApis.ForwardOnly, UrlFormat = ExperimentalApis.UrlFormat)]
+[Obsolete(ExperimentalApis.Message, DiagnosticId = ExperimentalApis.ForwardOnly, UrlFormat = ExperimentalApis.UrlFormat)]
+public sealed class OpenXmlPartEntry : IDisposable
+{
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2213:Disposable fields should be disposed", Justification = "Archive is owned by OpenXmlPackageWriter")]
+    private readonly ZipArchive _archive;
+    private readonly Uri _partUri;
+    private readonly Stream _stream;
+    private List<(string Id, Uri TargetUri, string RelationshipType, TargetMode TargetMode)>? _relationships;
+    private bool _disposed;
+    private int _nextRelId;
+
+    internal OpenXmlPartEntry(ZipArchive archive, Uri partUri, Stream stream)
+    {
+        _archive = archive;
+        _partUri = partUri;
+        _stream = stream;
+    }
+
+    /// <summary>
+    /// Gets the writable stream for this part's ZIP entry.
+    /// Write XML content to this stream using <see cref="OpenXmlWriter"/> or <see cref="XmlWriter"/>.
+    /// </summary>
+    public Stream Stream
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return _stream;
+        }
+    }
+
+    /// <summary>
+    /// Adds a relationship for this part.
+    /// </summary>
+    /// <param name="targetUri">Target URI (relative or absolute).</param>
+    /// <param name="relationshipType">The relationship type.</param>
+    /// <param name="targetMode">Internal or External.</param>
+    /// <param name="id">Optional explicit ID. Auto-generated if null.</param>
+    /// <returns>The assigned relationship ID.</returns>
+    public string AddRelationship(Uri targetUri, string relationshipType, TargetMode targetMode = TargetMode.Internal, string? id = null)
+    {
+        ThrowIfDisposed();
+
+        if (targetUri is null)
+        {
+            throw new ArgumentNullException(nameof(targetUri));
+        }
+
+        if (relationshipType is null)
+        {
+            throw new ArgumentNullException(nameof(relationshipType));
+        }
+
+        _relationships ??= new List<(string, Uri, string, TargetMode)>();
+
+        id ??= "rId" + (++_nextRelId).ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+        _relationships.Add((id, targetUri, relationshipType, targetMode));
+        return id;
+    }
+
+    /// <summary>
+    /// Closes the part stream and writes the part's .rels file if any relationships were added.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _stream.Dispose();
+
+        if (_relationships is not null && _relationships.Count > 0)
+        {
+            WriteRelationships();
+        }
+    }
+
+    private void WriteRelationships()
+    {
+        var partPath = _partUri.OriginalString.TrimStart('/');
+        var lastSlash = partPath.LastIndexOf('/');
+        string relsPath;
+
+        if (lastSlash >= 0)
+        {
+            var dir = partPath.Substring(0, lastSlash + 1);
+            var file = partPath.Substring(lastSlash + 1);
+            relsPath = string.Concat(dir, "_rels/", file, ".rels");
+        }
+        else
+        {
+            relsPath = string.Concat("_rels/", partPath, ".rels");
+        }
+
+        var relsEntry = _archive.CreateEntry(relsPath, CompressionLevel.Optimal);
+        using var relsStream = relsEntry.Open();
+        OpenXmlPackageWriter.WriteRelationshipsXml(relsStream, _relationships!);
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(OpenXmlPartEntry));
+        }
+    }
+}
+
+#endif

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/PartRelationship.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/PartRelationship.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NETSTANDARD || NETCOREAPP
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO.Packaging;
+
+namespace DocumentFormat.OpenXml.Packaging;
+
+/// <summary>
+/// Describes a relationship to be added to a part when using <see cref="OpenXmlPackageWriter.WritePart"/>.
+/// </summary>
+[Experimental(ExperimentalApis.ForwardOnly, UrlFormat = ExperimentalApis.UrlFormat)]
+[Obsolete(ExperimentalApis.Message, DiagnosticId = ExperimentalApis.ForwardOnly, UrlFormat = ExperimentalApis.UrlFormat)]
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "Data carrier struct not intended for comparison")]
+public readonly struct PartRelationship
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PartRelationship"/> struct.
+    /// </summary>
+    /// <param name="targetUri">The target URI.</param>
+    /// <param name="relationshipType">The relationship type.</param>
+    /// <param name="targetMode">The target mode (Internal or External).</param>
+    /// <param name="id">Optional explicit relationship ID.</param>
+    public PartRelationship(Uri targetUri, string relationshipType, TargetMode targetMode = TargetMode.Internal, string? id = null)
+    {
+        TargetUri = targetUri;
+        RelationshipType = relationshipType;
+        TargetMode = targetMode;
+        Id = id;
+    }
+
+    /// <summary>
+    /// Gets the target URI.
+    /// </summary>
+    public Uri TargetUri { get; }
+
+    /// <summary>
+    /// Gets the relationship type.
+    /// </summary>
+    public string RelationshipType { get; }
+
+    /// <summary>
+    /// Gets the target mode.
+    /// </summary>
+    public TargetMode TargetMode { get; }
+
+    /// <summary>
+    /// Gets the optional explicit relationship ID.
+    /// </summary>
+    public string? Id { get; }
+}
+
+#endif

--- a/src/DocumentFormat.OpenXml.Framework/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/DocumentFormat.OpenXml.Framework/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 [OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPackageWriter
 [OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPackageWriter.OpenXmlPackageWriter(System.IO.Stream! stream, bool leaveOpen = false) -> void
 [OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPackageWriter.AddRelationship(System.Uri! partUri, string! relationshipType, string? id = null) -> string!
@@ -18,4 +18,3 @@
 [OOXML0005]DocumentFormat.OpenXml.Packaging.PartRelationship.RelationshipType.get -> string!
 [OOXML0005]DocumentFormat.OpenXml.Packaging.PartRelationship.TargetMode.get -> System.IO.Packaging.TargetMode
 [OOXML0005]DocumentFormat.OpenXml.Packaging.PartRelationship.Id.get -> string?
-

--- a/src/DocumentFormat.OpenXml.Framework/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/DocumentFormat.OpenXml.Framework/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,21 @@
 ﻿#nullable enable
+[OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPackageWriter
+[OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPackageWriter.OpenXmlPackageWriter(System.IO.Stream! stream, bool leaveOpen = false) -> void
+[OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPackageWriter.AddRelationship(System.Uri! partUri, string! relationshipType, string? id = null) -> string!
+[OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPackageWriter.CreatePart(System.Uri! partUri, string! contentType) -> DocumentFormat.OpenXml.Packaging.OpenXmlPartEntry!
+[OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPackageWriter.WritePart(System.Uri! partUri, string! contentType, DocumentFormat.OpenXml.OpenXmlElement! rootElement, System.Collections.Generic.IEnumerable<DocumentFormat.OpenXml.Packaging.PartRelationship>? relationships = null) -> void
+[OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPackageWriter.Finish() -> void
+[OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPackageWriter.Dispose() -> void
+[OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPackageWriter.DisposeAsync() -> System.Threading.Tasks.ValueTask
+[OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPartEntry
+[OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPartEntry.Stream.get -> System.IO.Stream!
+[OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPartEntry.AddRelationship(System.Uri! targetUri, string! relationshipType, System.IO.Packaging.TargetMode targetMode = System.IO.Packaging.TargetMode.Internal, string? id = null) -> string!
+[OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPartEntry.Dispose() -> void
+[OOXML0005]DocumentFormat.OpenXml.Packaging.PartRelationship
+[OOXML0005]DocumentFormat.OpenXml.Packaging.PartRelationship.PartRelationship() -> void
+[OOXML0005]DocumentFormat.OpenXml.Packaging.PartRelationship.PartRelationship(System.Uri! targetUri, string! relationshipType, System.IO.Packaging.TargetMode targetMode = System.IO.Packaging.TargetMode.Internal, string? id = null) -> void
+[OOXML0005]DocumentFormat.OpenXml.Packaging.PartRelationship.TargetUri.get -> System.Uri!
+[OOXML0005]DocumentFormat.OpenXml.Packaging.PartRelationship.RelationshipType.get -> string!
+[OOXML0005]DocumentFormat.OpenXml.Packaging.PartRelationship.TargetMode.get -> System.IO.Packaging.TargetMode
+[OOXML0005]DocumentFormat.OpenXml.Packaging.PartRelationship.Id.get -> string?
 

--- a/src/DocumentFormat.OpenXml.Framework/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/DocumentFormat.OpenXml.Framework/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 [OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPackageWriter
 [OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPackageWriter.OpenXmlPackageWriter(System.IO.Stream! stream, bool leaveOpen = false) -> void
 [OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPackageWriter.AddRelationship(System.Uri! partUri, string! relationshipType, string? id = null) -> string!
@@ -6,7 +6,6 @@
 [OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPackageWriter.WritePart(System.Uri! partUri, string! contentType, DocumentFormat.OpenXml.OpenXmlElement! rootElement, System.Collections.Generic.IEnumerable<DocumentFormat.OpenXml.Packaging.PartRelationship>? relationships = null) -> void
 [OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPackageWriter.Finish() -> void
 [OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPackageWriter.Dispose() -> void
-[OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPackageWriter.DisposeAsync() -> System.Threading.Tasks.ValueTask
 [OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPartEntry
 [OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPartEntry.Stream.get -> System.IO.Stream!
 [OOXML0005]DocumentFormat.OpenXml.Packaging.OpenXmlPartEntry.AddRelationship(System.Uri! targetUri, string! relationshipType, System.IO.Packaging.TargetMode targetMode = System.IO.Packaging.TargetMode.Internal, string? id = null) -> string!
@@ -18,4 +17,3 @@
 [OOXML0005]DocumentFormat.OpenXml.Packaging.PartRelationship.RelationshipType.get -> string!
 [OOXML0005]DocumentFormat.OpenXml.Packaging.PartRelationship.TargetMode.get -> System.IO.Packaging.TargetMode
 [OOXML0005]DocumentFormat.OpenXml.Packaging.PartRelationship.Id.get -> string?
-

--- a/src/DocumentFormat.OpenXml/Packaging/PresentationDocument.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/PresentationDocument.cs
@@ -184,6 +184,29 @@ namespace DocumentFormat.OpenXml.Packaging
                 .Open();
         }
 
+#if NETSTANDARD || NETCOREAPP
+        /// <summary>
+        /// Creates a forward-only <see cref="OpenXmlPackageWriter"/> for writing a Presentation document
+        /// directly to the given stream without requiring a seekable stream or temporary <see cref="MemoryStream"/>.
+        /// </summary>
+        /// <param name="stream">The target stream. Does not need to be seekable.</param>
+        /// <param name="type">The type of the PresentationDocument.</param>
+        /// <param name="leaveOpen">Whether to leave the stream open after disposal.</param>
+        /// <returns>A forward-only package writer with the presentation relationship pre-registered.</returns>
+        [Experimental(ExperimentalApis.ForwardOnly, UrlFormat = ExperimentalApis.UrlFormat)]
+        [Obsolete(ExperimentalApis.Message, DiagnosticId = ExperimentalApis.ForwardOnly, UrlFormat = ExperimentalApis.UrlFormat)]
+        public static OpenXmlPackageWriter CreateForwardOnly(Stream stream, PresentationDocumentType type, bool leaveOpen = false)
+        {
+            _ = type; // Reserved for future use
+            var writer = new OpenXmlPackageWriter(stream, leaveOpen);
+            writer.AddRelationship(
+                new Uri("/ppt/presentation.xml", UriKind.Relative),
+                "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
+                "rId1");
+            return writer;
+        }
+#endif
+
         /// <summary>
         /// Creates a new instance of the PresentationDocument class from the specified file.
         /// </summary>

--- a/src/DocumentFormat.OpenXml/Packaging/SpreadsheetDocument.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/SpreadsheetDocument.cs
@@ -184,6 +184,29 @@ namespace DocumentFormat.OpenXml.Packaging
                 .Open();
         }
 
+#if NETSTANDARD || NETCOREAPP
+        /// <summary>
+        /// Creates a forward-only <see cref="OpenXmlPackageWriter"/> for writing a Spreadsheet document
+        /// directly to the given stream without requiring a seekable stream or temporary <see cref="MemoryStream"/>.
+        /// </summary>
+        /// <param name="stream">The target stream. Does not need to be seekable.</param>
+        /// <param name="type">The type of the SpreadsheetDocument.</param>
+        /// <param name="leaveOpen">Whether to leave the stream open after disposal.</param>
+        /// <returns>A forward-only package writer with the workbook relationship pre-registered.</returns>
+        [Experimental(ExperimentalApis.ForwardOnly, UrlFormat = ExperimentalApis.UrlFormat)]
+        [Obsolete(ExperimentalApis.Message, DiagnosticId = ExperimentalApis.ForwardOnly, UrlFormat = ExperimentalApis.UrlFormat)]
+        public static OpenXmlPackageWriter CreateForwardOnly(Stream stream, SpreadsheetDocumentType type, bool leaveOpen = false)
+        {
+            _ = type; // Reserved for future use
+            var writer = new OpenXmlPackageWriter(stream, leaveOpen);
+            writer.AddRelationship(
+                new Uri("/xl/workbook.xml", UriKind.Relative),
+                "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
+                "rId1");
+            return writer;
+        }
+#endif
+
         /// <summary>
         /// Creates a new instance of the SpreadsheetDocument class from the specified file.
         /// </summary>

--- a/src/DocumentFormat.OpenXml/Packaging/WordprocessingDocument.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/WordprocessingDocument.cs
@@ -228,6 +228,29 @@ namespace DocumentFormat.OpenXml.Packaging
             return factory.Open(new MemoryStream(), PackageOpenMode.Create);
         }
 
+#if NETSTANDARD || NETCOREAPP
+        /// <summary>
+        /// Creates a forward-only <see cref="OpenXmlPackageWriter"/> for writing a Word document
+        /// directly to the given stream without requiring a seekable stream or temporary <see cref="MemoryStream"/>.
+        /// </summary>
+        /// <param name="stream">The target stream. Does not need to be seekable.</param>
+        /// <param name="type">The type of the WordprocessingDocument.</param>
+        /// <param name="leaveOpen">Whether to leave the stream open after disposal.</param>
+        /// <returns>A forward-only package writer with the main document relationship pre-registered.</returns>
+        [Experimental(ExperimentalApis.ForwardOnly, UrlFormat = ExperimentalApis.UrlFormat)]
+        [Obsolete(ExperimentalApis.Message, DiagnosticId = ExperimentalApis.ForwardOnly, UrlFormat = ExperimentalApis.UrlFormat)]
+        public static OpenXmlPackageWriter CreateForwardOnly(Stream stream, WordprocessingDocumentType type, bool leaveOpen = false)
+        {
+            _ = type; // Reserved for future use (e.g., macro-enabled documents)
+            var writer = new OpenXmlPackageWriter(stream, leaveOpen);
+            writer.AddRelationship(
+                new Uri("/word/document.xml", UriKind.Relative),
+                "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
+                "rId1");
+            return writer;
+        }
+#endif
+
         /// <summary>
         /// Creates a new instance of the WordprocessingDocument class from the specified file.
         /// </summary>

--- a/test/DocumentFormat.OpenXml.Benchmarks/ForwardOnlyBenchmarks.cs
+++ b/test/DocumentFormat.OpenXml.Benchmarks/ForwardOnlyBenchmarks.cs
@@ -1,0 +1,627 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable OOXML0005
+
+using BenchmarkDotNet.Attributes;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using DocumentFormat.OpenXml.Wordprocessing;
+using System;
+using System.IO;
+
+using P = DocumentFormat.OpenXml.Presentation;
+using S = DocumentFormat.OpenXml.Spreadsheet;
+using W = DocumentFormat.OpenXml.Wordprocessing;
+
+namespace DocumentFormat.OpenXml.Benchmarks
+{
+    public class ForwardOnlyBenchmarks
+    {
+        [Benchmark(Baseline = true)]
+        public void Word_Simple_Standard()
+        {
+            using var stream = new NonwritingStream();
+            using var doc = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document);
+            doc.AddMainDocumentPart().Document = new Document(
+                new Body(
+                    new Paragraph(
+                        new W.Run(new W.Text("Hello, world!")))));
+        }
+
+        [Benchmark]
+        public void Word_Simple_ForwardOnly()
+        {
+            using var stream = new NonwritingStream();
+            using var writer = WordprocessingDocument.CreateForwardOnly(stream, WordprocessingDocumentType.Document);
+            writer.WritePart(
+                new Uri("/word/document.xml", UriKind.Relative),
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml",
+                new Document(
+                    new Body(
+                        new Paragraph(
+                            new W.Run(new W.Text("Hello, world!"))))));
+        }
+
+        [Benchmark]
+        public void Word_Medium_Standard()
+        {
+            using var stream = new NonwritingStream();
+            using var doc = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document);
+
+            var body = new Body();
+
+            for (int i = 0; i < 20; i++)
+            {
+                body.AppendChild(new Paragraph(
+                    new ParagraphProperties(new W.Bold()),
+                    new W.Run(
+                        new W.RunProperties(new W.Italic()),
+                        new W.Text("Paragraph " + i))));
+            }
+
+            doc.AddMainDocumentPart().Document = new Document(body);
+        }
+
+        [Benchmark]
+        public void Word_Medium_ForwardOnly()
+        {
+            using var stream = new NonwritingStream();
+            using var writer = WordprocessingDocument.CreateForwardOnly(stream, WordprocessingDocumentType.Document);
+
+            var body = new Body();
+
+            for (int i = 0; i < 20; i++)
+            {
+                body.AppendChild(new Paragraph(
+                    new ParagraphProperties(new W.Bold()),
+                    new W.Run(
+                        new W.RunProperties(new W.Italic()),
+                        new W.Text("Paragraph " + i))));
+            }
+
+            writer.WritePart(
+                new Uri("/word/document.xml", UriKind.Relative),
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml",
+                new Document(body));
+        }
+
+        [Benchmark]
+        public void Word_Complex_Standard()
+        {
+            using var stream = new NonwritingStream();
+            using var doc = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document);
+
+            var mainPart = doc.AddMainDocumentPart();
+
+            var body = new Body();
+
+            for (int i = 0; i < 100; i++)
+            {
+                body.AppendChild(new Paragraph(
+                    new ParagraphProperties(
+                        new ParagraphStyleId { Val = "Heading1" }),
+                    new W.Run(
+                        new W.RunProperties(
+                            new W.Bold(),
+                            new W.FontSize { Val = "28" }),
+                        new W.Text("Section " + i)),
+                    new W.Run(
+                        new W.Break()),
+                    new W.Run(
+                        new W.Text("Content for section " + i + " with some additional text to make it realistic."))));
+            }
+
+            mainPart.Document = new Document(body);
+
+            var stylesPart = mainPart.AddNewPart<StyleDefinitionsPart>();
+            stylesPart.Styles = new Styles(
+                new Style(
+                    new StyleName { Val = "heading 1" },
+                    new BasedOn { Val = "Normal" })
+                { Type = StyleValues.Paragraph, StyleId = "Heading1" });
+        }
+
+        [Benchmark]
+        public void Word_Complex_ForwardOnly()
+        {
+            using var stream = new NonwritingStream();
+            using var writer = WordprocessingDocument.CreateForwardOnly(stream, WordprocessingDocumentType.Document);
+
+            var body = new Body();
+
+            for (int i = 0; i < 100; i++)
+            {
+                body.AppendChild(new Paragraph(
+                    new ParagraphProperties(
+                        new ParagraphStyleId { Val = "Heading1" }),
+                    new W.Run(
+                        new W.RunProperties(
+                            new W.Bold(),
+                            new W.FontSize { Val = "28" }),
+                        new W.Text("Section " + i)),
+                    new W.Run(
+                        new W.Break()),
+                    new W.Run(
+                        new W.Text("Content for section " + i + " with some additional text to make it realistic."))));
+            }
+
+            var relationships = new[]
+            {
+                new PartRelationship(
+                    new Uri("styles.xml", UriKind.Relative),
+                    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles",
+                    id: "rId1"),
+            };
+
+            writer.WritePart(
+                new Uri("/word/document.xml", UriKind.Relative),
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml",
+                new Document(body),
+                relationships);
+
+            writer.WritePart(
+                new Uri("/word/styles.xml", UriKind.Relative),
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml",
+                new Styles(
+                    new Style(
+                        new StyleName { Val = "heading 1" },
+                        new BasedOn { Val = "Normal" })
+                    { Type = StyleValues.Paragraph, StyleId = "Heading1" }));
+        }
+
+        [Benchmark]
+        public void Spreadsheet_Simple_Standard()
+        {
+            using var stream = new NonwritingStream();
+            using var doc = SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook);
+
+            var workbookPart = doc.AddWorkbookPart();
+            var sheetPart = workbookPart.AddNewPart<WorksheetPart>();
+            sheetPart.Worksheet = new Worksheet(
+                new SheetData(
+                    new Row(
+                        new Cell { CellValue = new CellValue("Hello"), DataType = CellValues.String })));
+
+            workbookPart.Workbook = new Workbook(
+                new Sheets(
+                    new Sheet { Name = "Sheet1", SheetId = 1, Id = workbookPart.GetIdOfPart(sheetPart) }));
+        }
+
+        [Benchmark]
+        public void Spreadsheet_Simple_ForwardOnly()
+        {
+            using var stream = new NonwritingStream();
+            using var writer = SpreadsheetDocument.CreateForwardOnly(stream, SpreadsheetDocumentType.Workbook);
+
+            writer.WritePart(
+                new Uri("/xl/worksheets/sheet1.xml", UriKind.Relative),
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml",
+                new Worksheet(
+                    new SheetData(
+                        new Row(
+                            new Cell { CellValue = new CellValue("Hello"), DataType = CellValues.String }))));
+
+            writer.WritePart(
+                new Uri("/xl/workbook.xml", UriKind.Relative),
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml",
+                new Workbook(
+                    new Sheets(
+                        new Sheet { Name = "Sheet1", SheetId = 1, Id = "rId1" })),
+                new[]
+                {
+                    new PartRelationship(
+                        new Uri("worksheets/sheet1.xml", UriKind.Relative),
+                        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet",
+                        id: "rId1"),
+                });
+        }
+
+        [Benchmark]
+        public void Spreadsheet_Medium_Standard()
+        {
+            using var stream = new NonwritingStream();
+            using var doc = SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook);
+
+            var workbookPart = doc.AddWorkbookPart();
+            var sheetPart = workbookPart.AddNewPart<WorksheetPart>();
+
+            var sheetData = new SheetData();
+
+            for (uint r = 1; r <= 100; r++)
+            {
+                var row = new Row { RowIndex = r };
+
+                for (int c = 0; c < 10; c++)
+                {
+                    row.AppendChild(new Cell
+                    {
+                        CellValue = new CellValue(((r * 10) + c).ToString()),
+                        DataType = CellValues.Number,
+                    });
+                }
+
+                sheetData.AppendChild(row);
+            }
+
+            sheetPart.Worksheet = new Worksheet(sheetData);
+
+            workbookPart.Workbook = new Workbook(
+                new Sheets(
+                    new Sheet { Name = "Sheet1", SheetId = 1, Id = workbookPart.GetIdOfPart(sheetPart) }));
+        }
+
+        [Benchmark]
+        public void Spreadsheet_Medium_ForwardOnly()
+        {
+            using var stream = new NonwritingStream();
+            using var writer = SpreadsheetDocument.CreateForwardOnly(stream, SpreadsheetDocumentType.Workbook);
+
+            var sheetData = new SheetData();
+
+            for (uint r = 1; r <= 100; r++)
+            {
+                var row = new Row { RowIndex = r };
+
+                for (int c = 0; c < 10; c++)
+                {
+                    row.AppendChild(new Cell
+                    {
+                        CellValue = new CellValue(((r * 10) + c).ToString()),
+                        DataType = CellValues.Number,
+                    });
+                }
+
+                sheetData.AppendChild(row);
+            }
+
+            writer.WritePart(
+                new Uri("/xl/worksheets/sheet1.xml", UriKind.Relative),
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml",
+                new Worksheet(sheetData));
+
+            writer.WritePart(
+                new Uri("/xl/workbook.xml", UriKind.Relative),
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml",
+                new Workbook(
+                    new Sheets(
+                        new Sheet { Name = "Sheet1", SheetId = 1, Id = "rId1" })),
+                new[]
+                {
+                    new PartRelationship(
+                        new Uri("worksheets/sheet1.xml", UriKind.Relative),
+                        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet",
+                        id: "rId1"),
+                });
+        }
+
+        [Benchmark]
+        public void Spreadsheet_Complex_Standard()
+        {
+            using var stream = new NonwritingStream();
+            using var doc = SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook);
+
+            var workbookPart = doc.AddWorkbookPart();
+            var sheets = new Sheets();
+
+            for (int s = 0; s < 3; s++)
+            {
+                var sheetPart = workbookPart.AddNewPart<WorksheetPart>();
+
+                var sheetData = new SheetData();
+
+                for (uint r = 1; r <= 500; r++)
+                {
+                    var row = new Row { RowIndex = r };
+
+                    for (int c = 0; c < 10; c++)
+                    {
+                        row.AppendChild(new Cell
+                        {
+                            CellValue = new CellValue(((s * 5000) + (r * 10) + c).ToString()),
+                            DataType = CellValues.Number,
+                        });
+                    }
+
+                    sheetData.AppendChild(row);
+                }
+
+                sheetPart.Worksheet = new Worksheet(sheetData);
+
+                sheets.AppendChild(new Sheet
+                {
+                    Name = "Sheet" + (s + 1),
+                    SheetId = (uint)(s + 1),
+                    Id = workbookPart.GetIdOfPart(sheetPart),
+                });
+            }
+
+            workbookPart.Workbook = new Workbook(sheets);
+        }
+
+        [Benchmark]
+        public void Spreadsheet_Complex_ForwardOnly()
+        {
+            using var stream = new NonwritingStream();
+            using var writer = SpreadsheetDocument.CreateForwardOnly(stream, SpreadsheetDocumentType.Workbook);
+
+            var sheetRels = new PartRelationship[3];
+
+            for (int s = 0; s < 3; s++)
+            {
+                var sheetData = new SheetData();
+
+                for (uint r = 1; r <= 500; r++)
+                {
+                    var row = new Row { RowIndex = r };
+
+                    for (int c = 0; c < 10; c++)
+                    {
+                        row.AppendChild(new Cell
+                        {
+                            CellValue = new CellValue(((s * 5000) + (r * 10) + c).ToString()),
+                            DataType = CellValues.Number,
+                        });
+                    }
+
+                    sheetData.AppendChild(row);
+                }
+
+                var sheetUri = "worksheets/sheet" + (s + 1) + ".xml";
+                var relId = "rId" + (s + 1);
+
+                writer.WritePart(
+                    new Uri("/xl/" + sheetUri, UriKind.Relative),
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml",
+                    new Worksheet(sheetData));
+
+                sheetRels[s] = new PartRelationship(
+                    new Uri(sheetUri, UriKind.Relative),
+                    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet",
+                    id: relId);
+            }
+
+            var sheets = new Sheets();
+
+            for (int s = 0; s < 3; s++)
+            {
+                sheets.AppendChild(new Sheet
+                {
+                    Name = "Sheet" + (s + 1),
+                    SheetId = (uint)(s + 1),
+                    Id = "rId" + (s + 1),
+                });
+            }
+
+            writer.WritePart(
+                new Uri("/xl/workbook.xml", UriKind.Relative),
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml",
+                new Workbook(sheets),
+                sheetRels);
+        }
+
+        [Benchmark]
+        public void Presentation_Simple_Standard()
+        {
+            using var stream = new NonwritingStream();
+            using var doc = PresentationDocument.Create(stream, PresentationDocumentType.Presentation);
+
+            var presentationPart = doc.AddPresentationPart();
+            var slidePart = presentationPart.AddNewPart<SlidePart>();
+            slidePart.Slide = new P.Slide(
+                new P.CommonSlideData(
+                    new P.ShapeTree()));
+
+            presentationPart.Presentation = new P.Presentation(
+                new P.SlideIdList(
+                    new P.SlideId { Id = 256, RelationshipId = presentationPart.GetIdOfPart(slidePart) }),
+                new P.SlideSize { Cx = 9144000, Cy = 6858000 });
+        }
+
+        [Benchmark]
+        public void Presentation_Simple_ForwardOnly()
+        {
+            using var stream = new NonwritingStream();
+            using var writer = PresentationDocument.CreateForwardOnly(stream, PresentationDocumentType.Presentation);
+
+            writer.WritePart(
+                new Uri("/ppt/slides/slide1.xml", UriKind.Relative),
+                "application/vnd.openxmlformats-officedocument.presentationml.slide+xml",
+                new P.Slide(
+                    new P.CommonSlideData(
+                        new P.ShapeTree())));
+
+            writer.WritePart(
+                new Uri("/ppt/presentation.xml", UriKind.Relative),
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml",
+                new P.Presentation(
+                    new P.SlideIdList(
+                        new P.SlideId { Id = 256, RelationshipId = "rId1" }),
+                    new P.SlideSize { Cx = 9144000, Cy = 6858000 }),
+                new[]
+                {
+                    new PartRelationship(
+                        new Uri("slides/slide1.xml", UriKind.Relative),
+                        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide",
+                        id: "rId1"),
+                });
+        }
+
+        [Benchmark]
+        public void Presentation_Medium_Standard()
+        {
+            using var stream = new NonwritingStream();
+            using var doc = PresentationDocument.Create(stream, PresentationDocumentType.Presentation);
+
+            var presentationPart = doc.AddPresentationPart();
+            var slideIdList = new P.SlideIdList();
+
+            for (uint i = 0; i < 10; i++)
+            {
+                var slidePart = presentationPart.AddNewPart<SlidePart>();
+                slidePart.Slide = new P.Slide(
+                    new P.CommonSlideData(
+                        new P.ShapeTree(
+                            new P.Shape(
+                                new P.TextBody(
+                                    new Drawing.Paragraph(
+                                        new Drawing.Run(
+                                            new Drawing.Text("Slide " + (i + 1)))))))));
+
+                slideIdList.AppendChild(new P.SlideId
+                {
+                    Id = 256 + i,
+                    RelationshipId = presentationPart.GetIdOfPart(slidePart),
+                });
+            }
+
+            presentationPart.Presentation = new P.Presentation(
+                slideIdList,
+                new P.SlideSize { Cx = 9144000, Cy = 6858000 });
+        }
+
+        [Benchmark]
+        public void Presentation_Medium_ForwardOnly()
+        {
+            using var stream = new NonwritingStream();
+            using var writer = PresentationDocument.CreateForwardOnly(stream, PresentationDocumentType.Presentation);
+
+            var slideRels = new PartRelationship[10];
+            var slideIdList = new P.SlideIdList();
+
+            for (uint i = 0; i < 10; i++)
+            {
+                var relId = "rId" + (i + 1);
+
+                writer.WritePart(
+                    new Uri("/ppt/slides/slide" + (i + 1) + ".xml", UriKind.Relative),
+                    "application/vnd.openxmlformats-officedocument.presentationml.slide+xml",
+                    new P.Slide(
+                        new P.CommonSlideData(
+                            new P.ShapeTree(
+                                new P.Shape(
+                                    new P.TextBody(
+                                        new Drawing.Paragraph(
+                                            new Drawing.Run(
+                                                new Drawing.Text("Slide " + (i + 1))))))))));
+
+                slideRels[i] = new PartRelationship(
+                    new Uri("slides/slide" + (i + 1) + ".xml", UriKind.Relative),
+                    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide",
+                    id: relId);
+
+                slideIdList.AppendChild(new P.SlideId { Id = 256 + i, RelationshipId = relId });
+            }
+
+            writer.WritePart(
+                new Uri("/ppt/presentation.xml", UriKind.Relative),
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml",
+                new P.Presentation(
+                    slideIdList,
+                    new P.SlideSize { Cx = 9144000, Cy = 6858000 }),
+                slideRels);
+        }
+
+        [Benchmark]
+        public void Presentation_Complex_Standard()
+        {
+            using var stream = new NonwritingStream();
+            using var doc = PresentationDocument.Create(stream, PresentationDocumentType.Presentation);
+
+            var presentationPart = doc.AddPresentationPart();
+            var slideIdList = new P.SlideIdList();
+
+            for (uint i = 0; i < 30; i++)
+            {
+                var slidePart = presentationPart.AddNewPart<SlidePart>();
+
+                var shapeTree = new P.ShapeTree();
+
+                for (int j = 0; j < 5; j++)
+                {
+                    shapeTree.AppendChild(new P.Shape(
+                        new P.NonVisualShapeProperties(
+                            new P.NonVisualDrawingProperties { Id = (uint)(j + 1), Name = "Shape " + j },
+                            new P.NonVisualShapeDrawingProperties(),
+                            new P.ApplicationNonVisualDrawingProperties()),
+                        new P.ShapeProperties(
+                            new Drawing.Transform2D(
+                                new Drawing.Offset { X = j * 1000000L, Y = 1000000L },
+                                new Drawing.Extents { Cx = 900000L, Cy = 500000L })),
+                        new P.TextBody(
+                            new Drawing.BodyProperties(),
+                            new Drawing.Paragraph(
+                                new Drawing.Run(
+                                    new Drawing.Text("Shape " + j + " on Slide " + (i + 1)))))));
+                }
+
+                slidePart.Slide = new P.Slide(new P.CommonSlideData(shapeTree));
+
+                slideIdList.AppendChild(new P.SlideId
+                {
+                    Id = 256 + i,
+                    RelationshipId = presentationPart.GetIdOfPart(slidePart),
+                });
+            }
+
+            presentationPart.Presentation = new P.Presentation(
+                slideIdList,
+                new P.SlideSize { Cx = 9144000, Cy = 6858000 });
+        }
+
+        [Benchmark]
+        public void Presentation_Complex_ForwardOnly()
+        {
+            using var stream = new NonwritingStream();
+            using var writer = PresentationDocument.CreateForwardOnly(stream, PresentationDocumentType.Presentation);
+
+            var slideRels = new PartRelationship[30];
+            var slideIdList = new P.SlideIdList();
+
+            for (uint i = 0; i < 30; i++)
+            {
+                var relId = "rId" + (i + 1);
+
+                var shapeTree = new P.ShapeTree();
+
+                for (int j = 0; j < 5; j++)
+                {
+                    shapeTree.AppendChild(new P.Shape(
+                        new P.NonVisualShapeProperties(
+                            new P.NonVisualDrawingProperties { Id = (uint)(j + 1), Name = "Shape " + j },
+                            new P.NonVisualShapeDrawingProperties(),
+                            new P.ApplicationNonVisualDrawingProperties()),
+                        new P.ShapeProperties(
+                            new Drawing.Transform2D(
+                                new Drawing.Offset { X = j * 1000000L, Y = 1000000L },
+                                new Drawing.Extents { Cx = 900000L, Cy = 500000L })),
+                        new P.TextBody(
+                            new Drawing.BodyProperties(),
+                            new Drawing.Paragraph(
+                                new Drawing.Run(
+                                    new Drawing.Text("Shape " + j + " on Slide " + (i + 1)))))));
+                }
+
+                writer.WritePart(
+                    new Uri("/ppt/slides/slide" + (i + 1) + ".xml", UriKind.Relative),
+                    "application/vnd.openxmlformats-officedocument.presentationml.slide+xml",
+                    new P.Slide(new P.CommonSlideData(shapeTree)));
+
+                slideRels[i] = new PartRelationship(
+                    new Uri("slides/slide" + (i + 1) + ".xml", UriKind.Relative),
+                    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide",
+                    id: relId);
+
+                slideIdList.AppendChild(new P.SlideId { Id = 256 + i, RelationshipId = relId });
+            }
+
+            writer.WritePart(
+                new Uri("/ppt/presentation.xml", UriKind.Relative),
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml",
+                new P.Presentation(
+                    slideIdList,
+                    new P.SlideSize { Cx = 9144000, Cy = 6858000 }),
+                slideRels);
+        }
+    }
+}

--- a/test/DocumentFormat.OpenXml.Framework.Tests/OpenXmlPackageWriterTests.cs
+++ b/test/DocumentFormat.OpenXml.Framework.Tests/OpenXmlPackageWriterTests.cs
@@ -1,0 +1,483 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using System;
+using System.IO;
+using System.IO.Packaging;
+using Xunit;
+
+using W = DocumentFormat.OpenXml.Wordprocessing;
+using S = DocumentFormat.OpenXml.Spreadsheet;
+using P = DocumentFormat.OpenXml.Presentation;
+
+namespace DocumentFormat.OpenXml.Framework.Tests;
+
+#pragma warning disable OOXML0005
+
+public class OpenXmlPackageWriterTests
+{
+    [Fact]
+    public void WriteMinimalDocx_RoundTrips()
+    {
+        using var ms = new MemoryStream();
+
+        using (var writer = new OpenXmlPackageWriter(ms, leaveOpen: true))
+        {
+            writer.AddRelationship(
+                new Uri("/word/document.xml", UriKind.Relative),
+                "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
+                "rId1");
+
+            writer.WritePart(
+                new Uri("/word/document.xml", UriKind.Relative),
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml",
+                new Document(new Body(new Paragraph(new Run(new Text("Hello!"))))));
+        }
+
+        ms.Position = 0;
+
+        using var doc = WordprocessingDocument.Open(ms, false);
+        Assert.NotNull(doc.MainDocumentPart);
+        Assert.NotNull(doc.MainDocumentPart!.Document);
+        Assert.Equal("Hello!", doc.MainDocumentPart.Document.Body!.InnerText);
+    }
+
+    [Fact]
+    public void CreateForwardOnly_WordDocument_RoundTrips()
+    {
+        using var ms = new MemoryStream();
+
+        using (var writer = WordprocessingDocument.CreateForwardOnly(ms, WordprocessingDocumentType.Document, leaveOpen: true))
+        {
+            writer.WritePart(
+                new Uri("/word/document.xml", UriKind.Relative),
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml",
+                new Document(new Body(new Paragraph(new Run(new Text("Forward-only!"))))));
+        }
+
+        ms.Position = 0;
+
+        using var doc = WordprocessingDocument.Open(ms, false);
+        Assert.NotNull(doc.MainDocumentPart);
+        Assert.Equal("Forward-only!", doc.MainDocumentPart!.Document!.Body!.InnerText);
+    }
+
+    [Fact]
+    public void WriteToNonSeekableStream()
+    {
+        using var ms = new MemoryStream();
+        using var nonSeekable = new NonSeekableStream(ms);
+
+        using (var writer = new OpenXmlPackageWriter(nonSeekable, leaveOpen: true))
+        {
+            writer.AddRelationship(
+                new Uri("/word/document.xml", UriKind.Relative),
+                "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
+                "rId1");
+
+            writer.WritePart(
+                new Uri("/word/document.xml", UriKind.Relative),
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml",
+                new Document(new Body(new Paragraph(new Run(new Text("Non-seekable!"))))));
+        }
+
+        ms.Position = 0;
+
+        using var doc = WordprocessingDocument.Open(ms, false);
+        Assert.NotNull(doc.MainDocumentPart);
+        Assert.Equal("Non-seekable!", doc.MainDocumentPart!.Document!.Body!.InnerText);
+    }
+
+    [Fact]
+    public void CreatePart_WithOpenXmlWriter()
+    {
+        using var ms = new MemoryStream();
+
+        using (var writer = new OpenXmlPackageWriter(ms, leaveOpen: true))
+        {
+            writer.AddRelationship(
+                new Uri("/word/document.xml", UriKind.Relative),
+                "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
+                "rId1");
+
+            using (var entry = writer.CreatePart(
+                new Uri("/word/document.xml", UriKind.Relative),
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"))
+            {
+                using var xmlWriter = OpenXmlWriter.Create(entry.Stream);
+                xmlWriter.WriteStartDocument();
+                xmlWriter.WriteStartElement(new Document());
+                xmlWriter.WriteStartElement(new Body());
+                xmlWriter.WriteElement(new Paragraph(new Run(new Text("Streamed!"))));
+                xmlWriter.WriteEndElement(); // Body
+                xmlWriter.WriteEndElement(); // Document
+            }
+        }
+
+        ms.Position = 0;
+
+        using var doc = WordprocessingDocument.Open(ms, false);
+        Assert.NotNull(doc.MainDocumentPart);
+        Assert.Equal("Streamed!", doc.MainDocumentPart!.Document!.Body!.InnerText);
+    }
+
+    [Fact]
+    public void PartRelationships_AreWritten()
+    {
+        using var ms = new MemoryStream();
+
+        using (var writer = new OpenXmlPackageWriter(ms, leaveOpen: true))
+        {
+            writer.AddRelationship(
+                new Uri("/word/document.xml", UriKind.Relative),
+                "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
+                "rId1");
+
+            using (var entry = writer.CreatePart(
+                new Uri("/word/document.xml", UriKind.Relative),
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"))
+            {
+                entry.AddRelationship(
+                    new Uri("styles.xml", UriKind.Relative),
+                    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles",
+                    id: "rId1");
+
+                using var xmlWriter = OpenXmlWriter.Create(entry.Stream);
+                xmlWriter.WriteStartDocument();
+                xmlWriter.WriteStartElement(new Document());
+                xmlWriter.WriteStartElement(new Body());
+                xmlWriter.WriteEndElement();
+                xmlWriter.WriteEndElement();
+            }
+
+            writer.WritePart(
+                new Uri("/word/styles.xml", UriKind.Relative),
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml",
+                new Styles());
+        }
+
+        ms.Position = 0;
+
+        using var doc = WordprocessingDocument.Open(ms, false);
+        Assert.NotNull(doc.MainDocumentPart);
+
+        // Verify the part-level relationship was written
+        var rels = doc.MainDocumentPart!.GetPartsOfType<StyleDefinitionsPart>();
+        Assert.NotEmpty(rels);
+    }
+
+    [Fact]
+    public void DuplicatePartUri_Throws()
+    {
+        using var ms = new MemoryStream();
+        using var writer = new OpenXmlPackageWriter(ms);
+
+        writer.WritePart(
+            new Uri("/word/document.xml", UriKind.Relative),
+            "application/xml",
+            new Document());
+
+        Assert.Throws<InvalidOperationException>(() =>
+            writer.WritePart(
+                new Uri("/word/document.xml", UriKind.Relative),
+                "application/xml",
+                new Document()));
+    }
+
+    [Fact]
+    public void OperationsAfterFinish_Throw()
+    {
+        using var ms = new MemoryStream();
+        var writer = new OpenXmlPackageWriter(ms, leaveOpen: true);
+        writer.Finish();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            writer.AddRelationship(new Uri("/foo.xml", UriKind.Relative), "type"));
+
+        Assert.Throws<InvalidOperationException>(() =>
+            writer.CreatePart(new Uri("/foo.xml", UriKind.Relative), "type"));
+    }
+
+    [Fact]
+    public void AutoDisposesPreviousPartEntry()
+    {
+        using var ms = new MemoryStream();
+
+        using var writer = new OpenXmlPackageWriter(ms, leaveOpen: true);
+
+        writer.AddRelationship(
+            new Uri("/word/document.xml", UriKind.Relative),
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
+            "rId1");
+
+        // Create first part - don't dispose it manually
+        var entry1 = writer.CreatePart(
+            new Uri("/word/document.xml", UriKind.Relative),
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml");
+
+        // Writing to it should work
+        using (var xmlWriter = OpenXmlWriter.Create(entry1.Stream))
+        {
+            xmlWriter.WriteStartDocument();
+            xmlWriter.WriteStartElement(new Document());
+            xmlWriter.WriteEndElement();
+        }
+
+        // Creating a second part should auto-dispose the first
+        var entry2 = writer.CreatePart(
+            new Uri("/word/styles.xml", UriKind.Relative),
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml");
+
+        // The first entry's stream should now be disposed
+        Assert.Throws<ObjectDisposedException>(() => entry1.Stream);
+
+        entry2.Dispose();
+    }
+
+    [Fact]
+    public void CreateForwardOnly_SpreadsheetDocument_RoundTrips()
+    {
+        using var ms = new MemoryStream();
+
+        using (var writer = SpreadsheetDocument.CreateForwardOnly(ms, SpreadsheetDocumentType.Workbook, leaveOpen: true))
+        {
+            writer.WritePart(
+                new Uri("/xl/workbook.xml", UriKind.Relative),
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml",
+                new S.Workbook(new S.Sheets(new S.Sheet { Name = "Sheet1", SheetId = 1, Id = "rId1" })),
+                new[]
+                {
+                    new PartRelationship(
+                        new Uri("worksheets/sheet1.xml", UriKind.Relative),
+                        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet",
+                        id: "rId1"),
+                });
+
+            writer.WritePart(
+                new Uri("/xl/worksheets/sheet1.xml", UriKind.Relative),
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml",
+                new S.Worksheet(new S.SheetData(
+                    new S.Row(new S.Cell { CellValue = new S.CellValue("42"), DataType = S.CellValues.Number }))));
+        }
+
+        ms.Position = 0;
+
+        using var doc = SpreadsheetDocument.Open(ms, false);
+        Assert.NotNull(doc.WorkbookPart);
+        Assert.NotNull(doc.WorkbookPart!.Workbook);
+        Assert.NotEmpty(doc.WorkbookPart.Workbook.Sheets!);
+    }
+
+    [Fact]
+    public void CreateForwardOnly_PresentationDocument_RoundTrips()
+    {
+        using var ms = new MemoryStream();
+
+        using (var writer = PresentationDocument.CreateForwardOnly(ms, PresentationDocumentType.Presentation, leaveOpen: true))
+        {
+            writer.WritePart(
+                new Uri("/ppt/presentation.xml", UriKind.Relative),
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml",
+                new P.Presentation(new P.SlideIdList()));
+        }
+
+        ms.Position = 0;
+
+        using var doc = PresentationDocument.Open(ms, false);
+        Assert.NotNull(doc.PresentationPart);
+        Assert.NotNull(doc.PresentationPart!.Presentation);
+    }
+
+    [Fact]
+    public void ExternalRelationship_IsWritten()
+    {
+        using var ms = new MemoryStream();
+
+        using (var writer = new OpenXmlPackageWriter(ms, leaveOpen: true))
+        {
+            writer.AddRelationship(
+                new Uri("/word/document.xml", UriKind.Relative),
+                "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
+                "rId1");
+
+            using (var entry = writer.CreatePart(
+                new Uri("/word/document.xml", UriKind.Relative),
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"))
+            {
+                entry.AddRelationship(
+                    new Uri("https://example.com", UriKind.Absolute),
+                    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink",
+                    TargetMode.External,
+                    "rId1");
+
+                using var xmlWriter = OpenXmlWriter.Create(entry.Stream);
+                xmlWriter.WriteStartDocument();
+                xmlWriter.WriteStartElement(new Document());
+                xmlWriter.WriteStartElement(new Body());
+                xmlWriter.WriteEndElement();
+                xmlWriter.WriteEndElement();
+            }
+        }
+
+        ms.Position = 0;
+
+        using var doc = WordprocessingDocument.Open(ms, false);
+        Assert.NotNull(doc.MainDocumentPart);
+
+        var hyperlinks = doc.MainDocumentPart!.HyperlinkRelationships;
+        Assert.NotEmpty(hyperlinks);
+    }
+
+    [Fact]
+    public void NullStream_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new OpenXmlPackageWriter(null!));
+    }
+
+    [Fact]
+    public void NullPartUri_Throws()
+    {
+        using var ms = new MemoryStream();
+        using var writer = new OpenXmlPackageWriter(ms);
+        Assert.Throws<ArgumentNullException>(() => writer.CreatePart(null!, "text/xml"));
+    }
+
+    [Fact]
+    public void NullContentType_Throws()
+    {
+        using var ms = new MemoryStream();
+        using var writer = new OpenXmlPackageWriter(ms);
+        Assert.Throws<ArgumentNullException>(() => writer.CreatePart(new Uri("/foo.xml", UriKind.Relative), null!));
+    }
+
+    [Fact]
+    public void NullRootElement_Throws()
+    {
+        using var ms = new MemoryStream();
+        using var writer = new OpenXmlPackageWriter(ms);
+        Assert.Throws<ArgumentNullException>(() => writer.WritePart(new Uri("/foo.xml", UriKind.Relative), "text/xml", null!));
+    }
+
+    [Fact]
+    public void AddRelationship_AutoGeneratesId()
+    {
+        using var ms = new MemoryStream();
+        using var writer = new OpenXmlPackageWriter(ms);
+        var id = writer.AddRelationship(new Uri("/foo.xml", UriKind.Relative), "type");
+        Assert.StartsWith("rId", id);
+    }
+
+    [Fact]
+    public void PartEntry_AddRelationship_AutoGeneratesId()
+    {
+        using var ms = new MemoryStream();
+        using var writer = new OpenXmlPackageWriter(ms);
+        using var entry = writer.CreatePart(new Uri("/foo.xml", UriKind.Relative), "text/xml");
+        var id = entry.AddRelationship(new Uri("bar.xml", UriKind.Relative), "type");
+        Assert.StartsWith("rId", id);
+    }
+
+    [Fact]
+    public void PartEntry_AddRelationship_AfterDispose_Throws()
+    {
+        using var ms = new MemoryStream();
+        using var writer = new OpenXmlPackageWriter(ms);
+        var entry = writer.CreatePart(new Uri("/foo.xml", UriKind.Relative), "text/xml");
+        entry.Dispose();
+        Assert.Throws<ObjectDisposedException>(() =>
+            entry.AddRelationship(new Uri("bar.xml", UriKind.Relative), "type"));
+    }
+
+    [Fact]
+    public void FinishCalledTwice_DoesNotThrow()
+    {
+        using var ms = new MemoryStream();
+        var writer = new OpenXmlPackageWriter(ms, leaveOpen: true);
+        writer.Finish();
+        writer.Finish(); // second call should be no-op
+        writer.Dispose();
+    }
+
+    [Fact]
+    public void PartRelationship_Properties()
+    {
+        var uri = new Uri("foo.xml", UriKind.Relative);
+        var rel = new PartRelationship(uri, "type", TargetMode.External, "rId1");
+        Assert.Equal(uri, rel.TargetUri);
+        Assert.Equal("type", rel.RelationshipType);
+        Assert.Equal(TargetMode.External, rel.TargetMode);
+        Assert.Equal("rId1", rel.Id);
+    }
+
+    [Fact]
+    public void PartRelationship_DefaultValues()
+    {
+        var uri = new Uri("foo.xml", UriKind.Relative);
+        var rel = new PartRelationship(uri, "type");
+        Assert.Equal(TargetMode.Internal, rel.TargetMode);
+        Assert.Null(rel.Id);
+    }
+
+#if NET6_0_OR_GREATER
+    [Fact]
+    public async System.Threading.Tasks.Task DisposeAsync_FinalizesPackage()
+    {
+        using var ms = new MemoryStream();
+
+        await using (var writer = new OpenXmlPackageWriter(ms, leaveOpen: true))
+        {
+            writer.AddRelationship(
+                new Uri("/word/document.xml", UriKind.Relative),
+                "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
+                "rId1");
+
+            writer.WritePart(
+                new Uri("/word/document.xml", UriKind.Relative),
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml",
+                new Document(new Body()));
+        }
+
+        ms.Position = 0;
+
+        using var doc = WordprocessingDocument.Open(ms, false);
+        Assert.NotNull(doc.MainDocumentPart);
+    }
+#endif
+
+    private class NonSeekableStream : Stream
+    {
+        private readonly Stream _inner;
+
+        public NonSeekableStream(Stream inner) => _inner = inner;
+
+        public override bool CanRead => false;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => _inner.CanWrite;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => _inner.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => throw new NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin)
+            => throw new NotSupportedException();
+
+        public override void SetLength(long value)
+            => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count)
+            => _inner.Write(buffer, offset, count);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new experimental "forward-only" API for writing OpenXML packages (such as .docx, .xlsx, .pptx) directly to any writable stream, including non-seekable streams. The new API avoids the need for buffering documents in memory, making it more efficient for large documents and for streaming scenarios (e.g., HTTP responses, cloud uploads). The implementation includes new types, documentation, and experimental API registration.

**Forward-Only OpenXML Writing API:**

* Added the new `OpenXmlPackageWriter` class, which allows forward-only creation of OpenXML documents to any writable stream without requiring a seekable stream or memory buffering. This class manages part creation, relationships, and package finalization.
* Introduced the `OpenXmlPartEntry` class, representing a single part being written in forward-only mode, with support for streaming XML content and adding part-level relationships.
* Added the `PartRelationship` struct, used to declare relationships when writing parts with the forward-only writer.
* Registered the new API as experimental (`OOXML0005`) in the `ExperimentalApis` class.

**Documentation:**

* Added comprehensive documentation (`ForwardOnlyWriting.md`) describing the new API, usage scenarios, code samples, API reference, behavioral notes, comparison with the standard API, and performance benchmarks.