### PR TITLE
Accept percentage string form in Int32Value.Parse

### DIFF
--- a/src/DocumentFormat.OpenXml.Framework/SimpleTypes/Int32Value.cs
+++ b/src/DocumentFormat.OpenXml.Framework/SimpleTypes/Int32Value.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Xml;
 
 namespace DocumentFormat.OpenXml
@@ -40,7 +41,20 @@ namespace DocumentFormat.OpenXml
 
         private protected override string GetText(int input) => XmlConvert.ToString(input);
 
-        private protected override int Parse(string input) => XmlConvert.ToInt32(input);
+        private protected override int Parse(string input)
+        {
+            // ECMA-376 percentage types (e.g. ST_Percentage, ST_PositiveFixedPercentage) are a union of
+            // a decimal integer in 1000ths of a percent and a string with a trailing "%" (e.g. "50%").
+            // Office sometimes emits the string form, so accept it as a fallback for attributes
+            // mapped to Int32Value such as a:biLevel/@thresh.
+            if (input is { Length: > 0 } && input[input.Length - 1] == '%')
+            {
+                var number = input.Substring(0, input.Length - 1);
+                return (int)(double.Parse(number, CultureInfo.InvariantCulture) * 1000);
+            }
+
+            return XmlConvert.ToInt32(input);
+        }
 
         /// <summary>
         /// Implicitly converts the specified value to an <see cref="int"/> value.

--- a/test/DocumentFormat.OpenXml.Tests/SimpleTypes/BiLevelThresholdTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/SimpleTypes/BiLevelThresholdTests.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Drawing;
+using Xunit;
+
+namespace DocumentFormat.OpenXml.Tests.SimpleTypes;
+
+public class BiLevelThresholdTests
+{
+    // Regression for https://github.com/dotnet/Open-XML-SDK/issues/2007
+    // Office emits a:biLevel/@thresh using the ECMA-376 percentage string form ("50%")
+    // instead of the 1000ths-of-a-percent integer form ("50000"). Loading such files
+    // previously threw FormatException via Int32Value.Parse.
+    [Theory]
+    [InlineData("50%", 50000)]
+    [InlineData("50000", 50000)]
+    public void ParsesThreshold(string thresh, int expected)
+    {
+        var xml =
+            $"<a:cont xmlns:a=\"http://schemas.openxmlformats.org/drawingml/2006/main\"><a:biLevel thresh=\"{thresh}\" /></a:cont>";
+        var container = new EffectContainer(xml);
+
+        var biLevel = Assert.IsType<BiLevel>(container.FirstChild);
+        Assert.NotNull(biLevel.Threshold);
+        Assert.Equal(expected, biLevel.Threshold!.Value);
+    }
+}

--- a/test/DocumentFormat.OpenXml.Tests/SimpleTypes/BiLevelThresholdTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/SimpleTypes/BiLevelThresholdTests.cs
@@ -4,25 +4,26 @@
 using DocumentFormat.OpenXml.Drawing;
 using Xunit;
 
-namespace DocumentFormat.OpenXml.Tests.SimpleTypes;
-
-public class BiLevelThresholdTests
+namespace DocumentFormat.OpenXml.Tests.SimpleTypes
 {
-    // Regression for https://github.com/dotnet/Open-XML-SDK/issues/2007
-    // Office emits a:biLevel/@thresh using the ECMA-376 percentage string form ("50%")
-    // instead of the 1000ths-of-a-percent integer form ("50000"). Loading such files
-    // previously threw FormatException via Int32Value.Parse.
-    [Theory]
-    [InlineData("50%", 50000)]
-    [InlineData("50000", 50000)]
-    public void ParsesThreshold(string thresh, int expected)
+    public class BiLevelThresholdTests
     {
-        var xml =
-            $"<a:cont xmlns:a=\"http://schemas.openxmlformats.org/drawingml/2006/main\"><a:biLevel thresh=\"{thresh}\" /></a:cont>";
-        var container = new EffectContainer(xml);
+        // Regression for https://github.com/dotnet/Open-XML-SDK/issues/2007
+        // Office emits a:biLevel/@thresh using the ECMA-376 percentage string form ("50%")
+        // instead of the 1000ths-of-a-percent integer form ("50000"). Loading such files
+        // previously threw FormatException via Int32Value.Parse.
+        [Theory]
+        [InlineData("50%", 50000)]
+        [InlineData("50000", 50000)]
+        public void ParsesThreshold(string thresh, int expected)
+        {
+            var xml =
+                $"<a:cont xmlns:a=\"http://schemas.openxmlformats.org/drawingml/2006/main\"><a:biLevel thresh=\"{thresh}\" /></a:cont>";
+            var container = new EffectContainer(xml);
 
-        var biLevel = Assert.IsType<BiLevel>(container.FirstChild);
-        Assert.NotNull(biLevel.Threshold);
-        Assert.Equal(expected, biLevel.Threshold!.Value);
+            var biLevel = Assert.IsType<BiLevel>(container.FirstChild);
+            Assert.NotNull(biLevel.Threshold);
+            Assert.Equal(expected, biLevel.Threshold!.Value);
+        }
     }
 }

--- a/test/DocumentFormat.OpenXml.Tests/SimpleTypes/Int32ValueTests.cs
+++ b/test/DocumentFormat.OpenXml.Tests/SimpleTypes/Int32ValueTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Xunit;
+
 namespace DocumentFormat.OpenXml.Tests.SimpleTypes
 {
     public class Int32ValueTests : OpenXmlComparableSimpleValueTests<int>
@@ -14,6 +16,22 @@ namespace DocumentFormat.OpenXml.Tests.SimpleTypes
             SmallValue1 = new Int32Value(10);
             SmallValue2 = new Int32Value(10);
             LargeValue = new Int32Value(20);
+        }
+
+        // Regression for https://github.com/dotnet/Open-XML-SDK/issues/2007:
+        // ECMA-376 percentage attributes (e.g. a:biLevel/@thresh) are a union of an integer in
+        // 1000ths of a percent and a string with a trailing '%'. Office emits the string form.
+        [Theory]
+        [InlineData("50%", 50000)]
+        [InlineData("100%", 100000)]
+        [InlineData("0%", 0)]
+        [InlineData("0.5%", 500)]
+        [InlineData("-25%", -25000)]
+        [InlineData("12345", 12345)]
+        public void ParsesIntegerAndPercentageForms(string input, int expected)
+        {
+            var value = new Int32Value { InnerText = input };
+            Assert.Equal(expected, value.Value);
         }
     }
 }


### PR DESCRIPTION
Office emits ECMA-376 percentage attributes such as a:biLevel/@thresh in the string form ("50%") rather than 1000ths-of-a-percent integers, causing FormatException when loading those files. Parse the "%" suffix as a fallback so affected documents round-trip.

i think this is a fix for #2007